### PR TITLE
Fix query9 validator accepting wrong answers and refusals (word-boundary match)

### DIFF
--- a/query_crmarenapro/query9/validate.py
+++ b/query_crmarenapro/query9/validate.py
@@ -23,7 +23,7 @@ def validate(llm_output: str):
     llm_output_clean = llm_output.strip()
 
     # Check for exact state match (case insensitive)
-    if expected.upper() in llm_output_clean.upper():
+    if re.search(r'\b' + re.escape(expected) + r'\b', llm_output_clean, re.IGNORECASE):
         return True, f"Found expected state: {expected}"
 
     # Check if any valid state abbreviation is mentioned


### PR DESCRIPTION
Fixes #78.

`query_crmarenapro/query9/validate.py` used a plain substring test on its fast path:

```python
if expected.upper() in llm_output_clean.upper():   # expected = "MI"
```

`"MI"` occurs inside common words in agent prose (`determine`, `minimum`, `submitted`, `administrative`), so the validator accepted refusals and answers that named a different state.

This switches the fast path to word-boundary matching, which is already the semantics the fallback loop below it uses (`re.search(r'\b' + state + r'\b', ...)`). One line, no new imports, `re` is already imported.

### Before / after

Same eight inputs, run against the validator before and after the change:

| LLM output | before | after |
| --- | --- | --- |
| `MI` | PASS | PASS |
| `The state is MI.` | PASS | PASS |
| `the answer is mi` (lowercase) | PASS | PASS |
| `I could not determine the answer.` | **PASS** | fail |
| `The answer is CA, at a MInimum.` | **PASS** | fail |
| `The submitted record shows TX.` | **PASS** | fail |
| `CA` | fail | fail |
| `The answer is Texas.` | fail | fail |

All four false positives close; no true positive regresses, including the lowercase and in-prose forms.

### Scope

Only this one file. I found it by running all 104 `validate.py` files against two content-free probes (a refusal containing no numbers, and a string listing many candidate numbers). 85 resisted both; this was the only validator that accepted a refusal. The other 18 accept a numeric shotgun, which looks like the recall-over-precision tradeoff already noted in the paper rather than a defect, so I have not touched them.

Happy to follow up with a small CI test that asserts every validator rejects a refusal, if that would be useful. It would currently need an allowlist for those 18.
