### PR TITLE
Fix query8 validator rejecting the correct character spelling (apostrophe normalization)

### DIFF
--- a/query_imdb/query8/validate.py
+++ b/query_imdb/query8/validate.py
@@ -4,7 +4,9 @@ import re
 def normalize(text):
     # strip thousands-separator commas, then remove non-alphanumeric
     text = re.sub(r"(?<=\d),(?=\d{3}\b)", "", text)
-    text = re.sub(r"[^a-z0-9\s]", " ", text.lower())
+    text = text.lower()
+    text = re.sub(r"['\u2019`]", "", text)  # drop apostrophes so "Cockamamie's" -> "cockamamies"
+    text = re.sub(r"[^a-z0-9\s]", " ", text)
     return re.sub(r"\s+", " ", text).strip()
 
 


### PR DESCRIPTION
Fixes #81.

`normalize()` turned an apostrophe into a space, so the ground-truth character name `"Cockamamie's" Salesgirl` normalized to `cockamamie s salesgirl`, while the check searched for the literal `cockamamies salesgirl`. The correct spelling could never match, and only a misspelling passed.

This drops apostrophes in `normalize()` instead of spacing them, so the existing literal becomes reachable. The change is **additive**: nothing that passed before stops passing.

### Before / after

Every other clause held satisfied, varying only the character name:

| character name in answer | before | after |
| --- | --- | --- |
| `"Cockamamie's" Salesgirl` (correct, matches ground truth) | **fail** | PASS |
| `“Cockamamie’s” Salesgirl` (curly apostrophe) | **fail** | PASS |
| exact `ground_truth.csv` field text | **fail** | PASS |
| `Cockamamies Salesgirl` (misspelled) | PASS | PASS (unchanged) |
| a different character | fail | fail |

The curly `’` case matters in practice because models frequently emit it rather than `'`.

### Why this shape of fix

The alternative was to normalize the expected literal at the call site, matching how the actress clause already does it (`normalize("Aaron, Caroline") not in llm_norm`). That also works, but it would start **rejecting** the no-apostrophe spelling that passes today, which could regress an existing leaderboard submission. Fixing `normalize()` avoids that.

Found while adding a positive-control test that feeds each validator its own ground truth. 103 of the 104 accept it; this was the only one that did not.
