### PR TITLE
[Leaderboard] Alkera - Opus 4.8 - 80.44% Pass@1

### DIFF
--- a/leaderboard_submissions/alkera-opus-4.8_results.json
+++ b/leaderboard_submissions/alkera-opus-4.8_results.json
@@ -1,0 +1,1622 @@
+[
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "1",
+    "run": "0",
+    "answer": "@dylanvann/svelte 3.25.4 73499; @dumc11/tailwindcss 0.4.0 73464; @dreampie/semantic-ui 2.2.11 51069; @dongls/pdfjs-dist 3.2.72 44231; @dman777/shadow-dom-quill-temp 1.0.0 42407"
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "1",
+    "run": "1",
+    "answer": "@ec-nordbund/leaflet 1.7.1 (38715 stars); @domdomegg/swagger-ui 3.25.0 (24753 stars); @dnaroid/medusa 1.7.22 (20285 stars); @dxp-dc/vuedraggable 2.24.3 (19911 stars); @dongjiang/textmate-grammars 0.0.5 (18526 stars)"
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "1",
+    "run": "2",
+    "answer": "@dylanvann/svelte 3.25.4 (73499 stars); @dumc11/tailwindcss 0.4.0 (73464 stars); @dreampie/semantic-ui 2.2.11 (51069 stars); @dongls/pdfjs-dist 3.2.72 (44231 stars); @dman777/shadow-dom-quill-temp 1.0.0 (42407 stars)"
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "1",
+    "run": "3",
+    "answer": "@dylanvann/svelte 3.25.4 73499; @dumc11/tailwindcss 0.4.0 73464; @dreampie/semantic-ui 2.2.11 51069; @dongls/pdfjs-dist 3.2.72 44231; @dman777/shadow-dom-quill-temp 1.0.0 42407"
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "1",
+    "run": "4",
+    "answer": "@dylanvann/svelte 3.25.4 (73499 stars); @dumc11/tailwindcss 0.4.0 (73464 stars); @dothq/styled-components 1.0.0 (39660 stars); @dynasty/styled-components 3.2.1 (39660 stars); @ec-nordbund/leaflet 1.7.1 (38715 stars)"
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "2",
+    "run": "0",
+    "answer": "mui-org/material-ui 30522; moment/moment 7201; semantic-org/semantic-ui 4955; react-native-elements/react-native-elements 4623; sveltejs/svelte 4091"
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "2",
+    "run": "1",
+    "answer": "mui-org/material-ui 30522; moment/moment 7201; semantic-org/semantic-ui 4955; react-native-elements/react-native-elements 4623; sveltejs/svelte 4091"
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "2",
+    "run": "2",
+    "answer": "mui-org/material-ui 30522; moment/moment 7201; semantic-org/semantic-ui 4955; react-native-elements/react-native-elements 4623; sveltejs/svelte 4091"
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "2",
+    "run": "3",
+    "answer": "mui-org/material-ui 30522; moment/moment 7201; semantic-org/semantic-ui 4955; react-native-elements/react-native-elements 4623; sveltejs/svelte 4091"
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "2",
+    "run": "4",
+    "answer": "mui-org/material-ui 30522; moment/moment 7201; semantic-org/semantic-ui 4955; react-native-elements/react-native-elements 4623; sveltejs/svelte 4091"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "1",
+    "run": "0",
+    "answer": "0.137405 (18 of 131 README.md files in non-Python repositories include copyright information)"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "1",
+    "run": "1",
+    "answer": "0.1485148514851485 (15 of 101 README.md files from non-Python repositories include copyright information, using the word \"copyright\" case-insensitively over repos whose `languages` record excludes Python; equivalently 15/101 ≈ 14.85%. If repos with no language record are also treated as non-Python, it is 16/111 = 0.1441441441441441.)"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "1",
+    "run": "2",
+    "answer": "0.1221 (16 of 131 README.md files in non-Python repositories contain copyright information; 16/131 = 0.12213740458015267)"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "1",
+    "run": "3",
+    "answer": "Among non-Python repositories, 16 of their 131 README.md files include copyright information — a proportion of 0.122137 (≈12.2%), using the word \"copyright\" (case-insensitive). If the © symbol is also counted as copyright information, it is 18/131 = 0.137405."
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "1",
+    "run": "4",
+    "answer": "Among repositories that do not use Python, 20 of their 153 README.md files include copyright information — a proportion of 0.13071895424836602 (≈0.1307)."
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "2",
+    "run": "0",
+    "answer": "uacaps/PageMenu (Swift-primary repo containing the most-copied non-binary Swift file — `Demos/Demo 4/PageMenuDemoTabbar/PageMenuDemoTabbar/ContactTableViewCell.swift`, id 6f4cdb70f044b0486a24a07403600cb964a02672, copied 38 times)"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "2",
+    "run": "1",
+    "answer": "uacaps/PageMenu"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "2",
+    "run": "2",
+    "answer": "uacaps/PageMenu (its most-copied non-binary Swift file, id 6f4cdb70f044b0486a24a07403600cb964a02672 = ContactTableViewCell.swift, copied 38 times)"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "2",
+    "run": "3",
+    "answer": "uacaps/PageMenu"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "2",
+    "run": "4",
+    "answer": "uacaps/PageMenu (contains the most-copied non-binary Swift file, id 6f4cdb70f044b0486a24a07403600cb964a02672, path \"Demos/Demo 4/PageMenuDemoTabbar/PageMenuDemoTabbar/ContactTableViewCell.swift\", copied 38 times)"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "3",
+    "run": "0",
+    "answer": "1077"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "3",
+    "run": "1",
+    "answer": "1077"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "3",
+    "run": "2",
+    "answer": "1077"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "3",
+    "run": "3",
+    "answer": "1077"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "3",
+    "run": "4",
+    "answer": "1077"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "4",
+    "run": "0",
+    "answer": "apple/swift; twbs/bootstrap; Microsoft/vscode; facebook/react; tensorflow/tensorflow"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "4",
+    "run": "1",
+    "answer": "apple/swift; twbs/bootstrap; Microsoft/vscode; facebook/react; tensorflow/tensorflow"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "4",
+    "run": "2",
+    "answer": "apple/swift; twbs/bootstrap; Microsoft/vscode; facebook/react; tensorflow/tensorflow"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "4",
+    "run": "3",
+    "answer": "apple/swift; twbs/bootstrap; Microsoft/vscode; facebook/react; tensorflow/tensorflow"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "4",
+    "run": "4",
+    "answer": "apple/swift; twbs/bootstrap; Microsoft/vscode; facebook/react; tensorflow/tensorflow"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "1",
+    "run": "0",
+    "answer": "Astrocytoma 2.5712981411; Oligoastrocytoma 2.7135713052; Oligodendroglioma 2.6824579933"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "1",
+    "run": "1",
+    "answer": "Astrocytoma 2.5713 (2.571298141143903); Oligoastrocytoma 2.7136 (2.713571305193452); Oligodendroglioma 2.6825 (2.682457993294452)"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "1",
+    "run": "2",
+    "answer": "Astrocytoma 2.5713; Oligoastrocytoma 2.7136; Oligodendroglioma 2.6825 (full precision: Astrocytoma 2.5712981411, Oligoastrocytoma 2.7135713052, Oligodendroglioma 2.6824579933)"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "1",
+    "run": "3",
+    "answer": "Astrocytoma 2.5713; Oligoastrocytoma 2.7136; Oligodendroglioma 2.6825 (full precision: Astrocytoma = 2.5712981411, Oligoastrocytoma = 2.7135713052, Oligodendroglioma = 2.6824579933; average of log10(IGF2 normalized_count + 1) over LGG patients with valid IGF2 values and non-bracketed histology)"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "1",
+    "run": "4",
+    "answer": "Astrocytoma 2.5713; Oligoastrocytoma 2.7136; Oligodendroglioma 2.6825"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "2",
+    "run": "0",
+    "answer": "Infiltrating Lobular Carcinoma 50.5618% (90/178); Mixed Histology (please specify) 16.6667% (4/24); Other  specify 8.3333% (3/36)"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "2",
+    "run": "1",
+    "answer": "Infiltrating Lobular Carcinoma 50.5618%; Mixed Histology (please specify) 16.6667%; Other  specify 8.3333%"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "2",
+    "run": "2",
+    "answer": "Infiltrating Lobular Carcinoma 50.56% (90/178); Mixed Histology (please specify) 16.67% (4/24); Other, specify 8.33% (3/36)"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "2",
+    "run": "3",
+    "answer": "Infiltrating Lobular Carcinoma 50.56% (90/178); Mixed Histology (please specify) 16.67% (4/24); Other  specify 8.33% (3/36)"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "2",
+    "run": "4",
+    "answer": "Infiltrating Lobular Carcinoma 50.5618% (90/178); Mixed Histology (please specify) 16.6667% (4/24); Other  specify 8.3333% (3/36)"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "3",
+    "run": "0",
+    "answer": "305.1239198007461 (χ² ≈ 305.12; dof = 4). Reduced 5×2 table (histological_type: CDH1 absent, present) — Infiltrating Ductal Carcinoma: 757, 9; Infiltrating Lobular Carcinoma: 118, 83; Mixed Histology (please specify): 26, 4; Mucinous Carcinoma: 17, 0; Other specify: 42, 3."
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "3",
+    "run": "1",
+    "answer": "305.1239 (chi-square statistic ≈ 305.12; reduced 5×2 table of Infiltrating Ductal Carcinoma, Infiltrating Lobular Carcinoma, Other specify, Mixed Histology (please specify), Mucinous Carcinoma × CDH1 mutation present/absent, N=1059, after excluding Metaplastic Carcinoma, Medullary Carcinoma, and Infiltrating Carcinoma NOS whose row marginals ≤10)"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "3",
+    "run": "2",
+    "answer": "χ² = 305.1239 (≈305.12), degrees of freedom = 4"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "3",
+    "run": "3",
+    "answer": "χ² = 305.1239 (degrees of freedom = 4, p ≈ 8.5e-65), computed over the 5×2 table of histological type × CDH1 mutation presence for female BRCA patients after excluding the categories Infiltrating Carcinoma NOS, Medullary Carcinoma, and Metaplastic Carcinoma (marginal totals ≤ 10)."
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "3",
+    "run": "4",
+    "answer": "χ² = 305.1239 (degrees of freedom = 4), computed over the 5 retained histological types [Infiltrating Ductal Carcinoma, Infiltrating Lobular Carcinoma, Other specify, Mixed Histology (please specify), Mucinous Carcinoma] after excluding Metaplastic Carcinoma, Medullary Carcinoma, and Infiltrating Carcinoma NOS for having marginal totals ≤ 10."
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "1",
+    "run": "0",
+    "answer": "A22B; A23J; A23P; A24D; A24F; A41G; A47F; A61G; A61H; A61P; A62D; A63H; B04B; B07B; B08B; B09C; B21J; B22F; B24B; B25B; B25D; B27C; B27M; B60D; B60L; B60P; B61H; B63C; B63G; B65G; B66F; C01D; C01G; C21B; C21C; C22C; D21B; E01H; E02B; E02D; E03B; E04B; E04G; E21D; E21F; F02K; F04F; F16M; F25J; F26B; G01H; G01L; G01S; G05D; G06N; G06Q; G06T; G06V; G08G; G09F; G10L; G16B; G16C; G16H; G21F; H01M; H02B; H02G; H02J; H03H; H04K; H05F"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "1",
+    "run": "1",
+    "answer": "A22B; A23J; A23P; A24D; A24F; A41G; A47F; A61G; A61H; A61P; A62D; A63H; B04B; B07B; B08B; B09C; B21J; B22F; B24B; B25B; B25D; B27C; B27M; B60D; B60L; B60P; B61H; B63C; B63G; B65G; B66F; C01D; C01G; C21B; C21C; C22C; D21B; E01H; E02B; E02D; E03B; E04B; E04G; E21D; E21F; F02K; F04F; F16M; F25J; F26B; G01H; G01L; G01S; G05D; G06N; G06Q; G06T; G06V; G08G; G09F; G10L; G16B; G16C; G16H; G21F; H01M; H02B; H02G; H02J; H03H; H04K; H05F"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "1",
+    "run": "2",
+    "answer": "A22B; A23J; A23P; A24D; A24F; A41G; A47F; A61G; A61H; A61P; A62D; A63H; B04B; B07B; B08B; B09C; B21J; B22F; B24B; B25B; B25D; B27C; B27M; B60D; B60L; B60P; B61H; B63C; B63G; B65G; B66F; C01D; C01G; C21B; C21C; C22C; D21B; E01H; E02B; E02D; E03B; E04B; E04G; E21D; E21F; F02K; F04F; F16M; F25J; F26B; G01H; G01L; G01S; G05D; G06N; G06Q; G06T; G06V; G08G; G09F; G10L; G16B; G16C; G16H; G21F; H01M; H02B; H02G; H02J; H03H; H04K; H05F"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "1",
+    "run": "3",
+    "answer": "A22B; A23J; A23P; A24D; A24F; A41G; A47F; A61G; A61H; A61P; A62D; A63H; B04B; B07B; B08B; B09C; B21J; B22F; B24B; B25B; B25D; B27C; B27M; B60D; B60L; B60P; B61H; B63C; B63G; B65G; B66F; C01D; C01G; C21B; C21C; C22C; D21B; E01H; E02B; E02D; E03B; E04B; E04G; E21D; E21F; F02K; F04F; F16M; F25J; F26B; G01H; G01L; G01S; G05D; G06N; G06Q; G06T; G06V; G08G; G09F; G10L; G16B; G16C; G16H; G21F; H01M; H02B; H02G; H02J; H03H; H04K; H05F"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "1",
+    "run": "4",
+    "answer": "G06Q; H01M; G06T; G06V; H02J; G01S; G06N; B65G; A61P; G16H; G05D; C22C; B60L; G08G; G10L; B24B; E04B; E02D; B08B; G09F; A24F; H02G; A61H; E04G; B22F; B25B; A61G; G01L; F16M; C01G; F26B; H03H; H02B; E02B; B66F; E21D; G16B; B07B; B60P; A63H; A24D; E21F; F02K; E01H; G01H; A47F; C21B; B09C; E03B; B21J; A23P; F25J; B04B; G21F; C01D; C21C; B63C; G16C; A23J; B60D; B27M; F04F; B27C; A41G; B63G; B25D; A62D; B61H; A22B; H04K; H05F; D21B"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "2",
+    "run": "0",
+    "answer": "The two CPC level-4 technology areas with the highest EMA (α=0.1, =2.0) are: A61 MEDICAL OR VETERINARY SCIENCE; HYGIENE 2016; H04 ELECTRIC COMMUNICATION TECHNIQUE 2015. Full per-group listing (CPC code — full title — best year) for all 23 level-4 areas: A61 MEDICAL OR VETERINARY SCIENCE; HYGIENE 2016; H04 ELECTRIC COMMUNICATION TECHNIQUE 2015; A21 BAKING; EDIBLE DOUGHS 2015; B23 MACHINE TOOLS; METAL-WORKING NOT OTHERWISE PROVIDED FOR 2015; B29 WORKING OF PLASTICS; WORKING OF SUBSTANCES IN A PLASTIC STATE IN GENERAL 2007; B41 PRINTING; LINING MACHINES; TYPEWRITERS; STAMPS 2007; B60 VEHICLES IN GENERAL 2009; B62 LAND VEHICLES FOR TRAVELLING OTHERWISE THAN ON RAILS 2010; B63 SHIPS OR OTHER WATERBORNE VESSELS; RELATED EQUIPMENT 2014; C09 DYES; PAINTS; POLISHES; NATURAL RESINS; ADHESIVES; COMPOSITIONS NOT OTHERWISE PROVIDED FOR; APPLICATIONS OF MATERIALS NOT OTHERWISE PROVIDED FOR 2015; E02 HYDRAULIC ENGINEERING; FOUNDATIONS; SOIL SHIFTING 2012; E05 LOCKS; KEYS; WINDOW OR DOOR FITTINGS; SAFES 2012; F02 COMBUSTION ENGINES; HOT-GAS OR COMBUSTION-PRODUCT ENGINE PLANTS 2010; F16 ENGINEERING ELEMENTS AND UNITS; GENERAL MEASURES FOR PRODUCING AND MAINTAINING EFFECTIVE FUNCTIONING OF MACHINES OR INSTALLATIONS; THERMAL INSULATION IN GENERAL 2009; F23 COMBUSTION APPARATUS; COMBUSTION PROCESSES 2018; F24 HEATING; RANGES; VENTILATING 2018; F41 WEAPONS 2012; G01 MEASURING; TESTING 2008; G02 OPTICS 2016; G08 SIGNALLING 2017; H01 ELECTRIC ELEMENTS 2008; H02 GENERATION; CONVERSION OR DISTRIBUTION OF ELECTRIC POWER 2009; H03 ELECTRONIC CIRCUITRY 2015"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "2",
+    "run": "1",
+    "answer": "The Germany level-4 CPC technology areas with the highest exponential-moving-average (α=0.1) of yearly filings, among patents granted in the second half of 2019, tie at an EMA of 2.0: A61 MEDICAL OR VETERINARY SCIENCE; HYGIENE best year 2016; H04 ELECTRIC COMMUNICATION TECHNIQUE best year 2015."
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "2",
+    "run": "2",
+    "answer": "The CPC technology areas (level 4) in Germany with the highest exponential moving average (peak EMA = 2.0, α=0.1) of filings per year among patents granted in the second half of 2019 are — A61 MEDICAL OR VETERINARY SCIENCE; HYGIENE best year 2016; H04 ELECTRIC COMMUNICATION TECHNIQUE best year 2015."
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "2",
+    "run": "3",
+    "answer": "Two level-4 CPC technology areas tie for the highest exponential moving average (2.0) of yearly filings among German patents granted in H2 2019 — A61 MEDICAL OR VETERINARY SCIENCE; HYGIENE best year 2016; H04 ELECTRIC COMMUNICATION TECHNIQUE best year 2015"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "2",
+    "run": "4",
+    "answer": "The level-4 CPC technology areas (German patents granted in H2 2019) with the highest exponential moving average of filings/year (α=0.1), both peaking at EMA = 2.0, are: A61 MEDICAL OR VETERINARY SCIENCE; HYGIENE — best year 2016; H04 ELECTRIC COMMUNICATION TECHNIQUE — best year 2015"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "3",
+    "run": "0",
+    "answer": "BLOOM ENERGY CORP — PROCESSES OR MEANS, e.g. BATTERIES, FOR THE DIRECT CONVERSION OF CHEMICAL ENERGY INTO ELECTRICAL ENERGY (CPC subclass H01M); CRYSTAL IS INC — SINGLE-CRYSTAL GROWTH; UNIDIRECTIONAL SOLIDIFICATION OF EUTECTIC MATERIAL OR UNIDIRECTIONAL DEMIXING OF EUTECTOID MATERIAL; REFINING BY ZONE-MELTING OF MATERIAL; PRODUCTION OF A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; SINGLE CRYSTALS OR HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; AFTER-TREATMENT OF SINGLE CRYSTALS OR A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; APPARATUS THEREFOR (CPC subclass C30B); SCHOWALTER LEO J — SEMICONDUCTOR DEVICES NOT COVERED BY CLASS H10 (CPC subclass H01L)"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "3",
+    "run": "1",
+    "answer": "BLOOM ENERGY CORP — PROCESSES OR MEANS, e.g. BATTERIES, FOR THE DIRECT CONVERSION OF CHEMICAL ENERGY INTO ELECTRICAL ENERGY (H01M); CRYSTAL IS INC — SINGLE-CRYSTAL GROWTH; UNIDIRECTIONAL SOLIDIFICATION OF EUTECTIC MATERIAL OR UNIDIRECTIONAL DEMIXING OF EUTECTOID MATERIAL; REFINING BY ZONE-MELTING OF MATERIAL; PRODUCTION OF A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; SINGLE CRYSTALS OR HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; AFTER-TREATMENT OF SINGLE CRYSTALS OR A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; APPARATUS THEREFOR (C30B); SCHOWALTER LEO J — SEMICONDUCTOR DEVICES NOT COVERED BY CLASS H10 (H01L)"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "3",
+    "run": "2",
+    "answer": "BLOOM ENERGY CORP — PROCESSES OR MEANS, e.g. BATTERIES, FOR THE DIRECT CONVERSION OF CHEMICAL ENERGY INTO ELECTRICAL ENERGY (CPC subclass H01M); CRYSTAL IS INC — SINGLE-CRYSTAL GROWTH; UNIDIRECTIONAL SOLIDIFICATION OF EUTECTIC MATERIAL OR UNIDIRECTIONAL DEMIXING OF EUTECTOID MATERIAL; REFINING BY ZONE-MELTING OF MATERIAL; PRODUCTION OF A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; SINGLE CRYSTALS OR HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; AFTER-TREATMENT OF SINGLE CRYSTALS OR A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; APPARATUS THEREFOR (CPC subclass C30B); SCHOWALTER LEO J — SEMICONDUCTOR DEVICES NOT COVERED BY CLASS H10 (CPC subclass H01L)"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "3",
+    "run": "3",
+    "answer": "BLOOM ENERGY CORP — H01M — PROCESSES OR MEANS, e.g. BATTERIES, FOR THE DIRECT CONVERSION OF CHEMICAL ENERGY INTO ELECTRICAL ENERGY; CRYSTAL IS INC — C30B — SINGLE-CRYSTAL GROWTH; UNIDIRECTIONAL SOLIDIFICATION OF EUTECTIC MATERIAL OR UNIDIRECTIONAL DEMIXING OF EUTECTOID MATERIAL; REFINING BY ZONE-MELTING OF MATERIAL; PRODUCTION OF A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; SINGLE CRYSTALS OR HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; AFTER-TREATMENT OF SINGLE CRYSTALS OR A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; APPARATUS THEREFOR; SCHOWALTER LEO J — H01L — SEMICONDUCTOR DEVICES NOT COVERED BY CLASS H10"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "3",
+    "run": "4",
+    "answer": "BLOOM ENERGY CORP — H01M — PROCESSES OR MEANS, e.g. BATTERIES, FOR THE DIRECT CONVERSION OF CHEMICAL ENERGY INTO ELECTRICAL ENERGY; CRYSTAL IS INC — C30B — SINGLE-CRYSTAL GROWTH; UNIDIRECTIONAL SOLIDIFICATION OF EUTECTIC MATERIAL OR UNIDIRECTIONAL DEMIXING OF EUTECTOID MATERIAL; REFINING BY ZONE-MELTING OF MATERIAL; PRODUCTION OF A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; SINGLE CRYSTALS OR HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; AFTER-TREATMENT OF SINGLE CRYSTALS OR A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; APPARATUS THEREFOR; SCHOWALTER LEO J — H01L — SEMICONDUCTOR DEVICES NOT COVERED BY CLASS H10"
+  },
+  {
+    "dataset": "agnews",
+    "query": "1",
+    "run": "0",
+    "answer": "The Rundown"
+  },
+  {
+    "dataset": "agnews",
+    "query": "1",
+    "run": "1",
+    "answer": "The Rundown"
+  },
+  {
+    "dataset": "agnews",
+    "query": "1",
+    "run": "2",
+    "answer": "The Rundown"
+  },
+  {
+    "dataset": "agnews",
+    "query": "1",
+    "run": "3",
+    "answer": "The Rundown"
+  },
+  {
+    "dataset": "agnews",
+    "query": "1",
+    "run": "4",
+    "answer": "The Rundown"
+  },
+  {
+    "dataset": "agnews",
+    "query": "2",
+    "run": "0",
+    "answer": "17/111 ≈ 0.1532 (17 of Amy Jones's 111 articles are Science/Technology)"
+  },
+  {
+    "dataset": "agnews",
+    "query": "2",
+    "run": "1",
+    "answer": "0.1622 (18 of Amy Jones's 111 articles are Science/Technology; 18/111 = 6/37 ≈ 0.162162)"
+  },
+  {
+    "dataset": "agnews",
+    "query": "2",
+    "run": "2",
+    "answer": "16/111 ≈ 0.1441 (16 of Amy Jones's 111 articles are Science/Technology)"
+  },
+  {
+    "dataset": "agnews",
+    "query": "2",
+    "run": "3",
+    "answer": "16/111 ≈ 0.1441 (16 of Amy Jones's 111 articles are Science/Technology)"
+  },
+  {
+    "dataset": "agnews",
+    "query": "2",
+    "run": "4",
+    "answer": "15/111 ≈ 0.1351 (15 of Amy Jones's 111 articles are Science/Technology)"
+  },
+  {
+    "dataset": "agnews",
+    "query": "3",
+    "run": "0",
+    "answer": "≈ 338 business articles per year (about 3,715 over 2010–2020, i.e. 3,715 ÷ 11 = 337.7/yr; direct text classification yields 3,945 → 358.6/yr, which corrects to ≈3,757 → 341.6/yr after removing the classifier's measured +1.25pt business bias)."
+  },
+  {
+    "dataset": "agnews",
+    "query": "3",
+    "run": "1",
+    "answer": "339.27 business articles per year on average in Europe from 2010 to 2020 inclusive (3,732 business articles total over 11 years; by year — 2010:302, 2011:320, 2012:344, 2013:362, 2014:348, 2015:340, 2016:346, 2017:359, 2018:357, 2019:331, 2020:323)."
+  },
+  {
+    "dataset": "agnews",
+    "query": "3",
+    "run": "2",
+    "answer": "approximately 330 business articles per year (330.4 by the refined content classifier; 3,634 business articles over the 11 years 2010–2020 in Europe, ÷ 11)."
+  },
+  {
+    "dataset": "agnews",
+    "query": "3",
+    "run": "3",
+    "answer": "Approximately 338 business articles per year in Europe from 2010–2020 (best estimate; direct keyword classification counts 3,579 business articles over 11 years = 325.4/year, calibrated to AG News's 25% class balance ≈ 3,731/11 ≈ 339/year)."
+  },
+  {
+    "dataset": "agnews",
+    "query": "3",
+    "run": "4",
+    "answer": "≈ 338 business articles per year (≈ 3,715 total over 2010–2020, i.e. 25% of the 14,860 Europe articles ÷ 11 years ≈ 337.7)"
+  },
+  {
+    "dataset": "agnews",
+    "query": "4",
+    "run": "0",
+    "answer": "Europe"
+  },
+  {
+    "dataset": "agnews",
+    "query": "4",
+    "run": "1",
+    "answer": "Africa (the region with the largest number of 2015 articles in the World category — approximately 358 such articles)"
+  },
+  {
+    "dataset": "agnews",
+    "query": "4",
+    "run": "2",
+    "answer": "Africa"
+  },
+  {
+    "dataset": "agnews",
+    "query": "4",
+    "run": "3",
+    "answer": "Africa"
+  },
+  {
+    "dataset": "agnews",
+    "query": "4",
+    "run": "4",
+    "answer": "Africa (322 World-category articles in 2015; a statistical near-tie with South America 321 and North America 319, since region is assigned independently of category)"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "1",
+    "run": "0",
+    "answer": "2020s"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "1",
+    "run": "1",
+    "answer": "2020s"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "1",
+    "run": "2",
+    "answer": "2020s (average rating ≈ 4.6636, from 21 distinct rated books)"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "1",
+    "run": "3",
+    "answer": "2020s (average rating 4.663636, from 110 reviews across 21 distinct rated books published 2020–2023)"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "1",
+    "run": "4",
+    "answer": "2020s (average rating ≈ 4.6636)"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "2",
+    "run": "0",
+    "answer": "Reunion: The Children of Lauderdale Park; The Prophet: With Original 1923 Illustrations by the Author; The Melancholy Strumpet Master; Child Of The King A Journey of Hope Book 1: Earthly Story With A Heavenly Message; Fire Cracker; Local Honey; Hollywood Confessions: Hollywood Headlines Book #3 (Hollywood Headlines Mysteries); Knowing When To Die: Uncollected Stories; Childe Harold of Dysna; Forged in Blood (Freehold); Exits, Desires, & Slow Fires; Kennebago Moments; The Sludge; Liza of Lambeth; Something That Feels Like Truth (Switchgrass Books)"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "2",
+    "run": "1",
+    "answer": "Reunion: The Children of Lauderdale Park; The Prophet: With Original 1923 Illustrations by the Author; The Melancholy Strumpet Master; Child Of The King A Journey of Hope Book 1: Earthly Story With A Heavenly Message; Fire Cracker; Local Honey; Hollywood Confessions: Hollywood Headlines Book #3 (Hollywood Headlines Mysteries); Knowing When To Die: Uncollected Stories; Childe Harold of Dysna; Forged in Blood (Freehold); Exits, Desires, & Slow Fires; Kennebago Moments; The Sludge; Liza of Lambeth; Something That Feels Like Truth (Switchgrass Books)"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "2",
+    "run": "2",
+    "answer": "Reunion: The Children of Lauderdale Park; The Prophet: With Original 1923 Illustrations by the Author; The Melancholy Strumpet Master; Child Of The King A Journey of Hope Book 1: Earthly Story With A Heavenly Message; Fire Cracker; Local Honey; Hollywood Confessions: Hollywood Headlines Book #3 (Hollywood Headlines Mysteries); Knowing When To Die: Uncollected Stories; Childe Harold of Dysna; Forged in Blood (Freehold); Exits, Desires, & Slow Fires; Kennebago Moments; The Sludge; Liza of Lambeth; Something That Feels Like Truth (Switchgrass Books)"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "2",
+    "run": "3",
+    "answer": "Reunion: The Children of Lauderdale Park; The Prophet: With Original 1923 Illustrations by the Author; The Melancholy Strumpet Master; Child Of The King A Journey of Hope Book 1: Earthly Story With A Heavenly Message; Fire Cracker; Local Honey; Hollywood Confessions: Hollywood Headlines Book #3 (Hollywood Headlines Mysteries); Knowing When To Die: Uncollected Stories; Childe Harold of Dysna; Forged in Blood (Freehold); Exits, Desires, & Slow Fires; Kennebago Moments; The Sludge; Liza of Lambeth; Something That Feels Like Truth (Switchgrass Books)"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "2",
+    "run": "4",
+    "answer": "Reunion: The Children of Lauderdale Park; The Prophet: With Original 1923 Illustrations by the Author; The Melancholy Strumpet Master; Child Of The King A Journey of Hope Book 1: Earthly Story With A Heavenly Message; Fire Cracker; Local Honey; Hollywood Confessions: Hollywood Headlines Book #3 (Hollywood Headlines Mysteries); Knowing When To Die: Uncollected Stories; Childe Harold of Dysna; Forged in Blood (Freehold); Exits, Desires, & Slow Fires; Kennebago Moments; The Sludge; Liza of Lambeth; Something That Feels Like Truth (Switchgrass Books)"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "3",
+    "run": "0",
+    "answer": "14 books categorized as \"Children's Books\" have an average rating ≥ 4.5 from reviews dated 2020 onwards: Monstrous Stories #4: The Day the Mice Stood Still (5.0); The Old Man and the Pirate Princess (5.0); Egypt (Enchantment of the World) (5.0); Favorite Thorton W. Burgess Stories: 6 Books (5.0); Behind the Wheel (Choose Your Own Adventure #35)(Paperback/Revised) (5.0); Cheer Up, Ben Franklin! (Young Historians) (5.0); The Library Book (5.0); Benny Goes To The Moon: The great new book from Top Children's entertainer Gerry Ogilvie (1) (5.0); LunaLu the Llamacorn (5.0); Around the World Mazes (5.0); Pokémon: Sun & Moon, Vol. 8 (8) (5.0); Trouble in the CTC!: The Terra Prime Adventures Book 2 (4.9); Clark the Shark: Tooth Trouble, No. 1 (4.75); Cleo Porter and the Body Electric (4.708333333333333)"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "3",
+    "run": "1",
+    "answer": "Monstrous Stories #4: The Day the Mice Stood Still; The Old Man and the Pirate Princess; Egypt (Enchantment of the World); Favorite Thorton W. Burgess Stories: 6 Books; Behind the Wheel (Choose Your Own Adventure #35)(Paperback/Revised); Cheer Up, Ben Franklin! (Young Historians); The Library Book; Benny Goes To The Moon: The great new book from Top Children's entertainer Gerry Ogilvie (1); LunaLu the Llamacorn; Around the World Mazes; Pokémon: Sun & Moon, Vol. 8 (8); Trouble in the CTC!: The Terra Prime Adventures Book 2; Clark the Shark: Tooth Trouble, No. 1; Cleo Porter and the Body Electric"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "3",
+    "run": "2",
+    "answer": "Monstrous Stories #4: The Day the Mice Stood Still (5.0); The Old Man and the Pirate Princess (5.0); Egypt (Enchantment of the World) (5.0); Favorite Thorton W. Burgess Stories: 6 Books (5.0); Behind the Wheel (Choose Your Own Adventure #35)(Paperback/Revised) (5.0); Cheer Up, Ben Franklin! (Young Historians) (5.0); The Library Book (5.0); Benny Goes To The Moon: The great new book from Top Children's entertainer Gerry Ogilvie (1) (5.0); LunaLu the Llamacorn (5.0); Around the World Mazes (5.0); Pokémon: Sun & Moon, Vol. 8 (8) (5.0); Trouble in the CTC!: The Terra Prime Adventures Book 2 (4.9); Clark the Shark: Tooth Trouble, No. 1 (4.75); Cleo Porter and the Body Electric (4.7083)"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "3",
+    "run": "3",
+    "answer": "Monstrous Stories #4: The Day the Mice Stood Still (5.0); The Old Man and the Pirate Princess (5.0); Egypt (Enchantment of the World) (5.0); Favorite Thorton W. Burgess Stories: 6 Books (5.0); Behind the Wheel (Choose Your Own Adventure #35)(Paperback/Revised) (5.0); Cheer Up, Ben Franklin! (Young Historians) (5.0); The Library Book (5.0); Benny Goes To The Moon: The great new book from Top Children's entertainer Gerry Ogilvie (1) (5.0); LunaLu the Llamacorn (5.0); Around the World Mazes (5.0); Pokémon: Sun & Moon, Vol. 8 (8) (5.0); Trouble in the CTC!: The Terra Prime Adventures Book 2 (4.9); Clark the Shark: Tooth Trouble, No. 1 (4.75); Cleo Porter and the Body Electric (4.708333333333333)"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "3",
+    "run": "4",
+    "answer": "Monstrous Stories #4: The Day the Mice Stood Still 5.0; The Old Man and the Pirate Princess 5.0; Egypt (Enchantment of the World) 5.0; Favorite Thorton W. Burgess Stories: 6 Books 5.0; Behind the Wheel (Choose Your Own Adventure #35)(Paperback/Revised) 5.0; Cheer Up, Ben Franklin! (Young Historians) 5.0; The Library Book 5.0; Benny Goes To The Moon: The great new book from Top Children's entertainer Gerry Ogilvie (1) 5.0; LunaLu the Llamacorn 5.0; Around the World Mazes 5.0; Pokémon: Sun & Moon, Vol. 8 (8) 5.0; Trouble in the CTC!: The Terra Prime Adventures Book 2 4.9; Clark the Shark: Tooth Trouble, No. 1 4.75; Cleo Porter and the Body Electric 4.708333333333333"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "1",
+    "run": "0",
+    "answer": "Budget; Authority; Timeline"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "1",
+    "run": "1",
+    "answer": "Authority; Timeline"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "1",
+    "run": "2",
+    "answer": "No — the lead cannot be qualified. Failing BANT factors: Authority, Timeline"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "1",
+    "run": "3",
+    "answer": "Authority; Timeline"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "1",
+    "run": "4",
+    "answer": "Authority; Timeline"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "2",
+    "run": "0",
+    "answer": "ka0Wt000000Ens5IAC"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "2",
+    "run": "1",
+    "answer": "ka0Wt000000Ens5IAC"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "2",
+    "run": "2",
+    "answer": "ka0Wt000000Ens5IAC"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "2",
+    "run": "3",
+    "answer": "ka0Wt000000Ens5IAC"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "2",
+    "run": "4",
+    "answer": "ka0Wt000000Eq0MIAS"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "3",
+    "run": "0",
+    "answer": "Negotiation"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "3",
+    "run": "1",
+    "answer": "Negotiation"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "3",
+    "run": "2",
+    "answer": "Negotiation"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "3",
+    "run": "3",
+    "answer": "Negotiation"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "3",
+    "run": "4",
+    "answer": "Quote"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "4",
+    "run": "0",
+    "answer": "November"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "4",
+    "run": "1",
+    "answer": "November"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "4",
+    "run": "2",
+    "answer": "November"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "4",
+    "run": "3",
+    "answer": "November"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "4",
+    "run": "4",
+    "answer": "November"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "5",
+    "run": "0",
+    "answer": "a03Wt00000JqnHwIAJ"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "5",
+    "run": "1",
+    "answer": "a03Wt00000JqnHwIAJ"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "5",
+    "run": "2",
+    "answer": "a03Wt00000JqnHwIAJ"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "5",
+    "run": "3",
+    "answer": "a03Wt00000JqnHwIAJ"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "5",
+    "run": "4",
+    "answer": "a03Wt00000JqnHwIAJ"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "6",
+    "run": "0",
+    "answer": "ka0Wt000000EnwvIAC"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "6",
+    "run": "1",
+    "answer": "ka0Wt000000EnwvIAC"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "6",
+    "run": "2",
+    "answer": "ka0Wt000000EnwvIAC"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "6",
+    "run": "3",
+    "answer": "ka0Wt000000EnwvIAC"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "6",
+    "run": "4",
+    "answer": "ka0Wt000000EnwvIAC"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "7",
+    "run": "0",
+    "answer": "ka0Wt000000EpSUIA0"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "7",
+    "run": "1",
+    "answer": "ka0Wt000000EpSUIA0"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "7",
+    "run": "2",
+    "answer": "ka0Wt000000EoD3IAK"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "7",
+    "run": "3",
+    "answer": "ka0Wt000000EoD3IAK"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "7",
+    "run": "4",
+    "answer": "ka0Wt000000EoD3IAK"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "8",
+    "run": "0",
+    "answer": "005Wt000003NIliIAG"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "8",
+    "run": "1",
+    "answer": "005Wt000003NIliIAG"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "8",
+    "run": "2",
+    "answer": "005Wt000003NIliIAG"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "8",
+    "run": "3",
+    "answer": "005Wt000003NIliIAG"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "8",
+    "run": "4",
+    "answer": "005Wt000003NIliIAG"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "9",
+    "run": "0",
+    "answer": "MI"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "9",
+    "run": "1",
+    "answer": "MI"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "9",
+    "run": "2",
+    "answer": "MI"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "9",
+    "run": "3",
+    "answer": "MI"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "9",
+    "run": "4",
+    "answer": "MI"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "10",
+    "run": "0",
+    "answer": "005Wt000003NDqDIAW"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "10",
+    "run": "1",
+    "answer": "005Wt000003NDqDIAW"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "10",
+    "run": "2",
+    "answer": "005Wt000003NDqDIAW"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "10",
+    "run": "3",
+    "answer": "005Wt000003NDqDIAW"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "10",
+    "run": "4",
+    "answer": "005Wt000003NDqDIAW"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "11",
+    "run": "0",
+    "answer": "01tWt000006hV8LIAU"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "11",
+    "run": "1",
+    "answer": "01tWt000006hV8LIAU"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "11",
+    "run": "2",
+    "answer": "01tWt000006hV8LIAU"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "11",
+    "run": "3",
+    "answer": "01tWt000006hV8LIAU"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "11",
+    "run": "4",
+    "answer": "01tWt000006hV8LIAU"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "12",
+    "run": "0",
+    "answer": "005Wt000003NJgAIAW"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "12",
+    "run": "1",
+    "answer": "005Wt000003NJjNIAW"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "12",
+    "run": "2",
+    "answer": "005Wt000003NDEBIA4"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "12",
+    "run": "3",
+    "answer": "005Wt000003NJjNIAW"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "12",
+    "run": "4",
+    "answer": "005Wt000003NJjNIAW"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "13",
+    "run": "0",
+    "answer": "005Wt000003NBp4IAG"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "13",
+    "run": "1",
+    "answer": "005Wt000003NIXCIA4"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "13",
+    "run": "2",
+    "answer": "005Wt000003NIXCIA4"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "13",
+    "run": "3",
+    "answer": "005Wt000003NEa3IAG"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "13",
+    "run": "4",
+    "answer": "005Wt000003NIXCIA4"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "1",
+    "run": "0",
+    "answer": "Widows Peak Salon 4.857142857142857; City Textile 4.5; Nobel Textile Co 4.285714285714286; San Soo Dang 4.277777777777778; Nova Fabrics 3.3333333333333335"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "1",
+    "run": "1",
+    "answer": "Widows Peak Salon 4.857142857142857; City Textile 4.5; Nobel Textile Co 4.285714285714286; San Soo Dang 4.277777777777778; Nova Fabrics 3.3333333333333335"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "1",
+    "run": "2",
+    "answer": "Widows Peak Salon 4.857142857142857; City Textile 4.5; Nobel Textile Co 4.285714285714286; San Soo Dang 4.277777777777778; Nova Fabrics 3.3333333333333335"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "1",
+    "run": "3",
+    "answer": "1. Widows Peak Salon 4.857142857142857; 2. City Textile 4.5; 3. Nobel Textile Co 4.285714285714286; 4. San Soo Dang 4.277777777777778; 5. Nova Fabrics 3.3333333333333335"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "1",
+    "run": "4",
+    "answer": "Widows Peak Salon 4.857142857142857; City Textile 4.5; Nobel Textile Co 4.285714285714286; San Soo Dang 4.277777777777778; Nova Fabrics 3.3333333333333335"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "2",
+    "run": "0",
+    "answer": "Elite Massage 5.0; Angel-A Massage 4.333333333333333; Aurora Massage 4.178571428571429; J B Oriental Inc 4.166666666666667"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "2",
+    "run": "1",
+    "answer": "Elite Massage 5.0; Angel-A Massage 4.333333333333333; Aurora Massage 4.178571428571429; J B Oriental Inc 4.166666666666667"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "2",
+    "run": "2",
+    "answer": "Elite Massage 5.0; Angel-A Massage 4.333333333333333; Aurora Massage 4.178571428571429; J B Oriental Inc 4.166666666666667"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "2",
+    "run": "3",
+    "answer": "Elite Massage 5.0; Angel-A Massage 4.333333333333333; Aurora Massage 4.178571428571429; J B Oriental Inc 4.166666666666667"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "2",
+    "run": "4",
+    "answer": "Elite Massage 5.0; Angel-A Massage 4.333333333333333; Aurora Massage 4.178571428571429; J B Oriental Inc 4.166666666666667"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "3",
+    "run": "0",
+    "answer": "The top 5 businesses open after 6:00 PM on at least one weekday, ranked by highest average rating (all tied at 5.0): Beauty Divine Artistry — avg rating 5.0 — Mon–Fri 9AM–8PM, Sat 10AM–7PM, Sun 11AM–6PM; Mariscos el poblano — avg rating 5.0 — Mon 9AM–3:30AM, Tue 8AM–3:30PM, Wed 8AM–3:30PM, Thu Open 24 hours, Fri 8AM–3:30PM, Sat 8AM–3:30PM, Sun 8AM–3:30PM; TACOS LA CABANA — avg rating 5.0 — Mon 5–11PM, Tue Closed, Wed Closed, Thu Closed, Fri 5–11PM, Sat 5–11PM, Sun 5–11PM; Taba Rug Gallery — avg rating 5.0 — Mon–Sat 10AM–7PM, Sun 11AM–6PM; White Barn Candle Co — avg rating 5.0 — Mon–Sat 10AM–9PM, Sun 11AM–7PM."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "3",
+    "run": "1",
+    "answer": "The top 5 businesses (all tied at average rating 5.0) that stay open after 6:00 PM on at least one weekday are: Taba Rug Gallery (Mon–Sat 10AM–7PM, Sun 11AM–6PM) 5.0; Beauty Divine Artistry (Mon–Fri 9AM–8PM, Sat 10AM–7PM, Sun 11AM–6PM) 5.0; White Barn Candle Co (Mon–Sat 10AM–9PM, Sun 11AM–7PM) 5.0; Mariscos el poblano (Mon 9AM–3:30AM, Tue/Wed/Fri/Sat/Sun 8AM–3:30PM, Thu Open 24 hours) 5.0; TACOS LA CABANA (Mon/Fri/Sat/Sun 5–11PM, Tue/Wed/Thu Closed) 5.0."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "3",
+    "run": "2",
+    "answer": "Taba Rug Gallery — avg rating 5.0 — hours: Thu 10AM–7PM, Fri 10AM–7PM, Sat 10AM–7PM, Sun 11AM–6PM, Mon 10AM–7PM, Tue 10AM–7PM, Wed 10AM–7PM; Beauty Divine Artistry — avg rating 5.0 — hours: Thu 9AM–8PM, Fri 9AM–8PM, Sat 10AM–7PM, Sun 11AM–6PM, Mon 9AM–8PM, Tue 9AM–8PM, Wed 9AM–8PM; Mariscos el poblano — avg rating 5.0 — hours: Thu Open 24 hours, Fri 8AM–3:30PM, Sat 8AM–3:30PM, Sun 8AM–3:30PM, Mon 9AM–3:30AM, Tue 8AM–3:30PM, Wed 8AM–3:30PM; White Barn Candle Co — avg rating 5.0 — hours: Thu 10AM–9PM, Fri 10AM–9PM, Sat 10AM–9PM, Sun 11AM–7PM, Mon 10AM–9PM, Tue 10AM–9PM, Wed 10AM–9PM; TACOS LA CABANA — avg rating 5.0 — hours: Thu Closed, Fri 5–11PM, Sat 5–11PM, Sun 5–11PM, Mon 5–11PM, Tue Closed, Wed Closed"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "3",
+    "run": "3",
+    "answer": "Taba Rug Gallery 5.0 (Mon–Sat 10AM–7PM, Sun 11AM–6PM); Beauty Divine Artistry 5.0 (Mon–Fri 9AM–8PM, Sat 10AM–7PM, Sun 11AM–6PM); Mariscos el poblano 5.0 (Mon 9AM–3:30AM, Tue 8AM–3:30PM, Wed 8AM–3:30PM, Thu Open 24 hours, Fri 8AM–3:30PM, Sat 8AM–3:30PM, Sun 8AM–3:30PM); White Barn Candle Co 5.0 (Mon–Sat 10AM–9PM, Sun 11AM–7PM); TACOS LA CABANA 5.0 (Mon 5–11PM, Tue Closed, Wed Closed, Thu Closed, Fri 5–11PM, Sat 5–11PM, Sun 5–11PM). All five have an average rating of 5.0."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "3",
+    "run": "4",
+    "answer": "The top 5 (all tied at average rating 5.0) are — Beauty Divine Artistry, 5.0, Mon–Fri 9AM–8PM, Sat 10AM–7PM, Sun 11AM–6PM; Mariscos el poblano, 5.0, Mon 9AM–3:30AM, Tue 8AM–3:30PM, Wed 8AM–3:30PM, Thu Open 24 hours, Fri 8AM–3:30PM, Sat 8AM–3:30PM, Sun 8AM–3:30PM; TACOS LA CABANA, 5.0, Mon 5–11PM, Tue Closed, Wed Closed, Thu Closed, Fri 5–11PM, Sat 5–11PM, Sun 5–11PM; Taba Rug Gallery, 5.0, Mon–Sat 10AM–7PM, Sun 11AM–6PM; White Barn Candle Co, 5.0, Mon–Sat 10AM–9PM, Sun 11AM–7PM."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "4",
+    "run": "0",
+    "answer": "Encino Dermatology & Laser: Alex Khadavi MD 19; The Boochyard @ Local Roots 17; Aurora Massage 14"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "4",
+    "run": "1",
+    "answer": "Encino Dermatology & Laser: Alex Khadavi MD 19; The Boochyard @ Local Roots 17; Aurora Massage 14"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "4",
+    "run": "2",
+    "answer": "Encino Dermatology & Laser: Alex Khadavi MD 19; The Boochyard @ Local Roots 17; Aurora Massage 14"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "4",
+    "run": "3",
+    "answer": "Encino Dermatology & Laser: Alex Khadavi MD 19; The Boochyard @ Local Roots 17; Aurora Massage 14"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "4",
+    "run": "4",
+    "answer": "Encino Dermatology & Laser: Alex Khadavi MD 19; The Boochyard @ Local Roots 17; Aurora Massage 14"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "1",
+    "run": "0",
+    "answer": "1059.46"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "1",
+    "run": "1",
+    "answer": "1059.46 USD"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "1",
+    "run": "2",
+    "answer": "1059.46"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "1",
+    "run": "3",
+    "answer": "1059.46"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "1",
+    "run": "4",
+    "answer": "1059.46"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "2",
+    "run": "0",
+    "answer": "Amazon Music (1108.99 USD)"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "2",
+    "run": "1",
+    "answer": "Amazon Music (1108.99 USD)"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "2",
+    "run": "2",
+    "answer": "Amazon Music (1108.99 USD)"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "2",
+    "run": "3",
+    "answer": "Amazon Music (1108.99 USD)"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "2",
+    "run": "4",
+    "answer": "Amazon Music, with 1108.99 USD in total revenue."
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "3",
+    "run": "0",
+    "answer": "Zo gaat het leven aan je voor — by Syb van der Ploeg — 9013.69 USD (total revenue across all stores and countries, summed over its 5 duplicate track_ids: 3024, 3435, 12620, 12854, 13225)."
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "3",
+    "run": "1",
+    "answer": "Zo gaat het leven aan je voor — Syb van der Ploeg — 9013.69"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "3",
+    "run": "2",
+    "answer": "Zo gaat het leven aan je voor — by Syb van der Ploeg — with total revenue 9013.69 USD"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "3",
+    "run": "3",
+    "answer": "\"Zo gaat het leven aan je voor\" by Syb van der Ploeg, with total revenue 9013.69 USD (aggregated across its 5 duplicate track_ids: 3024, 13225, 12620, 12854, 3435)."
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "3",
+    "run": "4",
+    "answer": "Zo gaat het leven aan je voor — Syb van der Ploeg (total revenue 9013.69 USD, resolved from track_ids 12620, 3435, 3024, 13225, 12854)"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "1",
+    "run": "0",
+    "answer": "399001.SZ (Shenzhen Stock Exchange — SZSE Component Index), with the highest average intraday volatility in Asia since 2020 of 0.01834068808057066"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "1",
+    "run": "1",
+    "answer": "399001.SZ (Shenzhen Stock Exchange, SZSE Component Index) — highest average intraday volatility in the Asia region since 2020, at 0.01834068808057066"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "1",
+    "run": "2",
+    "answer": "399001.SZ (Shenzhen Component Index, Shenzhen Stock Exchange) — the highest average intraday volatility among Asia-region indices since 2020, at 0.01834068808057066 (avg of (High-Low)/Open over 342 trading days ≥ 2020-01-01)."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "1",
+    "run": "3",
+    "answer": "399001.SZ (Shenzhen Component Index — Shenzhen Stock Exchange), with an average intraday volatility since 2020 of 0.01834068808057066"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "1",
+    "run": "4",
+    "answer": "399001.SZ (Shenzhen Component Index — Shenzhen Stock Exchange, China), with the highest average intraday volatility in Asia since 2020 at 0.01834068808057066 (≈0.0183)."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "2",
+    "run": "0",
+    "answer": "IXIC (NASDAQ Composite) — 131 up days vs 120 down days in 2018. It is the only North American index with more up days than down days (NYA had 125 up / 126 down; GSPTSE had 115 up / 135 down)."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "2",
+    "run": "1",
+    "answer": "IXIC (NASDAQ Composite) — 131 up days vs 120 down days in 2018. It is the only North American index with more up days than down days (NYA: 125 up/126 down; GSPTSE: 115 up/135 down did not qualify)."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "2",
+    "run": "2",
+    "answer": "IXIC (NASDAQ Composite) — 131 up days vs 120 down days in 2018. It is the only North American index with more up days than down days."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "2",
+    "run": "3",
+    "answer": "IXIC (NASDAQ Composite) — 131 up days vs 120 down days in 2018. (The other two North American indices did not qualify: NYA 125 up / 126 down, GSPTSE 115 up / 135 down.)"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "2",
+    "run": "4",
+    "answer": "IXIC (NASDAQ Composite, NASDAQ) — 131 up days vs 120 down days in 2018. It is the only North American index with more up days than down days (NYA: 125 up / 126 down, and GSPTSE: 115 up / 135 down both had more down days)."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "3",
+    "run": "0",
+    "answer": "IXIC (NASDAQ Composite) — United States, overall return 3.8238; GDAXI (DAX) — Germany, 1.3493; NSEI (NIFTY 50) — India, 1.3487; 399001.SZ (Shenzhen Component) — China, 1.3404; TWII (Taiwan Weighted) — Taiwan, 1.2965."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "3",
+    "run": "1",
+    "answer": "The 5 indices with the highest overall returns from regular monthly (dollar-cost-averaged) investing since 2000, using common-currency (USD) prices, are: IXIC (NASDAQ Composite) — United States, overall return 3.8238; GDAXI (DAX) — Germany, 1.3493; NSEI (Nifty 50) — India, 1.3487; 399001.SZ (Shenzhen Component Index) — China, 1.3404; TWII (TAIEX) — Taiwan, 1.2965."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "3",
+    "run": "2",
+    "answer": "The 5 indices with the highest overall DCA returns from monthly investing since 2000 are — 1) IXIC (NASDAQ Composite), United States, overall return ≈ 3.8238; 2) GDAXI (DAX, Frankfurt), Germany, ≈ 1.3493; 3) NSEI (Nifty 50, National Stock Exchange of India), India, ≈ 1.3487; 4) 399001.SZ (Shenzhen Stock Exchange Component), China, ≈ 1.3404; 5) TWII (TAIEX, Taiwan Stock Exchange), Taiwan, ≈ 1.2965. Countries: United States, Germany, India, China, Taiwan."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "3",
+    "run": "3",
+    "answer": "The 5 indices with the highest overall returns from regular monthly (dollar-cost-averaged) investing since 2000 are: IXIC (NASDAQ Composite) — United States — 3.827; NSEI (Nifty 50) — India — 1.358; 399001.SZ (Shenzhen Component) — China — 1.347; GDAXI (DAX) — Germany — 1.347; TWII (TAIEX) — Taiwan — 1.298."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "3",
+    "run": "4",
+    "answer": "The 5 indices with the highest overall returns from monthly investing since 2000 are: IXIC (NASDAQ Composite) United States 3.823826; GDAXI (DAX) Germany 1.349285; NSEI (Nifty 50) India 1.348656; 399001.SZ (Shenzhen Component) China 1.340419; TWII (TAIEX) Taiwan 1.296452."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "1",
+    "run": "0",
+    "answer": "18.440000534057617 (the maximum adjusted closing price for The RealReal, Inc. [symbol REAL] in 2020, occurring on 2020-01-03)"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "1",
+    "run": "1",
+    "answer": "18.44 (adjusted closing price for The RealReal, Inc., ticker REAL, on 2020-01-03; full query precision 18.440000534057617)"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "1",
+    "run": "2",
+    "answer": "18.440000534057617"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "1",
+    "run": "3",
+    "answer": "18.440000534057617"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "1",
+    "run": "4",
+    "answer": "18.440000534057617"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "2",
+    "run": "0",
+    "answer": "31 ETFs listed on NYSE Arca reached an adjusted closing price above $200 at some point in 2015: UVXY 81500.0; GUSH 78699.21875; COM 40487.9921875; RTL 13306.7646484375; JDST 12988.4140625; HYUP 4329.7529296875; SOXS 3886.618896484375; VPC 2250.13916015625; DUST 1923.278564453125; LBJ 998.109130859375; PTIN 843.5269775390625; GFIN 686.75927734375; ERX 645.1613159179688; LABD 624.0791625976562; VIXY 491.0; BZQ 462.7842102050781; JNUG 451.0675659179688; SDOW 415.17431640625; BOIL 382.2000122070313; YANG 347.3471374511719; EDZ 302.0125427246094; FAZ 288.5361328125; XES 278.5540466308594; TZA 272.6275939941406; SSG 263.8677673339844; MDY 263.76544189453125; TECS 253.3043975830078; LABU 230.2828063964844; XOP 208.7365264892578; FXP 206.0038299560547; JPN 201.5238494873047. Total number of such ETFs: 31."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "2",
+    "run": "1",
+    "answer": "31 ETFs. BOIL; BZQ; COM; DUST; EDZ; ERX; FAZ; FXP; GFIN; GUSH; HYUP; JDST; JNUG; JPN; LABD; LABU; LBJ; MDY; PTIN; RTL; SDOW; SOXS; SSG; TECS; TZA; UVXY; VIXY; VPC; XES; XOP; YANG"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "2",
+    "run": "2",
+    "answer": "31 NYSE Arca ETFs reached an adjusted closing price above $200 during 2015: BOIL; BZQ; COM; DUST; EDZ; ERX; FAZ; FXP; GFIN; GUSH; HYUP; JDST; JNUG; JPN; LABD; LABU; LBJ; MDY; PTIN; RTL; SDOW; SOXS; SSG; TECS; TZA; UVXY; VIXY; VPC; XES; XOP; YANG. Total = 31."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "2",
+    "run": "3",
+    "answer": "31 NYSE Arca ETFs reached an adjusted closing price above $200 during 2015: BOIL; BZQ; COM; DUST; EDZ; ERX; FAZ; FXP; GFIN; GUSH; HYUP; JDST; JNUG; JPN; LABD; LABU; LBJ; MDY; PTIN; RTL; SDOW; SOXS; SSG; TECS; TZA; UVXY; VIXY; VPC; XES; XOP; YANG"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "2",
+    "run": "4",
+    "answer": "31 ETFs. BOIL; BZQ; COM; DUST; EDZ; ERX; FAZ; FXP; GFIN; GUSH; HYUP; JDST; JNUG; JPN; LABD; LABU; LBJ; MDY; PTIN; RTL; SDOW; SOXS; SSG; TECS; TZA; UVXY; VIXY; VPC; XES; XOP; YANG"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "3",
+    "run": "0",
+    "answer": "Apex Global Brands Inc. 23781.422924901184; BIO-key International, Inc. 10988.142292490118; CBAK Energy Technology, Inc. 86223.32015810277; China Ceramics Co., Ltd. 4366.798418972332; Correvio Pharma Corp. 145247.8260869565; CounterPath Corporation 375.49407114624506; DASAN Zhone Solutions, Inc. 15578.656126482214; Frontier Communications Corporation 254397.62845849802; Future FinTech Group Inc. 9.845238095238095; Ideanomics, Inc. 10.276679841897232; Ocean Power Technologies, Inc. 254.1501976284585; Pacific Ethanol, Inc. 10706.719367588932; Sunesis Pharmaceuticals, Inc. 781.8181818181819; Synthesis Energy Systems, Inc. 2390.513833992095; Sypris Solutions, Inc. 36836.36363636364"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "3",
+    "run": "1",
+    "answer": "Frontier Communications Corporation 254397.62845849802; Correvio Pharma Corp. 145247.8260869565; CBAK Energy Technology, Inc. 86223.32015810277; Sypris Solutions, Inc. 36836.36363636364; Apex Global Brands Inc. 23781.422924901184; DASAN Zhone Solutions, Inc. 15578.656126482214; BIO-key International, Inc. 10988.142292490118; Pacific Ethanol, Inc. 10706.719367588932; China Ceramics Co., Ltd. 4366.798418972332; Synthesis Energy Systems, Inc. 2390.513833992095; Sunesis Pharmaceuticals, Inc. 781.8181818181819; CounterPath Corporation 375.49407114624506; Ocean Power Technologies, Inc. 254.1501976284585; Ideanomics, Inc. 10.276679841897232; Future FinTech Group Inc. 9.845238095238095"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "3",
+    "run": "2",
+    "answer": "Frontier Communications Corporation 254397.62845849802; Correvio Pharma Corp. 145247.8260869565; CBAK Energy Technology, Inc. 86223.32015810277; Sypris Solutions, Inc. 36836.36363636364; Apex Global Brands Inc. 23781.422924901184; DASAN Zhone Solutions, Inc. 15578.656126482214; BIO-key International, Inc. 10988.142292490118; Pacific Ethanol, Inc. 10706.719367588932; China Ceramics Co., Ltd. 4366.798418972332; Synthesis Energy Systems, Inc. 2390.513833992095; Sunesis Pharmaceuticals, Inc. 781.8181818181819; CounterPath Corporation 375.49407114624506; Ocean Power Technologies, Inc. 254.1501976284585; Ideanomics, Inc. 10.276679841897232; Future FinTech Group Inc. 9.845238095238095"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "3",
+    "run": "3",
+    "answer": "Apex Global Brands Inc. 23781.422924901184; BIO-key International, Inc. 10988.142292490118; CBAK Energy Technology, Inc. 86223.32015810277; China Ceramics Co., Ltd. 4366.798418972332; Correvio Pharma Corp. 145247.8260869565; CounterPath Corporation 375.49407114624506; DASAN Zhone Solutions, Inc. 15578.656126482214; Frontier Communications Corporation 254397.62845849802; Future FinTech Group Inc. 9.845238095238095; Ideanomics, Inc. 10.276679841897232; Ocean Power Technologies, Inc. 254.1501976284585; Pacific Ethanol, Inc. 10706.719367588932; Sunesis Pharmaceuticals, Inc. 781.8181818181819; Synthesis Energy Systems, Inc. 2390.513833992095; Sypris Solutions, Inc. 36836.36363636364"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "3",
+    "run": "4",
+    "answer": "Apex Global Brands Inc. 23781.422924901184; BIO-key International, Inc. 10988.142292490118; CBAK Energy Technology, Inc. 86223.32015810277; China Ceramics Co., Ltd. 4366.798418972332; Correvio Pharma Corp. 145247.8260869565; CounterPath Corporation 375.49407114624506; DASAN Zhone Solutions, Inc. 15578.656126482214; Future FinTech Group Inc. 9.845238095238095; Frontier Communications Corporation 254397.62845849802; Ideanomics, Inc. 10.276679841897232; Ocean Power Technologies, Inc. 254.1501976284585; Pacific Ethanol, Inc. 10706.719367588932; Synthesis Energy Systems, Inc. 2390.513833992095; Sunesis Pharmaceuticals, Inc. 781.8181818181819; Sypris Solutions, Inc. 36836.36363636364"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "4",
+    "run": "0",
+    "answer": "MFA Financial, Inc.; Argo Group International Holdings, Ltd.; HDFC Bank Limited; Albany International Corporation; DTE Energy Company"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "4",
+    "run": "1",
+    "answer": "MFA Financial, Inc.; Argo Group International Holdings, Ltd.; HDFC Bank Limited; Albany International Corporation; DTE Energy Company"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "4",
+    "run": "2",
+    "answer": "MFA Financial, Inc.; Argo Group International Holdings, Ltd.; HDFC Bank Limited; Albany International Corporation; DTE Energy Company"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "4",
+    "run": "3",
+    "answer": "MFA Financial, Inc.; Argo Group International Holdings, Ltd.; HDFC Bank Limited; Albany International Corporation; DTE Energy Company"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "4",
+    "run": "4",
+    "answer": "HDFC Bank Limited; Albany International Corporation; Getty Realty Corporation; Mettler-Toledo International, Inc.; Pfizer, Inc."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "5",
+    "run": "0",
+    "answer": "Synthesis Energy Systems, Inc.; TD Holdings, Inc.; TMSR Holding Company Limited; Verb Technology Company, Inc.; Sunesis Pharmaceuticals, Inc."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "5",
+    "run": "1",
+    "answer": "Synthesis Energy Systems, Inc. (SES) 51; TD Holdings, Inc. (GLG) 42; TMSR Holding Company Limited (TMSR) 40; Verb Technology Company, Inc. (VERB) 38; Sunesis Pharmaceuticals, Inc. (SNSS) 32"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "5",
+    "run": "2",
+    "answer": "Synthesis Energy Systems, Inc.; TD Holdings, Inc.; TMSR Holding Company Limited; Verb Technology Company, Inc.; Sunesis Pharmaceuticals, Inc."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "5",
+    "run": "3",
+    "answer": "Synthesis Energy Systems, Inc.; TD Holdings, Inc.; TMSR Holding Company Limited; Verb Technology Company, Inc.; Sunesis Pharmaceuticals, Inc."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "5",
+    "run": "4",
+    "answer": "Synthesis Energy Systems, Inc.; TD Holdings, Inc.; TMSR Holding Company Limited; Verb Technology Company, Inc.; Sunesis Pharmaceuticals, Inc."
+  },
+  {
+    "dataset": "yelp",
+    "query": "1",
+    "run": "0",
+    "answer": "3.4974932249322492 (the average of the 8 Indianapolis, IN businesses' individual average ratings; if instead weighted by number of reviews, the pooled average across all 117 reviews is 3.547008547008547)"
+  },
+  {
+    "dataset": "yelp",
+    "query": "1",
+    "run": "1",
+    "answer": "3.4974932249322497 (average of the 8 Indianapolis, IN businesses' individual average ratings; equivalently 3.547008547008547 if all 117 reviews are pooled equally)"
+  },
+  {
+    "dataset": "yelp",
+    "query": "1",
+    "run": "2",
+    "answer": "3.4974932249322497"
+  },
+  {
+    "dataset": "yelp",
+    "query": "1",
+    "run": "3",
+    "answer": "3.4974932249322492 (the average of the 8 Indianapolis, Indiana businesses' individual ratings, each business's rating being the mean of its reviews' `rating`). If instead all 117 reviews are pooled with equal weight, the average is 3.547008547008547."
+  },
+  {
+    "dataset": "yelp",
+    "query": "1",
+    "run": "4",
+    "answer": "3.4974932249322492 (the average of the 8 Indianapolis, IN businesses' ratings, each business rated by the mean of its reviews' rating)"
+  },
+  {
+    "dataset": "yelp",
+    "query": "2",
+    "run": "0",
+    "answer": "Pennsylvania (PA) — 662 reviews (the most of any U.S. state); average rating of PA businesses = 3.699395770392749 (mean over all reviews; 3.6480058240814475 if averaging per-business ratings)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "2",
+    "run": "1",
+    "answer": "Pennsylvania (PA), with 662 reviews — the highest of any U.S. state; the average rating of businesses in PA is 3.6994 (3.699395770392749, the mean of all 662 review ratings)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "2",
+    "run": "2",
+    "answer": "Pennsylvania (PA), with 662 reviews — the highest of any U.S. state — and an average business rating of 3.6994 (3.699395770392749)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "2",
+    "run": "3",
+    "answer": "PA (Pennsylvania) — highest number of reviews at 662; average rating of businesses in that state = 3.699395770392749 (≈ 3.70)"
+  },
+  {
+    "dataset": "yelp",
+    "query": "2",
+    "run": "4",
+    "answer": "Pennsylvania (PA) — 662 reviews, average rating 3.699395770392749"
+  },
+  {
+    "dataset": "yelp",
+    "query": "3",
+    "run": "0",
+    "answer": "35"
+  },
+  {
+    "dataset": "yelp",
+    "query": "3",
+    "run": "1",
+    "answer": "35"
+  },
+  {
+    "dataset": "yelp",
+    "query": "3",
+    "run": "2",
+    "answer": "35"
+  },
+  {
+    "dataset": "yelp",
+    "query": "3",
+    "run": "3",
+    "answer": "35"
+  },
+  {
+    "dataset": "yelp",
+    "query": "3",
+    "run": "4",
+    "answer": "35"
+  },
+  {
+    "dataset": "yelp",
+    "query": "4",
+    "run": "0",
+    "answer": "Restaurants — 27 businesses accept credit cards; average rating = 3.6337 (3.633676092544987)"
+  },
+  {
+    "dataset": "yelp",
+    "query": "4",
+    "run": "1",
+    "answer": "Restaurants 3.633676092544987 (category \"Restaurants\" has the most credit-card-accepting businesses — 27 — and its average rating is 3.6337, the mean of 778 review ratings; equivalently ~3.63)"
+  },
+  {
+    "dataset": "yelp",
+    "query": "4",
+    "run": "2",
+    "answer": "Restaurants — 27 credit-card-accepting businesses (the most of any category), average rating 3.6337 (mean of all 778 review ratings for those businesses; 3.4342 if averaging per-business ratings)"
+  },
+  {
+    "dataset": "yelp",
+    "query": "4",
+    "run": "3",
+    "answer": "Restaurants — 27 credit-card-accepting businesses, average rating 3.6337 (mean of review ratings across those businesses; ≈3.63)"
+  },
+  {
+    "dataset": "yelp",
+    "query": "4",
+    "run": "4",
+    "answer": "Restaurants — 27 credit-card-accepting businesses, average rating 3.6337 (≈3.63)"
+  },
+  {
+    "dataset": "yelp",
+    "query": "5",
+    "run": "0",
+    "answer": "Pennsylvania (PA), with 8 WiFi-offering businesses; the average rating for those businesses is 3.48 (3.4839857651245554, pooled over their 281 reviews)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "5",
+    "run": "1",
+    "answer": "Pennsylvania (PA) — 8 WiFi-offering businesses, with an average rating of 3.4839857651245554 (≈3.48) across their reviews."
+  },
+  {
+    "dataset": "yelp",
+    "query": "5",
+    "run": "2",
+    "answer": "Pennsylvania (PA), with 8 WiFi-offering businesses and an average rating of 3.4839857651245554"
+  },
+  {
+    "dataset": "yelp",
+    "query": "5",
+    "run": "3",
+    "answer": "Pennsylvania (PA) — 8 businesses offer WiFi, with an average rating of 3.4839857651245554 (average of all 281 reviews; equivalently 3.5826549750334915 if averaging the 8 businesses' individual average ratings)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "5",
+    "run": "4",
+    "answer": "Pennsylvania (PA) — 8 businesses offer WiFi, the most of any U.S. state; their average rating is 3.4839857651245554 (pooled over all 281 reviews; equivalently 3.5826549750334915 if averaging each business's own mean rating)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "6",
+    "run": "0",
+    "answer": "Coffee House Too Cafe (businessid_9) — highest average rating of 4.375 (over 16 reviews) between Jan 1 and Jun 30, 2016. Categories: Restaurants, Breakfast & Brunch, American (New), Cafes."
+  },
+  {
+    "dataset": "yelp",
+    "query": "6",
+    "run": "1",
+    "answer": "Coffee House Too Cafe (business_id businessid_9), with an average rating of 4.375 from 16 reviews between Jan 1 and Jun 30, 2016. Categories: Restaurants, Breakfast & Brunch, American (New), Cafes."
+  },
+  {
+    "dataset": "yelp",
+    "query": "6",
+    "run": "2",
+    "answer": "Coffee House Too Cafe (businessid_9) — highest average rating 4.375 over 16 reviews in Jan 1–Jun 30 2016; categories: Restaurants, Breakfast & Brunch, American (New), Cafes."
+  },
+  {
+    "dataset": "yelp",
+    "query": "6",
+    "run": "3",
+    "answer": "Coffee House Too Cafe (businessid_9), average rating 4.375 over 16 reviews — categories: Restaurants, Breakfast & Brunch, American (New), Cafes"
+  },
+  {
+    "dataset": "yelp",
+    "query": "6",
+    "run": "4",
+    "answer": "Coffee House Too Cafe — highest average rating 4.375 (16 reviews) between Jan 1 and Jun 30, 2016. Category: Restaurants, Breakfast & Brunch, American (New), Cafes."
+  },
+  {
+    "dataset": "yelp",
+    "query": "7",
+    "run": "0",
+    "answer": "Restaurants 58; Food 38; American (New) 24; Shopping 20; Breakfast & Brunch 19"
+  },
+  {
+    "dataset": "yelp",
+    "query": "7",
+    "run": "1",
+    "answer": "Restaurants 58; Food 38; American (New) 24; Shopping 20; Breakfast & Brunch 19"
+  },
+  {
+    "dataset": "yelp",
+    "query": "7",
+    "run": "2",
+    "answer": "Restaurants 58; Food 38; American (New) 24; Shopping 20; Breakfast & Brunch 19"
+  },
+  {
+    "dataset": "yelp",
+    "query": "7",
+    "run": "3",
+    "answer": "Restaurants 58; Food 38; American (New) 24; Shopping 20; Breakfast & Brunch 19"
+  },
+  {
+    "dataset": "yelp",
+    "query": "7",
+    "run": "4",
+    "answer": "Restaurants 58; Food 38; American (New) 24; Shopping 20; Breakfast & Brunch 19"
+  }
+]


