### PR TITLE
[Leaderboard] SCRIBE — Claude Opus 4.7 — 81.85% Pass@1

### DIFF
--- a/leaderboard_submissions/scribe_opus47xhigh.json
+++ b/leaderboard_submissions/scribe_opus47xhigh.json
@@ -1,0 +1,1622 @@
+[
+  {
+    "dataset": "agnews",
+    "query": "1",
+    "run": "0",
+    "answer": "The Rundown"
+  },
+  {
+    "dataset": "agnews",
+    "query": "1",
+    "run": "1",
+    "answer": "The Rundown"
+  },
+  {
+    "dataset": "agnews",
+    "query": "1",
+    "run": "2",
+    "answer": "The Rundown"
+  },
+  {
+    "dataset": "agnews",
+    "query": "1",
+    "run": "3",
+    "answer": "The Rundown"
+  },
+  {
+    "dataset": "agnews",
+    "query": "1",
+    "run": "4",
+    "answer": "The Rundown"
+  },
+  {
+    "dataset": "agnews",
+    "query": "2",
+    "run": "0",
+    "answer": "0.14414414414414414"
+  },
+  {
+    "dataset": "agnews",
+    "query": "2",
+    "run": "1",
+    "answer": "0.1532"
+  },
+  {
+    "dataset": "agnews",
+    "query": "2",
+    "run": "2",
+    "answer": "0.180180"
+  },
+  {
+    "dataset": "agnews",
+    "query": "2",
+    "run": "3",
+    "answer": "13.51"
+  },
+  {
+    "dataset": "agnews",
+    "query": "2",
+    "run": "4",
+    "answer": "0.1802"
+  },
+  {
+    "dataset": "agnews",
+    "query": "3",
+    "run": "0",
+    "answer": "Not Applicable"
+  },
+  {
+    "dataset": "agnews",
+    "query": "3",
+    "run": "1",
+    "answer": "Not Applicable"
+  },
+  {
+    "dataset": "agnews",
+    "query": "3",
+    "run": "2",
+    "answer": "Not Applicable"
+  },
+  {
+    "dataset": "agnews",
+    "query": "3",
+    "run": "3",
+    "answer": "Not Applicable"
+  },
+  {
+    "dataset": "agnews",
+    "query": "3",
+    "run": "4",
+    "answer": "Not Applicable"
+  },
+  {
+    "dataset": "agnews",
+    "query": "4",
+    "run": "0",
+    "answer": "Africa"
+  },
+  {
+    "dataset": "agnews",
+    "query": "4",
+    "run": "1",
+    "answer": "Africa"
+  },
+  {
+    "dataset": "agnews",
+    "query": "4",
+    "run": "2",
+    "answer": "Africa"
+  },
+  {
+    "dataset": "agnews",
+    "query": "4",
+    "run": "3",
+    "answer": "South America"
+  },
+  {
+    "dataset": "agnews",
+    "query": "4",
+    "run": "4",
+    "answer": "South America"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "1",
+    "run": "0",
+    "answer": "2020s"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "1",
+    "run": "1",
+    "answer": "2020s"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "1",
+    "run": "2",
+    "answer": "2020s"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "1",
+    "run": "3",
+    "answer": "2020s"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "1",
+    "run": "4",
+    "answer": "2020s"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "2",
+    "run": "0",
+    "answer": "Reunion: The Children of Lauderdale Park; The Prophet: With Original 1923 Illustrations by the Author; The Melancholy Strumpet Master; Child Of The King A Journey of Hope Book 1: Earthly Story With A Heavenly Message; Fire Cracker; Local Honey; Hollywood Confessions: Hollywood Headlines Book #3 (Hollywood Headlines Mysteries); Knowing When To Die: Uncollected Stories; Childe Harold of Dysna; Forged in Blood (Freehold); Exits, Desires, & Slow Fires; Kennebago Moments; The Sludge; Liza of Lambeth; Something That Feels Like Truth (Switchgrass Books)"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "2",
+    "run": "1",
+    "answer": "['Child Of The King A Journey of Hope Book 1: Earthly Story With A Heavenly Message', 'Childe Harold of Dysna', 'Exits, Desires, & Slow Fires', 'Fire Cracker', 'Forged in Blood (Freehold)', 'Hollywood Confessions: Hollywood Headlines Book #3 (Hollywood Headlines Mysteries)', 'Kennebago Moments', 'Knowing When To Die: Uncollected Stories', 'Liza of Lambeth', 'Local Honey', 'Reunion: The Children of Lauderdale Park', 'Something That Feels Like Truth (Switchgrass Books)', 'The Melancholy Strumpet Master', 'The Prophet: With Original 1923 Illustrations by the Author', 'The Sludge']"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "2",
+    "run": "2",
+    "answer": "['Child Of The King A Journey of Hope Book 1: Earthly Story With A Heavenly Message', 'Childe Harold of Dysna', 'Exits, Desires, & Slow Fires', 'Fire Cracker', 'Forged in Blood (Freehold)', 'Hollywood Confessions: Hollywood Headlines Book #3 (Hollywood Headlines Mysteries)', 'Kennebago Moments', 'Knowing When To Die: Uncollected Stories', 'Liza of Lambeth', 'Local Honey', 'Reunion: The Children of Lauderdale Park', 'Something That Feels Like Truth (Switchgrass Books)', 'The Melancholy Strumpet Master', 'The Prophet: With Original 1923 Illustrations by the Author', 'The Sludge']"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "2",
+    "run": "3",
+    "answer": "['Reunion: The Children of Lauderdale Park', 'The Prophet: With Original 1923 Illustrations by the Author', 'The Melancholy Strumpet Master', 'Child Of The King A Journey of Hope Book 1: Earthly Story With A Heavenly Message', 'Fire Cracker', 'Local Honey', 'Hollywood Confessions: Hollywood Headlines Book #3 (Hollywood Headlines Mysteries)', 'Knowing When To Die: Uncollected Stories', 'Childe Harold of Dysna', 'Forged in Blood (Freehold)', 'Exits, Desires, & Slow Fires', 'Kennebago Moments', 'The Sludge', 'Liza of Lambeth', 'Something That Feels Like Truth (Switchgrass Books)']"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "2",
+    "run": "4",
+    "answer": "['Reunion: The Children of Lauderdale Park', 'The Prophet: With Original 1923 Illustrations by the Author', 'The Melancholy Strumpet Master', 'Child Of The King A Journey of Hope Book 1: Earthly Story With A Heavenly Message', 'Fire Cracker', 'Local Honey', 'Hollywood Confessions: Hollywood Headlines Book #3 (Hollywood Headlines Mysteries)', 'Knowing When To Die: Uncollected Stories', 'Childe Harold of Dysna', 'Forged in Blood (Freehold)', 'Exits, Desires, & Slow Fires', 'Kennebago Moments', 'The Sludge', 'Liza of Lambeth', 'Something That Feels Like Truth (Switchgrass Books)']"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "3",
+    "run": "0",
+    "answer": "['Around the World Mazes', 'Behind the Wheel (Choose Your Own Adventure #35)(Paperback/Revised)', \"Benny Goes To The Moon: The great new book from Top Children's entertainer Gerry Ogilvie (1)\", 'Cheer Up, Ben Franklin! (Young Historians)', 'Clark the Shark: Tooth Trouble, No. 1', 'Cleo Porter and the Body Electric', 'Egypt (Enchantment of the World)', 'Favorite Thorton W. Burgess Stories: 6 Books', 'LunaLu the Llamacorn', 'Monstrous Stories #4: The Day the Mice Stood Still', 'Pokémon: Sun & Moon, Vol. 8 (8)', 'The Library Book', 'The Old Man and the Pirate Princess', 'Trouble in the CTC!: The Terra Prime Adventures Book 2']"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "3",
+    "run": "1",
+    "answer": "['Around the World Mazes', 'Behind the Wheel (Choose Your Own Adventure #35)(Paperback/Revised)', \"Benny Goes To The Moon: The great new book from Top Children's entertainer Gerry Ogilvie (1)\", 'Cheer Up, Ben Franklin! (Young Historians)', 'Clark the Shark: Tooth Trouble, No. 1', 'Cleo Porter and the Body Electric', 'Egypt (Enchantment of the World)', 'Favorite Thorton W. Burgess Stories: 6 Books', 'LunaLu the Llamacorn', 'Monstrous Stories #4: The Day the Mice Stood Still', 'Pokémon: Sun & Moon, Vol. 8 (8)', 'The Library Book', 'The Old Man and the Pirate Princess', 'Trouble in the CTC!: The Terra Prime Adventures Book 2']"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "3",
+    "run": "2",
+    "answer": "['The Library Book', \"Benny Goes To The Moon: The great new book from Top Children's entertainer Gerry Ogilvie (1)\", 'Cheer Up, Ben Franklin! (Young Historians)', 'Behind the Wheel (Choose Your Own Adventure #35)(Paperback/Revised)', 'Favorite Thorton W. Burgess Stories: 6 Books', 'Egypt (Enchantment of the World)', 'Monstrous Stories #4: The Day the Mice Stood Still', 'Pokémon: Sun & Moon, Vol. 8 (8)', 'Around the World Mazes', 'LunaLu the Llamacorn', 'The Old Man and the Pirate Princess', 'Trouble in the CTC!: The Terra Prime Adventures Book 2', 'Clark the Shark: Tooth Trouble, No. 1', 'Cleo Porter and the Body Electric']"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "3",
+    "run": "3",
+    "answer": "['Around the World Mazes', 'Behind the Wheel (Choose Your Own Adventure #35)(Paperback/Revised)', \"Benny Goes To The Moon: The great new book from Top Children's entertainer Gerry Ogilvie (1)\", 'Cheer Up, Ben Franklin! (Young Historians)', 'Clark the Shark: Tooth Trouble, No. 1', 'Cleo Porter and the Body Electric', 'Egypt (Enchantment of the World)', 'Favorite Thorton W. Burgess Stories: 6 Books', 'LunaLu the Llamacorn', 'Monstrous Stories #4: The Day the Mice Stood Still', 'Pokémon: Sun & Moon, Vol. 8 (8)', 'The Library Book', 'The Old Man and the Pirate Princess', 'Trouble in the CTC!: The Terra Prime Adventures Book 2']"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "3",
+    "run": "4",
+    "answer": "['Around the World Mazes', \"Benny Goes To The Moon: The great new book from Top Children's entertainer Gerry Ogilvie (1)\", 'Behind the Wheel (Choose Your Own Adventure #35)(Paperback/Revised)', 'Cheer Up, Ben Franklin! (Young Historians)', 'Egypt (Enchantment of the World)', 'Favorite Thorton W. Burgess Stories: 6 Books', 'LunaLu the Llamacorn', 'Monstrous Stories #4: The Day the Mice Stood Still', 'Pokémon: Sun & Moon, Vol. 8 (8)', 'The Library Book', 'The Old Man and the Pirate Princess', 'Trouble in the CTC!: The Terra Prime Adventures Book 2', 'Clark the Shark: Tooth Trouble, No. 1', 'Cleo Porter and the Body Electric']"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "1",
+    "run": "0",
+    "answer": "Budget, Authority"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "1",
+    "run": "1",
+    "answer": "Authority, Timeline"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "1",
+    "run": "2",
+    "answer": "Authority"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "1",
+    "run": "3",
+    "answer": "Authority"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "1",
+    "run": "4",
+    "answer": "Authority, Timeline"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "10",
+    "run": "0",
+    "answer": "005Wt000003NDqDIAW"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "10",
+    "run": "1",
+    "answer": "005Wt000003NDqDIAW"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "10",
+    "run": "2",
+    "answer": "005Wt000003NDqDIAW"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "10",
+    "run": "3",
+    "answer": "005Wt000003NDqDIAW"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "10",
+    "run": "4",
+    "answer": "005Wt000003NDqDIAW"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "11",
+    "run": "0",
+    "answer": "01tWt000006hV8LIAU"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "11",
+    "run": "1",
+    "answer": "01tWt000006hV8LIAU"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "11",
+    "run": "2",
+    "answer": "01tWt000006hV8LIAU"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "11",
+    "run": "3",
+    "answer": "01tWt000006hV8LIAU"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "11",
+    "run": "4",
+    "answer": "01tWt000006hV8LIAU"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "12",
+    "run": "0",
+    "answer": "005Wt000003NDEBIA4"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "12",
+    "run": "1",
+    "answer": "005Wt000003NDEBIA4"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "12",
+    "run": "2",
+    "answer": "005Wt000003NDEBIA4"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "12",
+    "run": "3",
+    "answer": "005Wt000003NDEBIA4"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "12",
+    "run": "4",
+    "answer": "005Wt000003NDEBIA4"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "13",
+    "run": "0",
+    "answer": "005Wt000003NIXCIA4"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "13",
+    "run": "1",
+    "answer": "005Wt000003NIXCIA4"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "13",
+    "run": "2",
+    "answer": "005Wt000003NIXCIA4"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "13",
+    "run": "3",
+    "answer": "005Wt000003NIXCIA4"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "13",
+    "run": "4",
+    "answer": "005Wt000003NIXCIA4"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "2",
+    "run": "0",
+    "answer": "ka0Wt000000Eq0MIAS"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "2",
+    "run": "1",
+    "answer": "ka0Wt000000Ens5IAC"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "2",
+    "run": "2",
+    "answer": "ka0Wt000000Ens5IAC"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "2",
+    "run": "3",
+    "answer": "ka0Wt000000Ens5IAC"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "2",
+    "run": "4",
+    "answer": "ka0Wt000000Ens5IAC"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "3",
+    "run": "0",
+    "answer": "Negotiation"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "3",
+    "run": "1",
+    "answer": "Negotiation"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "3",
+    "run": "2",
+    "answer": "Negotiation"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "3",
+    "run": "3",
+    "answer": "Negotiation"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "3",
+    "run": "4",
+    "answer": "Negotiation"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "4",
+    "run": "0",
+    "answer": "November"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "4",
+    "run": "1",
+    "answer": "November"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "4",
+    "run": "2",
+    "answer": "November"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "4",
+    "run": "3",
+    "answer": "November"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "4",
+    "run": "4",
+    "answer": "November"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "5",
+    "run": "0",
+    "answer": "a03Wt00000JqnHwIAJ"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "5",
+    "run": "1",
+    "answer": "a03Wt00000JqnHwIAJ"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "5",
+    "run": "2",
+    "answer": "a03Wt00000JqnHwIAJ"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "5",
+    "run": "3",
+    "answer": "a03Wt00000JqnHwIAJ"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "5",
+    "run": "4",
+    "answer": "a03Wt00000JqnHwIAJ"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "6",
+    "run": "0",
+    "answer": "ka0Wt000000EnwvIAC"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "6",
+    "run": "1",
+    "answer": "ka0Wt000000EnwvIAC"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "6",
+    "run": "2",
+    "answer": "ka0Wt000000EnwvIAC"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "6",
+    "run": "3",
+    "answer": "ka0Wt000000EnwvIAC"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "6",
+    "run": "4",
+    "answer": "ka0Wt000000EnwvIAC"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "7",
+    "run": "0",
+    "answer": "ka0Wt000000EoD3IAK"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "7",
+    "run": "1",
+    "answer": "ka0Wt000000EoD3IAK"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "7",
+    "run": "2",
+    "answer": "ka0Wt000000EoD3IAK"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "7",
+    "run": "3",
+    "answer": "ka0Wt000000EoD3IAK"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "7",
+    "run": "4",
+    "answer": "ka0Wt000000EoD3IAK"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "8",
+    "run": "0",
+    "answer": "005Wt000003NIliIAG"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "8",
+    "run": "1",
+    "answer": "005Wt000003NIliIAG"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "8",
+    "run": "2",
+    "answer": "005Wt000003NIliIAG"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "8",
+    "run": "3",
+    "answer": "005Wt000003NIliIAG"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "8",
+    "run": "4",
+    "answer": "005Wt000003NIliIAG"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "9",
+    "run": "0",
+    "answer": "MI"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "9",
+    "run": "1",
+    "answer": "MI"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "9",
+    "run": "2",
+    "answer": "MI"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "9",
+    "run": "3",
+    "answer": "MI"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "9",
+    "run": "4",
+    "answer": "MI"
+  },
+  {
+    "dataset": "deps_dev_v1",
+    "query": "1",
+    "run": "0",
+    "answer": "[('@dylanvann/svelte', '3.25.4'), ('@dumc11/tailwindcss', '0.4.0'), ('@dynasty/styled-components', '3.2.1'), ('@dothq/styled-components', '1.0.0'), ('@ec-nordbund/leaflet', '1.7.1')]"
+  },
+  {
+    "dataset": "deps_dev_v1",
+    "query": "1",
+    "run": "1",
+    "answer": "[('@dylanvann/svelte', '3.25.4'), ('@dumc11/tailwindcss', '0.4.0'), ('@dreampie/semantic-ui', '2.2.11'), ('@dongls/pdfjs-dist', '3.2.72'), ('@dman777/shadow-dom-quill-temp', '1.0.0')]"
+  },
+  {
+    "dataset": "deps_dev_v1",
+    "query": "1",
+    "run": "2",
+    "answer": "[('@dylanvann/svelte', '3.25.4'), ('@dumc11/tailwindcss', '0.4.0'), ('@dreampie/semantic-ui', '2.2.11'), ('@dongls/pdfjs-dist', '3.2.72'), ('@dman777/shadow-dom-quill-temp', '1.0.0')]"
+  },
+  {
+    "dataset": "deps_dev_v1",
+    "query": "1",
+    "run": "3",
+    "answer": "[('@dylanvann/svelte', '3.25.4'), ('@dumc11/tailwindcss', '0.4.0'), ('@dreampie/semantic-ui', '2.2.11'), ('@dongls/pdfjs-dist', '3.2.72'), ('@dman777/shadow-dom-quill-temp', '1.0.0')]"
+  },
+  {
+    "dataset": "deps_dev_v1",
+    "query": "1",
+    "run": "4",
+    "answer": "@dylanvann/svelte (3.25.4), @dumc11/tailwindcss (0.4.0), @dongls/pdfjs-dist (3.2.72), @dman777/shadow-dom-quill-temp (1.0.0), @dynasty/styled-components (3.2.1)"
+  },
+  {
+    "dataset": "deps_dev_v1",
+    "query": "2",
+    "run": "0",
+    "answer": "[('mui-org/material-ui', 30522), ('moment/moment', 7201), ('semantic-org/semantic-ui', 4955), ('react-native-elements/react-native-elements', 4623), ('sveltejs/svelte', 4091)]"
+  },
+  {
+    "dataset": "deps_dev_v1",
+    "query": "2",
+    "run": "1",
+    "answer": "[('mui-org/material-ui', 30522), ('moment/moment', 7201), ('semantic-org/semantic-ui', 4955), ('react-native-elements/react-native-elements', 4623), ('sveltejs/svelte', 4091)]"
+  },
+  {
+    "dataset": "deps_dev_v1",
+    "query": "2",
+    "run": "2",
+    "answer": "[('mui-org/material-ui', 30522), ('moment/moment', 7201), ('semantic-org/semantic-ui', 4955), ('react-native-elements/react-native-elements', 4623), ('sveltejs/svelte', 4091)]"
+  },
+  {
+    "dataset": "deps_dev_v1",
+    "query": "2",
+    "run": "3",
+    "answer": "[('mui-org/material-ui', 30522), ('moment/moment', 7201), ('semantic-org/semantic-ui', 4955), ('react-native-elements/react-native-elements', 4623), ('sveltejs/svelte', 4091)]"
+  },
+  {
+    "dataset": "deps_dev_v1",
+    "query": "2",
+    "run": "4",
+    "answer": "[('mui-org/material-ui', 30522), ('moment/moment', 7201), ('semantic-org/semantic-ui', 4955), ('react-native-elements/react-native-elements', 4623), ('sveltejs/svelte', 4091)]"
+  },
+  {
+    "dataset": "github_repos",
+    "query": "1",
+    "run": "0",
+    "answer": "0.3333"
+  },
+  {
+    "dataset": "github_repos",
+    "query": "1",
+    "run": "1",
+    "answer": "0.3333"
+  },
+  {
+    "dataset": "github_repos",
+    "query": "1",
+    "run": "2",
+    "answer": "0.3333333333333333"
+  },
+  {
+    "dataset": "github_repos",
+    "query": "1",
+    "run": "3",
+    "answer": "13.7681%"
+  },
+  {
+    "dataset": "github_repos",
+    "query": "1",
+    "run": "4",
+    "answer": "12.2137"
+  },
+  {
+    "dataset": "github_repos",
+    "query": "2",
+    "run": "0",
+    "answer": "uacaps/PageMenu"
+  },
+  {
+    "dataset": "github_repos",
+    "query": "2",
+    "run": "1",
+    "answer": "uacaps/PageMenu"
+  },
+  {
+    "dataset": "github_repos",
+    "query": "2",
+    "run": "2",
+    "answer": "uacaps/PageMenu"
+  },
+  {
+    "dataset": "github_repos",
+    "query": "2",
+    "run": "3",
+    "answer": "uacaps/PageMenu"
+  },
+  {
+    "dataset": "github_repos",
+    "query": "2",
+    "run": "4",
+    "answer": "uacaps/PageMenu"
+  },
+  {
+    "dataset": "github_repos",
+    "query": "3",
+    "run": "0",
+    "answer": "1077"
+  },
+  {
+    "dataset": "github_repos",
+    "query": "3",
+    "run": "1",
+    "answer": "1077"
+  },
+  {
+    "dataset": "github_repos",
+    "query": "3",
+    "run": "2",
+    "answer": "1077"
+  },
+  {
+    "dataset": "github_repos",
+    "query": "3",
+    "run": "3",
+    "answer": "1077"
+  },
+  {
+    "dataset": "github_repos",
+    "query": "3",
+    "run": "4",
+    "answer": "1077"
+  },
+  {
+    "dataset": "github_repos",
+    "query": "4",
+    "run": "0",
+    "answer": "['apple/swift', 'twbs/bootstrap', 'Microsoft/vscode', 'facebook/react', 'tensorflow/tensorflow']"
+  },
+  {
+    "dataset": "github_repos",
+    "query": "4",
+    "run": "1",
+    "answer": "['apple/swift', 'twbs/bootstrap', 'Microsoft/vscode', 'facebook/react', 'tensorflow/tensorflow']"
+  },
+  {
+    "dataset": "github_repos",
+    "query": "4",
+    "run": "2",
+    "answer": "['apple/swift', 'twbs/bootstrap', 'Microsoft/vscode', 'facebook/react', 'tensorflow/tensorflow']"
+  },
+  {
+    "dataset": "github_repos",
+    "query": "4",
+    "run": "3",
+    "answer": "apple/swift, twbs/bootstrap, Microsoft/vscode, facebook/react, tensorflow/tensorflow"
+  },
+  {
+    "dataset": "github_repos",
+    "query": "4",
+    "run": "4",
+    "answer": "apple/swift, twbs/bootstrap, Microsoft/vscode, facebook/react, tensorflow/tensorflow"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "1",
+    "run": "0",
+    "answer": "[('Widows Peak Salon', 4.86), ('City Textile', 4.5), ('Nobel Textile Co', 4.29), ('San Soo Dang', 4.28), ('Nova Fabrics', 3.33)]"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "1",
+    "run": "1",
+    "answer": "[('Widows Peak Salon', 4.86), ('City Textile', 4.50), ('Nobel Textile Co', 4.29), ('San Soo Dang', 4.28), ('Nova Fabrics', 3.33)]"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "1",
+    "run": "2",
+    "answer": "[(\"Widows Peak Salon\", 4.857142857142857), (\"City Textile\", 4.5), (\"Nobel Textile Co\", 4.285714285714286), (\"San Soo Dang\", 4.277777777777778), (\"Nova Fabrics\", 3.3333333333333335)]"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "1",
+    "run": "3",
+    "answer": "Widows Peak Salon, City Textile, Nobel Textile Co, San Soo Dang, Nova Fabrics"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "1",
+    "run": "4",
+    "answer": "['Widows Peak Salon', 'City Textile', 'Nobel Textile Co', 'San Soo Dang', 'Nova Fabrics']"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "2",
+    "run": "0",
+    "answer": "[('Elite Massage', 5.0), ('Angel-A Massage', 4.33), ('Aurora Massage', 4.18)]"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "2",
+    "run": "1",
+    "answer": "Elite Massage: 5.00, Angel-A Massage: 4.33, Aurora Massage: 4.18"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "2",
+    "run": "2",
+    "answer": "Elite Massage: 5.00, Angel-A Massage: 4.33, Aurora Massage: 4.18"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "2",
+    "run": "3",
+    "answer": "Elite Massage: 5.00, Angel-A Massage: 4.33, Aurora Massage: 4.18"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "2",
+    "run": "4",
+    "answer": "[('Elite Massage', 5.0), ('Angel-A Massage', 4.33), ('Aurora Massage', 4.18)]"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "3",
+    "run": "0",
+    "answer": "[('Taba Rug Gallery', 'Monday: 10AM–7PM; Tuesday: 10AM–7PM; Wednesday: 10AM–7PM; Thursday: 10AM–7PM; Friday: 10AM–7PM; Saturday: 10AM–7PM; Sunday: 11AM–6PM', 5.0), ('Beauty Divine Artistry', 'Monday: 9AM–8PM; Tuesday: 9AM–8PM; Wednesday: 9AM–8PM; Thursday: 9AM–8PM; Friday: 9AM–8PM; Saturday: 10AM–7PM; Sunday: 11AM–6PM', 5.0), ('Mariscos el poblano', 'Monday: 9AM–3:30AM; Tuesday: 8AM–3:30PM; Wednesday: 8AM–3:30PM; Thursday: Open 24 hours; Friday: 8AM–3:30PM; Saturday: 8AM–3:30PM; Sunday: 8AM–3:30PM', 5.0), ('TACOS LA CABANA', 'Monday: 5–11PM; Tuesday: Closed; Wednesday: Closed; Thursday: Closed; Friday: 5–11PM; Saturday: 5–11PM; Sunday: 5–11PM', 5.0), ('White Barn Candle Co', 'Monday: 10AM–9PM; Tuesday: 10AM–9PM; Wednesday: 10AM–9PM; Thursday: 10AM–9PM; Friday: 10AM–9PM; Saturday: 10AM–9PM; Sunday: 11AM–7PM', 5.0)]"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "3",
+    "run": "1",
+    "answer": "[('Taba Rug Gallery', 'Mon: 10AM–7PM; Tue: 10AM–7PM; Wed: 10AM–7PM; Thu: 10AM–7PM; Fri: 10AM–7PM; Sat: 10AM–7PM; Sun: 11AM–6PM', 5.0), ('Beauty Divine Artistry', 'Mon: 9AM–8PM; Tue: 9AM–8PM; Wed: 9AM–8PM; Thu: 9AM–8PM; Fri: 9AM–8PM; Sat: 10AM–7PM; Sun: 11AM–6PM', 5.0), ('Mariscos el poblano', 'Mon: 9AM–3:30AM; Tue: 8AM–3:30PM; Wed: 8AM–3:30PM; Thu: Open 24 hours; Fri: 8AM–3:30PM; Sat: 8AM–3:30PM; Sun: 8AM–3:30PM', 5.0), ('White Barn Candle Co', 'Mon: 10AM–9PM; Tue: 10AM–9PM; Wed: 10AM–9PM; Thu: 10AM–9PM; Fri: 10AM–9PM; Sat: 10AM–9PM; Sun: 11AM–7PM', 5.0), ('TACOS LA CABANA', 'Mon: 5–11PM; Tue: Closed; Wed: Closed; Thu: Closed; Fri: 5–11PM; Sat: 5–11PM; Sun: 5–11PM', 5.0)]"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "3",
+    "run": "2",
+    "answer": "[('Taba Rug Gallery', [['Thursday', '10AM–7PM'], ['Friday', '10AM–7PM'], ['Saturday', '10AM–7PM'], ['Sunday', '11AM–6PM'], ['Monday', '10AM–7PM'], ['Tuesday', '10AM–7PM'], ['Wednesday', '10AM–7PM']], 5.0), ('Beauty Divine Artistry', [['Thursday', '9AM–8PM'], ['Friday', '9AM–8PM'], ['Saturday', '10AM–7PM'], ['Sunday', '11AM–6PM'], ['Monday', '9AM–8PM'], ['Tuesday', '9AM–8PM'], ['Wednesday', '9AM–8PM']], 5.0), ('Mariscos el poblano', [['Thursday', 'Open 24 hours'], ['Friday', '8AM–3:30PM'], ['Saturday', '8AM–3:30PM'], ['Sunday', '8AM–3:30PM'], ['Monday', '9AM–3:30AM'], ['Tuesday', '8AM–3:30PM'], ['Wednesday', '8AM–3:30PM']], 5.0), ('TACOS LA CABANA', [['Thursday', 'Closed'], ['Friday', '5–11PM'], ['Saturday', '5–11PM'], ['Sunday', '5–11PM'], ['Monday', '5–11PM'], ['Tuesday', 'Closed'], ['Wednesday', 'Closed']], 5.0), ('White Barn Candle Co', [['Thursday', '10AM–9PM'], ['Friday', '10AM–9PM'], ['Saturday', '10AM–9PM'], ['Sunday', '11AM–7PM'], ['Monday', '10AM–9PM'], ['Tuesday', '10AM–9PM'], ['Wednesday', '10AM–9PM']], 5.0)]"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "3",
+    "run": "3",
+    "answer": "[('Taba Rug Gallery', 'Thursday: 10AM–7PM, Friday: 10AM–7PM, Saturday: 10AM–7PM, Sunday: 11AM–6PM, Monday: 10AM–7PM, Tuesday: 10AM–7PM, Wednesday: 10AM–7PM', 5.0), ('Beauty Divine Artistry', 'Thursday: 9AM–8PM, Friday: 9AM–8PM, Saturday: 10AM–7PM, Sunday: 11AM–6PM, Monday: 9AM–8PM, Tuesday: 9AM–8PM, Wednesday: 9AM–8PM', 5.0), ('Mariscos el poblano', 'Thursday: Open 24 hours, Friday: 8AM–3:30PM, Saturday: 8AM–3:30PM, Sunday: 8AM–3:30PM, Monday: 9AM–3:30AM, Tuesday: 8AM–3:30PM, Wednesday: 8AM–3:30PM', 5.0), ('TACOS LA CABANA', 'Thursday: Closed, Friday: 5–11PM, Saturday: 5–11PM, Sunday: 5–11PM, Monday: 5–11PM, Tuesday: Closed, Wednesday: Closed', 5.0), ('White Barn Candle Co', 'Thursday: 10AM–9PM, Friday: 10AM–9PM, Saturday: 10AM–9PM, Sunday: 11AM–7PM, Monday: 10AM–9PM, Tuesday: 10AM–9PM, Wednesday: 10AM–9PM', 5.0)]"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "3",
+    "run": "4",
+    "answer": "[('Taba Rug Gallery', 'Mon: 10AM–7PM; Tue: 10AM–7PM; Wed: 10AM–7PM; Thu: 10AM–7PM; Fri: 10AM–7PM; Sat: 10AM–7PM; Sun: 11AM–6PM', 5.0), ('Beauty Divine Artistry', 'Mon: 9AM–8PM; Tue: 9AM–8PM; Wed: 9AM–8PM; Thu: 9AM–8PM; Fri: 9AM–8PM; Sat: 10AM–7PM; Sun: 11AM–6PM', 5.0), ('Mariscos el poblano', 'Mon: 9AM–3:30AM; Tue: 8AM–3:30PM; Wed: 8AM–3:30PM; Thu: Open 24 hours; Fri: 8AM–3:30PM; Sat: 8AM–3:30PM; Sun: 8AM–3:30PM', 5.0), ('TACOS LA CABANA', 'Mon: 5–11PM; Tue: Closed; Wed: Closed; Thu: Closed; Fri: 5–11PM; Sat: 5–11PM; Sun: 5–11PM', 5.0), ('White Barn Candle Co', 'Mon: 10AM–9PM; Tue: 10AM–9PM; Wed: 10AM–9PM; Thu: 10AM–9PM; Fri: 10AM–9PM; Sat: 10AM–9PM; Sun: 11AM–7PM', 5.0)]"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "4",
+    "run": "0",
+    "answer": "[('Encino Dermatology & Laser: Alex Khadavi MD', 19), ('The Boochyard @ Local Roots', 17), ('Aurora Massage', 14)]"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "4",
+    "run": "1",
+    "answer": "[('Encino Dermatology & Laser: Alex Khadavi MD', 19), ('The Boochyard @ Local Roots', 17), ('Aurora Massage', 14)]"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "4",
+    "run": "2",
+    "answer": "[('Encino Dermatology & Laser: Alex Khadavi MD', 19), ('The Boochyard @ Local Roots', 17), ('Aurora Massage', 14)]"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "4",
+    "run": "3",
+    "answer": "Encino Dermatology & Laser: Alex Khadavi MD (19), The Boochyard @ Local Roots (17), Aurora Massage (14)"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "4",
+    "run": "4",
+    "answer": "[(\"Encino Dermatology & Laser: Alex Khadavi MD\", 19), (\"The Boochyard @ Local Roots\", 17), (\"Aurora Massage\", 14)]"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "1",
+    "run": "0",
+    "answer": "1059.46"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "1",
+    "run": "1",
+    "answer": "1059.46"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "1",
+    "run": "2",
+    "answer": "1059.46"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "1",
+    "run": "3",
+    "answer": "1059.46"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "1",
+    "run": "4",
+    "answer": "1059.46"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "2",
+    "run": "0",
+    "answer": "Amazon Music"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "2",
+    "run": "1",
+    "answer": "Amazon Music"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "2",
+    "run": "2",
+    "answer": "Amazon Music"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "2",
+    "run": "3",
+    "answer": "Amazon Music"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "2",
+    "run": "4",
+    "answer": "Amazon Music"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "3",
+    "run": "0",
+    "answer": "Zo gaat het leven aan je voor"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "3",
+    "run": "1",
+    "answer": "Zo gaat het leven aan je voor — Syb van der Ploeg"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "3",
+    "run": "2",
+    "answer": "Zo gaat het leven aan je voor"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "3",
+    "run": "3",
+    "answer": "Zo gaat het leven aan je voor — Syb van der Ploeg"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "3",
+    "run": "4",
+    "answer": "Zo gaat het leven aan je voor"
+  },
+  {
+    "dataset": "pancancer_atlas",
+    "query": "1",
+    "run": "0",
+    "answer": "[('Astrocytoma', 2.571298), ('Oligoastrocytoma', 2.713571), ('Oligodendroglioma', 2.682458)]"
+  },
+  {
+    "dataset": "pancancer_atlas",
+    "query": "1",
+    "run": "1",
+    "answer": "[('Astrocytoma', 2.5713), ('Oligoastrocytoma', 2.7136), ('Oligodendroglioma', 2.6825)]"
+  },
+  {
+    "dataset": "pancancer_atlas",
+    "query": "1",
+    "run": "2",
+    "answer": "Astrocytoma: 2.5713, Oligoastrocytoma: 2.7136, Oligodendroglioma: 2.6825"
+  },
+  {
+    "dataset": "pancancer_atlas",
+    "query": "1",
+    "run": "3",
+    "answer": "[('Astrocytoma', 2.5713), ('Oligoastrocytoma', 2.7136), ('Oligodendroglioma', 2.6825)]"
+  },
+  {
+    "dataset": "pancancer_atlas",
+    "query": "1",
+    "run": "4",
+    "answer": "[('Astrocytoma', 2.5713), ('Oligoastrocytoma', 2.7136), ('Oligodendroglioma', 2.6825)]"
+  },
+  {
+    "dataset": "pancancer_atlas",
+    "query": "2",
+    "run": "0",
+    "answer": "['Infiltrating Lobular Carcinoma', 'Mixed Histology (please specify)', 'Other  specify']"
+  },
+  {
+    "dataset": "pancancer_atlas",
+    "query": "2",
+    "run": "1",
+    "answer": "[('Infiltrating Lobular Carcinoma', 50.5618), ('Mixed Histology (please specify)', 16.6667), ('Other  specify', 8.3333)]"
+  },
+  {
+    "dataset": "pancancer_atlas",
+    "query": "2",
+    "run": "2",
+    "answer": "['Infiltrating Lobular Carcinoma', 'Mixed Histology (please specify)', 'Other  specify']"
+  },
+  {
+    "dataset": "pancancer_atlas",
+    "query": "2",
+    "run": "3",
+    "answer": "[('Infiltrating Lobular Carcinoma', 50.56), ('Mixed Histology (please specify)', 16.67), ('Other  specify', 8.33)]"
+  },
+  {
+    "dataset": "pancancer_atlas",
+    "query": "2",
+    "run": "4",
+    "answer": "['Infiltrating Lobular Carcinoma', 'Mixed Histology (please specify)', 'Other  specify']"
+  },
+  {
+    "dataset": "pancancer_atlas",
+    "query": "3",
+    "run": "0",
+    "answer": "305.1239"
+  },
+  {
+    "dataset": "pancancer_atlas",
+    "query": "3",
+    "run": "1",
+    "answer": "305.1239198007461"
+  },
+  {
+    "dataset": "pancancer_atlas",
+    "query": "3",
+    "run": "2",
+    "answer": "305.1239"
+  },
+  {
+    "dataset": "pancancer_atlas",
+    "query": "3",
+    "run": "3",
+    "answer": "305.1239"
+  },
+  {
+    "dataset": "pancancer_atlas",
+    "query": "3",
+    "run": "4",
+    "answer": "305.1239"
+  },
+  {
+    "dataset": "patents",
+    "query": "1",
+    "run": "0",
+    "answer": "['A22B', 'A23J', 'A23P', 'A24D', 'A24F', 'A41G', 'A47F', 'A61G', 'A61H', 'A61P', 'A62D', 'A63H', 'B04B', 'B07B', 'B08B', 'B09C', 'B21J', 'B22F', 'B24B', 'B25B', 'B25D', 'B27C', 'B27M', 'B60D', 'B60L', 'B60P', 'B61H', 'B63C', 'B63G', 'B65G', 'B66F', 'C01D', 'C01G', 'C21B', 'C21C', 'C22C', 'D21B', 'E01H', 'E02B', 'E02D', 'E03B', 'E04B', 'E04G', 'E21D', 'E21F', 'F02K', 'F04F', 'F16M', 'F25J', 'F26B', 'G01H', 'G01L', 'G01S', 'G05D', 'G06N', 'G06Q', 'G06T', 'G06V', 'G08G', 'G09F', 'G10L', 'G16B', 'G16C', 'G16H', 'G21F', 'H01M', 'H02B', 'H02G', 'H02J', 'H03H', 'H04K', 'H05F']"
+  },
+  {
+    "dataset": "patents",
+    "query": "1",
+    "run": "1",
+    "answer": "['A22B', 'A23J', 'A23P', 'A24D', 'A24F', 'A41G', 'A47F', 'A61G', 'A61H', 'A61P', 'A62D', 'A63H', 'B04B', 'B07B', 'B08B', 'B09C', 'B21J', 'B22F', 'B24B', 'B25B', 'B25D', 'B27C', 'B27M', 'B60D', 'B60L', 'B60P', 'B61H', 'B63C', 'B63G', 'B65G', 'B66F', 'C01D', 'C01G', 'C21B', 'C21C', 'C22C', 'D21B', 'E01H', 'E02B', 'E02D', 'E03B', 'E04B', 'E04G', 'E21D', 'E21F', 'F02K', 'F04F', 'F16M', 'F25J', 'F26B', 'G01H', 'G01L', 'G01S', 'G05D', 'G06N', 'G06Q', 'G06T', 'G06V', 'G08G', 'G09F', 'G10L', 'G16B', 'G16C', 'G16H', 'G21F', 'H01M', 'H02B', 'H02G', 'H02J', 'H03H', 'H04K', 'H05F']"
+  },
+  {
+    "dataset": "patents",
+    "query": "1",
+    "run": "2",
+    "answer": "['A22B', 'A23J', 'A23P', 'A24D', 'A24F', 'A41G', 'A47F', 'A61G', 'A61H', 'A61P', 'A62D', 'A63H', 'B04B', 'B07B', 'B08B', 'B09C', 'B21J', 'B22F', 'B24B', 'B25B', 'B25D', 'B27C', 'B27M', 'B60D', 'B60L', 'B60P', 'B61H', 'B63C', 'B63G', 'B65G', 'B66F', 'C01D', 'C01G', 'C21B', 'C21C', 'C22C', 'D21B', 'E01H', 'E02B', 'E02D', 'E03B', 'E04B', 'E04G', 'E21D', 'E21F', 'F02K', 'F04F', 'F16M', 'F25J', 'F26B', 'G01H', 'G01L', 'G01S', 'G05D', 'G06N', 'G06Q', 'G06T', 'G06V', 'G08G', 'G09F', 'G10L', 'G16B', 'G16C', 'G16H', 'G21F', 'H01M', 'H02B', 'H02G', 'H02J', 'H03H', 'H04K', 'H05F']"
+  },
+  {
+    "dataset": "patents",
+    "query": "1",
+    "run": "3",
+    "answer": "['A22B', 'A23J', 'A23P', 'A24D', 'A24F', 'A41G', 'A47F', 'A61G', 'A61H', 'A61P', 'A62D', 'A63H', 'B04B', 'B07B', 'B08B', 'B09C', 'B21J', 'B22F', 'B24B', 'B25B', 'B25D', 'B27C', 'B27M', 'B60D', 'B60L', 'B60P', 'B61H', 'B63C', 'B63G', 'B65G', 'B66F', 'C01D', 'C01G', 'C21B', 'C21C', 'C22C', 'D21B', 'E01H', 'E02B', 'E02D', 'E03B', 'E04B', 'E04G', 'E21D', 'E21F', 'F02K', 'F04F', 'F16M', 'F25J', 'F26B', 'G01H', 'G01L', 'G01S', 'G05D', 'G06N', 'G06Q', 'G06T', 'G06V', 'G08G', 'G09F', 'G10L', 'G16B', 'G16C', 'G16H', 'G21F', 'H01M', 'H02B', 'H02G', 'H02J', 'H03H', 'H04K', 'H05F']"
+  },
+  {
+    "dataset": "patents",
+    "query": "1",
+    "run": "4",
+    "answer": "['A22B', 'A23J', 'A23P', 'A24D', 'A24F', 'A41G', 'A47F', 'A61G', 'A61H', 'A61P', 'A62D', 'A63H', 'B04B', 'B07B', 'B08B', 'B09C', 'B21J', 'B22F', 'B24B', 'B25B', 'B25D', 'B27C', 'B27M', 'B60D', 'B60L', 'B60P', 'B61H', 'B63C', 'B63G', 'B65G', 'B66F', 'C01D', 'C01G', 'C21B', 'C21C', 'C22C', 'D21B', 'E01H', 'E02B', 'E02D', 'E03B', 'E04B', 'E04G', 'E21D', 'E21F', 'F02K', 'F04F', 'F16M', 'F25J', 'F26B', 'G01H', 'G01L', 'G01S', 'G05D', 'G06N', 'G06Q', 'G06T', 'G06V', 'G08G', 'G09F', 'G10L', 'G16B', 'G16C', 'G16H', 'G21F', 'H01M', 'H02B', 'H02G', 'H02J', 'H03H', 'H04K', 'H05F']"
+  },
+  {
+    "dataset": "patents",
+    "query": "2",
+    "run": "0",
+    "answer": "[('BAKING; EDIBLE DOUGHS', 'A21', 2015), ('MEDICAL OR VETERINARY SCIENCE; HYGIENE', 'A61', 2016), ('MACHINE TOOLS; METAL-WORKING NOT OTHERWISE PROVIDED FOR', 'B23', 2015), ('WORKING OF PLASTICS; WORKING OF SUBSTANCES IN A PLASTIC STATE IN GENERAL', 'B29', 2007), ('PRINTING; LINING MACHINES; TYPEWRITERS; STAMPS', 'B41', 2007), ('VEHICLES IN GENERAL', 'B60', 2009), ('LAND VEHICLES FOR TRAVELLING OTHERWISE THAN ON RAILS', 'B62', 2010), ('SHIPS OR OTHER WATERBORNE VESSELS; RELATED EQUIPMENT', 'B63', 2014), ('DYES; PAINTS; POLISHES; NATURAL RESINS; ADHESIVES; COMPOSITIONS NOT OTHERWISE PROVIDED FOR; APPLICATIONS OF MATERIALS NOT OTHERWISE PROVIDED FOR', 'C09', 2015), ('HYDRAULIC ENGINEERING; FOUNDATIONS; SOIL SHIFTING', 'E02', 2012), ('LOCKS; KEYS; WINDOW OR DOOR FITTINGS; SAFES', 'E05', 2012), ('COMBUSTION ENGINES; HOT-GAS OR COMBUSTION-PRODUCT ENGINE PLANTS', 'F02', 2010), ('ENGINEERING ELEMENTS AND UNITS; GENERAL MEASURES FOR PRODUCING AND MAINTAINING EFFECTIVE FUNCTIONING OF MACHINES OR INSTALLATIONS; THERMAL INSULATION IN GENERAL', 'F16', 2009), ('COMBUSTION APPARATUS; COMBUSTION PROCESSES', 'F23', 2018), ('HEATING; RANGES; VENTILATING', 'F24', 2018), ('WEAPONS', 'F41', 2012), ('MEASURING; TESTING', 'G01', 2008), ('OPTICS', 'G02', 2016), ('SIGNALLING', 'G08', 2017), ('ELECTRIC ELEMENTS', 'H01', 2008), ('GENERATION; CONVERSION OR DISTRIBUTION OF ELECTRIC POWER', 'H02', 2009), ('ELECTRONIC CIRCUITRY', 'H03', 2015), ('ELECTRIC COMMUNICATION TECHNIQUE', 'H04', 2015)]"
+  },
+  {
+    "dataset": "patents",
+    "query": "2",
+    "run": "1",
+    "answer": "[('MEDICAL OR VETERINARY SCIENCE; HYGIENE', 'A61', 2016), ('ELECTRIC COMMUNICATION TECHNIQUE', 'H04', 2015), ('BAKING; EDIBLE DOUGHS', 'A21', 2015), ('MACHINE TOOLS; METAL-WORKING NOT OTHERWISE PROVIDED FOR', 'B23', 2015), ('WORKING OF PLASTICS; WORKING OF SUBSTANCES IN A PLASTIC STATE IN GENERAL', 'B29', 2007), ('PRINTING; LINING MACHINES; TYPEWRITERS; STAMPS', 'B41', 2007), ('VEHICLES IN GENERAL', 'B60', 2009), ('LAND VEHICLES FOR TRAVELLING OTHERWISE THAN ON RAILS', 'B62', 2010), ('SHIPS OR OTHER WATERBORNE VESSELS; RELATED EQUIPMENT', 'B63', 2014), ('DYES; PAINTS; POLISHES; NATURAL RESINS; ADHESIVES; COMPOSITIONS NOT OTHERWISE PROVIDED FOR; APPLICATIONS OF MATERIALS NOT OTHERWISE PROVIDED FOR', 'C09', 2015), ('HYDRAULIC ENGINEERING; FOUNDATIONS; SOIL SHIFTING', 'E02', 2012), ('LOCKS; KEYS; WINDOW OR DOOR FITTINGS; SAFES', 'E05', 2012), ('COMBUSTION ENGINES; HOT-GAS OR COMBUSTION-PRODUCT ENGINE PLANTS', 'F02', 2010), ('ENGINEERING ELEMENTS AND UNITS; GENERAL MEASURES FOR PRODUCING AND MAINTAINING EFFECTIVE FUNCTIONING OF MACHINES OR INSTALLATIONS; THERMAL INSULATION IN GENERAL', 'F16', 2009), ('COMBUSTION APPARATUS; COMBUSTION PROCESSES', 'F23', 2018), ('HEATING; RANGES; VENTILATING', 'F24', 2018), ('WEAPONS', 'F41', 2012), ('MEASURING; TESTING', 'G01', 2008), ('OPTICS', 'G02', 2016), ('SIGNALLING', 'G08', 2017), ('ELECTRIC ELEMENTS', 'H01', 2008), ('GENERATION; CONVERSION OR DISTRIBUTION OF ELECTRIC POWER', 'H02', 2009), ('ELECTRONIC CIRCUITRY', 'H03', 2015)]"
+  },
+  {
+    "dataset": "patents",
+    "query": "2",
+    "run": "2",
+    "answer": "[('BAKING; EDIBLE DOUGHS', 'A21', 2015), ('MEDICAL OR VETERINARY SCIENCE; HYGIENE', 'A61', 2016), ('MACHINE TOOLS; METAL-WORKING NOT OTHERWISE PROVIDED FOR', 'B23', 2015), ('WORKING OF PLASTICS; WORKING OF SUBSTANCES IN A PLASTIC STATE IN GENERAL', 'B29', 2007), ('PRINTING; LINING MACHINES; TYPEWRITERS; STAMPS', 'B41', 2007), ('VEHICLES IN GENERAL', 'B60', 2009), ('LAND VEHICLES FOR TRAVELLING OTHERWISE THAN ON RAILS', 'B62', 2010), ('SHIPS OR OTHER WATERBORNE VESSELS; RELATED EQUIPMENT', 'B63', 2014), ('DYES; PAINTS; POLISHES; NATURAL RESINS; ADHESIVES; COMPOSITIONS NOT OTHERWISE PROVIDED FOR; APPLICATIONS OF MATERIALS NOT OTHERWISE PROVIDED FOR', 'C09', 2015), ('HYDRAULIC ENGINEERING; FOUNDATIONS; SOIL SHIFTING', 'E02', 2012), ('LOCKS; KEYS; WINDOW OR DOOR FITTINGS; SAFES', 'E05', 2012), ('COMBUSTION ENGINES; HOT-GAS OR COMBUSTION-PRODUCT ENGINE PLANTS', 'F02', 2010), ('ENGINEERING ELEMENTS AND UNITS; GENERAL MEASURES FOR PRODUCING AND MAINTAINING EFFECTIVE FUNCTIONING OF MACHINES OR INSTALLATIONS; THERMAL INSULATION IN GENERAL', 'F16', 2009), ('COMBUSTION APPARATUS; COMBUSTION PROCESSES', 'F23', 2018), ('HEATING; RANGES; VENTILATING', 'F24', 2018), ('WEAPONS', 'F41', 2012), ('MEASURING; TESTING', 'G01', 2008), ('OPTICS', 'G02', 2016), ('SIGNALLING', 'G08', 2017), ('ELECTRIC ELEMENTS', 'H01', 2008), ('GENERATION; CONVERSION OR DISTRIBUTION OF ELECTRIC POWER', 'H02', 2009), ('ELECTRONIC CIRCUITRY', 'H03', 2015), ('ELECTRIC COMMUNICATION TECHNIQUE', 'H04', 2015)]"
+  },
+  {
+    "dataset": "patents",
+    "query": "2",
+    "run": "3",
+    "answer": "[('ELECTRIC COMMUNICATION TECHNIQUE', 'H04', 2015), ('MEDICAL OR VETERINARY SCIENCE; HYGIENE', 'A61', 2016)]"
+  },
+  {
+    "dataset": "patents",
+    "query": "2",
+    "run": "4",
+    "answer": "[('BAKING; EDIBLE DOUGHS', 'A21', 2018), ('MEDICAL OR VETERINARY SCIENCE; HYGIENE', 'A61', 2021), ('MACHINE TOOLS; METAL-WORKING NOT OTHERWISE PROVIDED FOR', 'B23', 2022), ('WORKING OF PLASTICS; WORKING OF SUBSTANCES IN A PLASTIC STATE IN GENERAL', 'B29', 2021), ('PRINTING; LINING MACHINES; TYPEWRITERS; STAMPS', 'B41', 2020), ('VEHICLES IN GENERAL', 'B60', 2021), ('LAND VEHICLES FOR TRAVELLING OTHERWISE THAN ON RAILS', 'B62', 2021), ('SHIPS OR OTHER WATERBORNE VESSELS; RELATED EQUIPMENT', 'B63', 2022), ('DYES; PAINTS; POLISHES; NATURAL RESINS; ADHESIVES; COMPOSITIONS NOT OTHERWISE PROVIDED FOR; APPLICATIONS OF MATERIALS NOT OTHERWISE PROVIDED FOR', 'C09', 2021), ('HYDRAULIC ENGINEERING; FOUNDATIONS; SOIL SHIFTING', 'E02', 2022), ('LOCKS; KEYS; WINDOW OR DOOR FITTINGS; SAFES', 'E05', 2018), ('COMBUSTION ENGINES; HOT-GAS OR COMBUSTION-PRODUCT ENGINE PLANTS', 'F02', 2019), ('ENGINEERING ELEMENTS AND UNITS; GENERAL MEASURES FOR PRODUCING AND MAINTAINING EFFECTIVE FUNCTIONING OF MACHINES OR INSTALLATIONS; THERMAL INSULATION IN GENERAL', 'F16', 2021), ('COMBUSTION APPARATUS; COMBUSTION PROCESSES', 'F23', 2018), ('HEATING; RANGES; VENTILATING', 'F24', 2022), ('WEAPONS', 'F41', 2021), ('MEASURING; TESTING', 'G01', 2022), ('OPTICS', 'G02', 2021), ('SIGNALLING', 'G08', 2022), ('ELECTRIC ELEMENTS', 'H01', 2022), ('GENERATION; CONVERSION OR DISTRIBUTION OF ELECTRIC POWER', 'H02', 2022), ('ELECTRONIC CIRCUITRY', 'H03', 2021), ('ELECTRIC COMMUNICATION TECHNIQUE', 'H04', 2021)]"
+  },
+  {
+    "dataset": "patents",
+    "query": "3",
+    "run": "0",
+    "answer": "CALIFORNIA INST OF TECHN — GEOPHYSICS; GRAVITATIONAL MEASUREMENTS; DETECTING MASSES OR OBJECTS; TAGS; BLOOM ENERGY CORP — PROCESSES OR MEANS, e.g. BATTERIES, FOR THE DIRECT CONVERSION OF CHEMICAL ENERGY INTO ELECTRICAL ENERGY; CRYSTAL IS INC — SINGLE-CRYSTAL GROWTH; UNIDIRECTIONAL SOLIDIFICATION OF EUTECTIC MATERIAL OR UNIDIRECTIONAL DEMIXING OF EUTECTOID MATERIAL; REFINING BY ZONE-MELTING OF MATERIAL; PRODUCTION OF A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; SINGLE CRYSTALS OR HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; AFTER-TREATMENT OF SINGLE CRYSTALS OR A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; APPARATUS THEREFOR; SCHOWALTER LEO J — SEMICONDUCTOR DEVICES NOT COVERED BY CLASS H10"
+  },
+  {
+    "dataset": "patents",
+    "query": "3",
+    "run": "1",
+    "answer": "[('BLOOM ENERGY CORP', 'PROCESSES OR MEANS, e.g. BATTERIES, FOR THE DIRECT CONVERSION OF CHEMICAL ENERGY INTO ELECTRICAL ENERGY'), ('CALIFORNIA INST OF TECHN', 'GEOPHYSICS; GRAVITATIONAL MEASUREMENTS; DETECTING MASSES OR OBJECTS; TAGS'), ('CRYSTAL IS INC', 'SINGLE-CRYSTAL GROWTH; UNIDIRECTIONAL SOLIDIFICATION OF EUTECTIC MATERIAL OR UNIDIRECTIONAL DEMIXING OF EUTECTOID MATERIAL; REFINING BY ZONE-MELTING OF MATERIAL; PRODUCTION OF A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; SINGLE CRYSTALS OR HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; AFTER-TREATMENT OF SINGLE CRYSTALS OR A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; APPARATUS THEREFOR'), ('SCHOWALTER LEO J', 'SEMICONDUCTOR DEVICES NOT COVERED BY CLASS H10')]"
+  },
+  {
+    "dataset": "patents",
+    "query": "3",
+    "run": "2",
+    "answer": "[('CALIFORNIA INST OF TECHN', 'GEOPHYSICS; GRAVITATIONAL MEASUREMENTS; DETECTING MASSES OR OBJECTS; TAGS'), ('BLOOM ENERGY CORP', 'PROCESSES OR MEANS, e.g. BATTERIES, FOR THE DIRECT CONVERSION OF CHEMICAL ENERGY INTO ELECTRICAL ENERGY'), ('CRYSTAL IS INC', 'SINGLE-CRYSTAL GROWTH; UNIDIRECTIONAL SOLIDIFICATION OF EUTECTIC MATERIAL OR UNIDIRECTIONAL DEMIXING OF EUTECTOID MATERIAL; REFINING BY ZONE-MELTING OF MATERIAL; PRODUCTION OF A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; SINGLE CRYSTALS OR HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; AFTER-TREATMENT OF SINGLE CRYSTALS OR A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; APPARATUS THEREFOR'), ('SCHOWALTER LEO J', 'SEMICONDUCTOR DEVICES NOT COVERED BY CLASS H10')]"
+  },
+  {
+    "dataset": "patents",
+    "query": "3",
+    "run": "3",
+    "answer": "[('BLOOM ENERGY CORP', 'PROCESSES OR MEANS, e.g. BATTERIES, FOR THE DIRECT CONVERSION OF CHEMICAL ENERGY INTO ELECTRICAL ENERGY'), ('CALIFORNIA INST OF TECHN', 'GEOPHYSICS; GRAVITATIONAL MEASUREMENTS; DETECTING MASSES OR OBJECTS; TAGS'), ('CRYSTAL IS INC', 'SINGLE-CRYSTAL GROWTH; UNIDIRECTIONAL SOLIDIFICATION OF EUTECTIC MATERIAL OR UNIDIRECTIONAL DEMIXING OF EUTECTOID MATERIAL; REFINING BY ZONE-MELTING OF MATERIAL; PRODUCTION OF A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; SINGLE CRYSTALS OR HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; AFTER-TREATMENT OF SINGLE CRYSTALS OR A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; APPARATUS THEREFOR'), ('SCHOWALTER LEO J', 'SEMICONDUCTOR DEVICES NOT COVERED BY CLASS H10')]"
+  },
+  {
+    "dataset": "patents",
+    "query": "3",
+    "run": "4",
+    "answer": "BLOOM ENERGY CORP — PROCESSES OR MEANS, e.g. BATTERIES, FOR THE DIRECT CONVERSION OF CHEMICAL ENERGY INTO ELECTRICAL ENERGY; CALIFORNIA INST OF TECHN — GEOPHYSICS; GRAVITATIONAL MEASUREMENTS; DETECTING MASSES OR OBJECTS; TAGS; CRYSTAL IS INC — SINGLE-CRYSTAL GROWTH; UNIDIRECTIONAL SOLIDIFICATION OF EUTECTIC MATERIAL OR UNIDIRECTIONAL DEMIXING OF EUTECTOID MATERIAL; REFINING BY ZONE-MELTING OF MATERIAL; PRODUCTION OF A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; SINGLE CRYSTALS OR HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; AFTER-TREATMENT OF SINGLE CRYSTALS OR A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; APPARATUS THEREFOR; SCHOWALTER LEO J — SEMICONDUCTOR DEVICES NOT COVERED BY CLASS H10"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "1",
+    "run": "0",
+    "answer": "399001.SZ"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "1",
+    "run": "1",
+    "answer": "399001.SZ"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "1",
+    "run": "2",
+    "answer": "399001.SZ"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "1",
+    "run": "3",
+    "answer": "399001.SZ"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "1",
+    "run": "4",
+    "answer": "399001.SZ"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "2",
+    "run": "0",
+    "answer": "['IXIC']"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "2",
+    "run": "1",
+    "answer": "IXIC"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "2",
+    "run": "2",
+    "answer": "['IXIC']"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "2",
+    "run": "3",
+    "answer": "['IXIC']"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "2",
+    "run": "4",
+    "answer": "['IXIC']"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "3",
+    "run": "0",
+    "answer": "[('IXIC','United States'), ('NSEI','India'), ('399001.SZ','China'), ('GDAXI','Germany'), ('TWII','Taiwan')]"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "3",
+    "run": "1",
+    "answer": "[('IXIC', 'United States'), ('NSEI', 'India'), ('399001.SZ', 'China'), ('GDAXI', 'Germany'), ('TWII', 'Taiwan')]"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "3",
+    "run": "2",
+    "answer": "[('IXIC', 'United States'), ('NSEI', 'India'), ('399001.SZ', 'China'), ('GDAXI', 'Germany'), ('TWII', 'Taiwan')]"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "3",
+    "run": "3",
+    "answer": "[('IXIC', 'United States', 3.8269), ('NSEI', 'India', 1.3584), ('399001.SZ', 'China', 1.3475), ('GDAXI', 'Germany', 1.3470), ('TWII', 'Taiwan', 1.2982)]"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "3",
+    "run": "4",
+    "answer": "[(\"IXIC\", \"United States\"), (\"NSEI\", \"India\"), (\"399001.SZ\", \"China\"), (\"GDAXI\", \"Germany\"), (\"TWII\", \"Taiwan\")]"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "1",
+    "run": "0",
+    "answer": "18.44"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "1",
+    "run": "1",
+    "answer": "18.44"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "1",
+    "run": "2",
+    "answer": "18.440000534057617"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "1",
+    "run": "3",
+    "answer": "18.440000534057617"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "1",
+    "run": "4",
+    "answer": "18.44"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "2",
+    "run": "0",
+    "answer": "(31, ['BOIL', 'BZQ', 'COM', 'DUST', 'EDZ', 'ERX', 'FAZ', 'FXP', 'GFIN', 'GUSH', 'HYUP', 'JDST', 'JNUG', 'JPN', 'LABD', 'LABU', 'LBJ', 'MDY', 'PTIN', 'RTL', 'SDOW', 'SOXS', 'SSG', 'TECS', 'TZA', 'UVXY', 'VIXY', 'VPC', 'XES', 'XOP', 'YANG'])"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "2",
+    "run": "1",
+    "answer": "(['BOIL', 'BZQ', 'COM', 'DUST', 'EDZ', 'ERX', 'FAZ', 'FXP', 'GFIN', 'GUSH', 'HYUP', 'JDST', 'JNUG', 'JPN', 'LABD', 'LABU', 'LBJ', 'MDY', 'PTIN', 'RTL', 'SDOW', 'SOXS', 'SSG', 'TECS', 'TZA', 'UVXY', 'VIXY', 'VPC', 'XES', 'XOP', 'YANG'], 31)"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "2",
+    "run": "2",
+    "answer": "(['BOIL', 'BZQ', 'COM', 'DUST', 'EDZ', 'ERX', 'FAZ', 'FXP', 'GFIN', 'GUSH', 'HYUP', 'JDST', 'JNUG', 'JPN', 'LABD', 'LABU', 'LBJ', 'MDY', 'PTIN', 'RTL', 'SDOW', 'SOXS', 'SSG', 'TECS', 'TZA', 'UVXY', 'VIXY', 'VPC', 'XES', 'XOP', 'YANG'], 31)"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "2",
+    "run": "3",
+    "answer": "(31, ['BOIL', 'BZQ', 'COM', 'DUST', 'EDZ', 'ERX', 'FAZ', 'FXP', 'GFIN', 'GUSH', 'HYUP', 'JDST', 'JNUG', 'JPN', 'LABD', 'LABU', 'LBJ', 'MDY', 'PTIN', 'RTL', 'SDOW', 'SOXS', 'SSG', 'TECS', 'TZA', 'UVXY', 'VIXY', 'VPC', 'XES', 'XOP', 'YANG'])"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "2",
+    "run": "4",
+    "answer": "(['BOIL', 'BZQ', 'COM', 'DUST', 'EDZ', 'ERX', 'FAZ', 'FXP', 'GFIN', 'GUSH', 'HYUP', 'JDST', 'JNUG', 'JPN', 'LABD', 'LABU', 'LBJ', 'MDY', 'PTIN', 'RTL', 'SDOW', 'SOXS', 'SSG', 'TECS', 'TZA', 'UVXY', 'VIXY', 'VPC', 'XES', 'XOP', 'YANG'], 31)"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "3",
+    "run": "0",
+    "answer": "[('Apex Global Brands Inc.', 23781.42), ('BIO-key International, Inc.', 10988.14), ('CBAK Energy Technology, Inc.', 86223.32), ('China Ceramics Co., Ltd.', 4366.80), ('Correvio Pharma Corp.', 145247.83), ('CounterPath Corporation', 375.49), ('DASAN Zhone Solutions, Inc.', 15578.66), ('Future FinTech Group Inc.', 9.85), ('Frontier Communications Corporation', 254397.63), ('Ideanomics, Inc.', 10.28), ('Ocean Power Technologies, Inc.', 254.15), ('Pacific Ethanol, Inc.', 10706.72), ('Synthesis Energy Systems, Inc.', 2390.51), ('Sunesis Pharmaceuticals, Inc.', 781.82), ('Sypris Solutions, Inc.', 36836.36)]"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "3",
+    "run": "1",
+    "answer": "[('Apex Global Brands Inc.', 23781.422924901184), ('BIO-key International, Inc.', 10988.142292490118), ('CBAK Energy Technology, Inc.', 86223.32015810277), ('China Ceramics Co., Ltd.', 4366.798418972332), ('Correvio Pharma Corp.', 145247.8260869565), ('CounterPath Corporation', 375.49407114624506), ('DASAN Zhone Solutions, Inc.', 15578.656126482214), ('Future FinTech Group Inc.', 9.845238095238095), ('Frontier Communications Corporation', 254397.62845849802), ('Ideanomics, Inc.', 10.276679841897232), ('Ocean Power Technologies, Inc.', 254.1501976284585), ('Pacific Ethanol, Inc.', 10706.719367588932), ('Synthesis Energy Systems, Inc.', 2390.513833992095), ('Sunesis Pharmaceuticals, Inc.', 781.8181818181819), ('Sypris Solutions, Inc.', 36836.36363636364)]"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "3",
+    "run": "2",
+    "answer": "[(\"Apex Global Brands Inc.\", 23781.4229), (\"BIO-key International, Inc.\", 10988.1423), (\"CBAK Energy Technology, Inc.\", 86223.3202), (\"China Ceramics Co., Ltd.\", 4366.7984), (\"Correvio Pharma Corp.\", 145247.8261), (\"CounterPath Corporation\", 375.4941), (\"DASAN Zhone Solutions, Inc.\", 15578.6561), (\"Frontier Communications Corporation\", 254397.6285), (\"Future FinTech Group Inc.\", 9.8452), (\"Ideanomics, Inc.\", 10.2767), (\"Ocean Power Technologies, Inc.\", 254.1502), (\"Pacific Ethanol, Inc.\", 10706.7194), (\"Sunesis Pharmaceuticals, Inc.\", 781.8182), (\"Synthesis Energy Systems, Inc.\", 2390.5138), (\"Sypris Solutions, Inc.\", 36836.3636)]"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "3",
+    "run": "3",
+    "answer": "[('Apex Global Brands Inc.', 23781.42), ('BIO-key International, Inc.', 10988.14), ('CBAK Energy Technology, Inc.', 86223.32), ('China Ceramics Co., Ltd.', 4366.80), ('Correvio Pharma Corp.', 145247.83), ('CounterPath Corporation', 375.49), ('DASAN Zhone Solutions, Inc.', 15578.66), ('Future FinTech Group Inc.', 9.85), ('Frontier Communications Corporation', 254397.63), ('Ideanomics, Inc.', 10.28), ('Ocean Power Technologies, Inc.', 254.15), ('Pacific Ethanol, Inc.', 10706.72), ('Synthesis Energy Systems, Inc.', 2390.51), ('Sunesis Pharmaceuticals, Inc.', 781.82), ('Sypris Solutions, Inc.', 36836.36)]"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "3",
+    "run": "4",
+    "answer": "[(\"Apex Global Brands Inc.\", 23781.422925), (\"BIO-key International, Inc.\", 10988.142292), (\"CBAK Energy Technology, Inc.\", 86223.320158), (\"China Ceramics Co., Ltd.\", 4366.798419), (\"Correvio Pharma Corp.\", 145247.826087), (\"CounterPath Corporation\", 375.494071), (\"DASAN Zhone Solutions, Inc.\", 15578.656126), (\"Frontier Communications Corporation\", 254397.628458), (\"Future FinTech Group Inc.\", 9.845238), (\"Ideanomics, Inc.\", 10.276680), (\"Ocean Power Technologies, Inc.\", 254.150198), (\"Pacific Ethanol, Inc.\", 10706.719368), (\"Sunesis Pharmaceuticals, Inc.\", 781.818182), (\"Synthesis Energy Systems, Inc.\", 2390.513834), (\"Sypris Solutions, Inc.\", 36836.363636)]"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "4",
+    "run": "0",
+    "answer": "MFA Financial, Argo Group International Holdings, HDFC Bank Limited, Albany International Corporation, DTE Energy Company"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "4",
+    "run": "1",
+    "answer": "MFA Financial, Inc.; Argo Group International Holdings, Ltd.; HDFC Bank Limited; Albany International Corporation; DTE Energy Company"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "4",
+    "run": "2",
+    "answer": "['MFA Financial, Inc.', 'Argo Group International Holdings, Ltd.', 'HDFC Bank Limited', 'Albany International Corporation', 'DTE Energy Company']"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "4",
+    "run": "3",
+    "answer": "MFA Financial, Inc., Argo Group International Holdings, Ltd., HDFC Bank Limited, Albany International Corporation, DTE Energy Company"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "4",
+    "run": "4",
+    "answer": "['MFA Financial, Inc.', 'Argo Group International Holdings, Ltd.', 'HDFC Bank Limited', 'Albany International Corporation', 'DTE Energy Company']"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "5",
+    "run": "0",
+    "answer": "Synthesis Energy Systems, Inc.; TD Holdings, Inc.; TMSR Holding Company Limited; Verb Technology Company, Inc.; Sunesis Pharmaceuticals, Inc."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "5",
+    "run": "1",
+    "answer": "Synthesis Energy Systems, Inc.; TD Holdings, Inc.; TMSR Holding Company Limited; Verb Technology Company, Inc.; Sunesis Pharmaceuticals, Inc."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "5",
+    "run": "2",
+    "answer": "['Synthesis Energy Systems, Inc.', 'TD Holdings, Inc.', 'TMSR Holding Company Limited', 'Verb Technology Company, Inc.', 'Sunesis Pharmaceuticals, Inc.']"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "5",
+    "run": "3",
+    "answer": "['Synthesis Energy Systems, Inc.', 'TD Holdings, Inc.', 'TMSR Holding Company Limited', 'Verb Technology Company, Inc.', 'Sunesis Pharmaceuticals, Inc.']"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "5",
+    "run": "4",
+    "answer": "Synthesis Energy Systems, Inc.; TD Holdings, Inc.; TMSR Holding Company Limited; Verb Technology Company, Inc.; Sunesis Pharmaceuticals, Inc."
+  },
+  {
+    "dataset": "yelp",
+    "query": "1",
+    "run": "0",
+    "answer": "3.547"
+  },
+  {
+    "dataset": "yelp",
+    "query": "1",
+    "run": "1",
+    "answer": "3.5470"
+  },
+  {
+    "dataset": "yelp",
+    "query": "1",
+    "run": "2",
+    "answer": "3.55"
+  },
+  {
+    "dataset": "yelp",
+    "query": "1",
+    "run": "3",
+    "answer": "3.55"
+  },
+  {
+    "dataset": "yelp",
+    "query": "1",
+    "run": "4",
+    "answer": "3.547008547008547"
+  },
+  {
+    "dataset": "yelp",
+    "query": "2",
+    "run": "0",
+    "answer": "('PA', 3.7)"
+  },
+  {
+    "dataset": "yelp",
+    "query": "2",
+    "run": "1",
+    "answer": "('PA', 3.70)"
+  },
+  {
+    "dataset": "yelp",
+    "query": "2",
+    "run": "2",
+    "answer": "('PA', 3.70)"
+  },
+  {
+    "dataset": "yelp",
+    "query": "2",
+    "run": "3",
+    "answer": "('PA', 3.70)"
+  },
+  {
+    "dataset": "yelp",
+    "query": "2",
+    "run": "4",
+    "answer": "('PA', 3.70)"
+  },
+  {
+    "dataset": "yelp",
+    "query": "3",
+    "run": "0",
+    "answer": "35"
+  },
+  {
+    "dataset": "yelp",
+    "query": "3",
+    "run": "1",
+    "answer": "35"
+  },
+  {
+    "dataset": "yelp",
+    "query": "3",
+    "run": "2",
+    "answer": "35"
+  },
+  {
+    "dataset": "yelp",
+    "query": "3",
+    "run": "3",
+    "answer": "35"
+  },
+  {
+    "dataset": "yelp",
+    "query": "3",
+    "run": "4",
+    "answer": "35"
+  },
+  {
+    "dataset": "yelp",
+    "query": "4",
+    "run": "0",
+    "answer": "Restaurants, 3.63"
+  },
+  {
+    "dataset": "yelp",
+    "query": "4",
+    "run": "1",
+    "answer": "('Restaurants', 3.64)"
+  },
+  {
+    "dataset": "yelp",
+    "query": "4",
+    "run": "2",
+    "answer": "('Restaurants', 3.64)"
+  },
+  {
+    "dataset": "yelp",
+    "query": "4",
+    "run": "3",
+    "answer": "('Restaurants', 3.64)"
+  },
+  {
+    "dataset": "yelp",
+    "query": "4",
+    "run": "4",
+    "answer": "('Restaurants', 3.63)"
+  },
+  {
+    "dataset": "yelp",
+    "query": "5",
+    "run": "0",
+    "answer": "('PA', 3.48)"
+  },
+  {
+    "dataset": "yelp",
+    "query": "5",
+    "run": "1",
+    "answer": "('PA', 3.48)"
+  },
+  {
+    "dataset": "yelp",
+    "query": "5",
+    "run": "2",
+    "answer": "('PA', 3.48)"
+  },
+  {
+    "dataset": "yelp",
+    "query": "5",
+    "run": "3",
+    "answer": "('PA', 3.48)"
+  },
+  {
+    "dataset": "yelp",
+    "query": "5",
+    "run": "4",
+    "answer": "('PA', 3.48)"
+  },
+  {
+    "dataset": "yelp",
+    "query": "6",
+    "run": "0",
+    "answer": "(\"Coffee House Too Cafe\", \"Restaurants, Breakfast & Brunch, American (New), Cafes\")"
+  },
+  {
+    "dataset": "yelp",
+    "query": "6",
+    "run": "1",
+    "answer": "(\"Coffee House Too Cafe\", \"Restaurants, Breakfast & Brunch, American (New), Cafes\")"
+  },
+  {
+    "dataset": "yelp",
+    "query": "6",
+    "run": "2",
+    "answer": "('Coffee House Too Cafe', 'Restaurants, Breakfast & Brunch, American (New), Cafes')"
+  },
+  {
+    "dataset": "yelp",
+    "query": "6",
+    "run": "3",
+    "answer": "[('Coffee House Too Cafe', 'Restaurants, Breakfast & Brunch, American (New), Cafes')]"
+  },
+  {
+    "dataset": "yelp",
+    "query": "6",
+    "run": "4",
+    "answer": "(\"Coffee House Too Cafe\", \"Restaurants, Breakfast & Brunch, American (New), Cafes\")"
+  },
+  {
+    "dataset": "yelp",
+    "query": "7",
+    "run": "0",
+    "answer": "[('Restaurants', 58), ('Food', 38), ('American (New)', 24), ('Shopping', 20), ('Breakfast & Brunch', 19)]"
+  },
+  {
+    "dataset": "yelp",
+    "query": "7",
+    "run": "1",
+    "answer": "[('Restaurants', 58), ('Food', 38), ('American (New)', 24), ('Shopping', 20), ('Breakfast & Brunch', 19)]"
+  },
+  {
+    "dataset": "yelp",
+    "query": "7",
+    "run": "2",
+    "answer": "[('Restaurants', 58), ('Food', 38), ('American (New)', 24), ('Shopping', 20), ('Breakfast & Brunch', 19)]"
+  },
+  {
+    "dataset": "yelp",
+    "query": "7",
+    "run": "3",
+    "answer": "Restaurants, Food, American (New), Shopping, Breakfast & Brunch"
+  },
+  {
+    "dataset": "yelp",
+    "query": "7",
+    "run": "4",
+    "answer": "[('Restaurants', 58), ('Food', 38), ('American (New)', 24), ('Shopping', 20), ('Breakfast & Brunch', 19)]"
+  }
+]


