### PR TITLE
Fix team links on leaderboard

### DIFF
--- a/docs/data/leaderboards.json
+++ b/docs/data/leaderboards.json
@@ -12,7 +12,7 @@
       "trials": 5,
       "passAt1": 0.5603,
       "team": "Pi Coding Agent",
-      "teamUrl": "https://github.com/mariozechner/pi-coding-agent",
+      "teamUrl": "https://github.com/ucbepic/DataAgentBench/pull/31",
       "prUrl": "https://github.com/ucbepic/DataAgentBench/pull/31",
       "date": "2026-04-21"
     },
@@ -98,7 +98,7 @@
       "trials": 5,
       "passAt1": 0.128,
       "team": "Team Cohere",
-      "teamUrl": "https://github.com/trp1-cohere-team/data-analytics-agent",
+      "teamUrl": "https://github.com/ucbepic/DataAgentBench/pull/38",
       "prUrl": "https://github.com/ucbepic/DataAgentBench/pull/38",
       "date": "2026-04-21"
     },


### PR DESCRIPTION
## Summary
- The team-name link for Pi Coding Agent (#31) was pointing at `mariozechner/pi-coding-agent` (the SDK author), not the team that made the submission. Now points at the submission PR.
- The team-name link for Team Cohere (#38) was pointing at their source repo. Now points at the submission PR.
- Tenacious (#32) was already linking to the PR — unchanged.

PromptQL and EPIC Data Lab rows are unchanged (they have real org pages).

## Test plan
- [ ] Check the website leaderboard — clicking the team name on rows #1, #4, #10 should land on the corresponding PR.