### PR DESCRIPTION
## Alkera (Opus 4.8) — Leaderboard Submission

**Agent name:** Alkera
**Backbone LLM:** Claude Opus 4.8 (`xhigh` reasoning)
**Hints:** Yes
**Trials:** 5 per query
**Stratified Pass@1:** **80.44%**

## Architecture

Alkera is given its standard prompt, an addendum system prompt (described in method) inspired by SCRIBE's submission, and native tools for SQL querying (returning objects that can be paginated, SQL schema queries, bash, data lineage (reads relational data relations), and spawning review subagents. All these data tools only pull from the provided databases for the task. See more on [our method](https://github.com/AlkeraAI/Alkera-DAB-July/blob/main/METHODS.md).

## Results

| Dataset | Pass@1 |
|---|---|
| bookreview | 1.00 |
| googlelocal | 1.00 |
| music_brainz_20k | 1.00 |
| stockindex | 1.00 |
| stockmarket | 0.96 |
| yelp | 0.94 |
| crmarenapro | 0.80 |
| PATENTS | 0.73 |
| PANCANCER_ATLAS | 0.67 |
| agnews | 0.55 |
| DEPS_DEV_V1 | 0.50 |
| GITHUB_REPOS | 0.50 |
| **Stratified Pass@1** | **0.8044** |

## Notes

- **270 entries** (54 queries × 5 trials), validated against the official DAB validators (`common_scaffold/validate/validate.py`)
- **Integrity (per `SUBMISSION_RUBRIC.md` §2).** Answers come solely from the agent's own analysis of the provided databases. Every one of the 270 traces was self-audited over its full tool-call surface with three independent checkers: **0** reads of `validate.py` / `ground_truth.csv` / `queries.json` / other runs' artifacts, **0** external fetches (`load_dataset`, HuggingFace cache, `snapshot_download`, `curl`/`wget`/`git clone`, Kaggle), **0** cached-model loads.
- **Prompt disclosure.** The system addendum, inspired by SCRIBE's submission, is benchmark-agnostic — an answer-delivery contract, literal-reading/verification discipline, and standard analytical conventions (result shape & grain, code-vs-name identifiers, EMA / dollar-cost-averaging, etc.). It contains no gold values, no per-dataset rules, and no validator references; any example tokens in it are fictional. Full text below.
- **Submission file:** `leaderboard_submissions/alkera-opus-4.8_results.json`
- **Execution traces (all 270 runs):** https://github.com/AlkeraAI/Alkera-DAB-July/blob/main/traces/alkera-opus-4.8_traces.tar.gz