### PR DESCRIPTION
## SCRIBE — Leaderboard Submission

**Agent name:** SCRIBE
**Backbone LLM:** Claude Opus 4.7
**Hints:** No
**Trials:** 5 per query
**Stratified Pass@1:** 81.85%

## Architecture

SCRIBE is a two-stage pipeline: a **Spec Agent** first reads the task description and generates a structured execution plan; an **Executor** then carries out the plan using Python, SQL (PostgreSQL / SQLite / DuckDB), and MongoDB tools in an iterative loop with up to 40 iterations. A **Planner** agent is available mid-execution for course correction.

All three stages use Claude Opus 4.7. No pre-built indexes or schema hints — databases are discovered at runtime via live introspection.

## Results

| Dataset | Pass@1 |
|---|---|
| bookreview | 1.00 |
| music\_brainz\_20k | 1.00 |
| stockindex | 1.00 |
| stockmarket | 1.00 |
| yelp | 1.00 |
| crmarenapro | 0.94 |
| patents | 0.87 |
| googlelocal | 0.75 |
| github\_repos | 0.65 |
| pancancer\_atlas | 0.67 |
| deps\_dev\_v1 | 0.50 |
| agnews | 0.45 |
| **Stratified Pass@1** | **0.8185** |

## Notes

- 270 entries (54 queries × 5 trials), validated against official DAB validators with 0 errors.
- Preamble sandbox blocks `load_dataset`, HuggingFace cache reads, `subprocess`, `pyarrow.memory_map`, and `os.walk` over external cache paths.
- Submission: [scribe_opus47xhigh.json](https://github.com/Suraj-gameramp/DataAgentBench/releases/download/scribe-opus47xhigh/scribe_opus47xhigh.json) · Traces: [scribe_opus47xhigh_traces.tar.gz](https://github.com/Suraj-gameramp/DataAgentBench/releases/download/scribe-opus47xhigh/scribe_opus47xhigh_traces.tar.gz)