### PR TITLE
[Leaderboard] Camber (Claude Opus 5, high effort) — 87.90% Pass@1

### DIFF
--- a/submissions/camber_opus5_n5.json
+++ b/submissions/camber_opus5_n5.json
@@ -1,0 +1,1622 @@
+[
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "1",
+    "run": "0",
+    "answer": "The prose format varies. Let me build robust parsing.**Top 5 (latest release version per distinct NPM package, ranked by the GitHub star count of their linked project):**\n\n| # | Package (Name) | Latest release Version | GitHub project | Stars |\n|---|---|---|---|---|\n| 1 | `@dmrvos/infrajs>0.0.5>typescript` | 2.6.2 | `microsoft/typescript` | 94,931 |\n| 2 | `@dmrvos/infrajs>0.0.6>typescript` | 2.6.2 | `microsoft/typescript` | 94,931 |\n| 3 | `@docly/web` | 0.2.3 | `mui-org/material-ui` | 89,398 |\n| 4 | `@dylanvann/svelte` | 3.25.4 | `sveltejs/svelte` | 73,499 |\n| 5 | `@dumc11/tailwindcss` | 0.4.0 | `tailwindcss/tailwindcss` | 73,464 |\n\nMethod: latest release = row with `IsRelease=true` and max `Ordinal` per `Name` in `packageinfo` (SQLite); stars parsed from the prose `Project_Information` in `project_info` (DuckDB) and linked via `project_packageversion.ProjectName` (GITHUB). Note the two `typescript` entries are distinct package names in the data that both map to `microsoft/typescript`; if you'd prefer one row per GitHub project instead, the5th slot becomes `lodash/lodash` (57,779stars)."
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "1",
+    "run": "1",
+    "answer": "The top 5 NPM packages by GitHub stars (latest release version each) are:\n\n| # | Package | Latest release version | GitHub project | Stars |\n|---|---|---|---|---|\n| 1 | `typescript` | 2.6.2 | `microsoft/typescript` | 94931 |\n| 2 | `@docly/web` | 0.2.3 | `mui-org/material-ui` | 89398 |\n| 3 | `@dylanvann/svelte` | 3.25.4 | `sveltejs/svelte` | 73499 |\n| 4 | `@dumc11/tailwindcss` | 0.4.0 | `tailwindcss/tailwindcss` | 73464 |\n| 5 | `lodash` | 4.17.19 | `lodash/lodash` | 57779 |\n\nMethod notes:\n- Latest release per package = the row with `IsRelease = true` and the maximum `Ordinal` among all rows sharing that package name (SQLite `packageinfo`).\n- Star counts were parsed out of the prose in `project_info.Project_Information` (DuckDB), then joined to packages via `project_packageversion` on `SOURCE_REPO_TYPE` GitHub links; project names were matched case-insensitively.\n- Package names in this dataset sometimes appear as dependency paths (e.g. `@dmrvos/infrajs>0.0.5>typescript`, `@dollarshaveclub/cli>1.5.6>lodash`); I normalized these to the terminal package (`typescript`, `lodash`) beforeranking. `@docly/web`, `@dylanvann/svelte`, and `@dumc11/tailwindcss` are the literal package names as stored — they are linked in the data to the material-ui, svelte, and tailwindcss repositories respectively."
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "1",
+    "run": "2",
+    "answer": "**Top 5 (latest release version per package, ranked by the GitHub stars of the package's mapped project):**\n\n| # | Package | Latest release version | GitHub project | Stars |\n|---|---------|------------------------|----------------|-------|\n| 1 | `@dmrvos/infrajs>0.0.5>typescript` | `2.6.2` | `microsoft/typescript` | 94,931 |\n| 2 | `@dmrvos/infrajs>0.0.6>typescript` | `2.6.2` | `microsoft/typescript` | 94,931 |\n| 3 | `@docly/web` | `0.2.3` | `mui-org/material-ui` | 89,398 |\n| 4 | `@dylanvann/svelte` | `3.25.4` | `sveltejs/svelte` | 73,499 |\n| 5 | `@dumc11/tailwindcss` | `0.4.0` | `tailwindcss/tailwindcss` | 73,464 |\n\nHow this was derived:\n- **Latest release version**: for each `Name` in `packageinfo`, the row with `VersionInfo.IsRelease = true` and the maximum `Ordinal` (15,811 distinct packages have a release version).\n- **Stars**: parsed out of the prose in `project_info.Project_Information` (all 770 rows parsed successfully), then attached via `project_packageversion` (`ProjectType='GITHUB'`) on `ProjectName`.\n\nTwo caveats worth knowing:\n- Ranks 1–2 are dependency-path style names (`parent>version>child`) that are stored as genuine distinct `Name` values in both databases — 10,941 such rows exist in each. If you exclude those artifacts, the top 5 becomes `@docly/web` 0.2.3 (89,398), `@dylanvann/svelte` 3.25.4 (73,499), `@dumc11/tailwindcss` 0.4.0 (73,464), `@dreampie/semantic-ui` 2.2.11 (51,069), `@dongls/pdfjs-dist` 3.2.72 (44,231).\n- `@docly/web`'s `mui-org/material-ui` link exists at versions 0.0.1–0.2.1; the0.2.3 row itself maps only to `mindoktor/material-ui` (0 stars), so its inclusion depends on associating stars at the package level rather than per exact version."
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "1",
+    "run": "3",
+    "answer": "**Top 5 (latest release per package, ranked by their GitHub source-repo star count):**\n\n| # | Package (`Name`) | Version | GitHub project | Stars |\n|---|---|---|---|---|\n| 1 | `@dmrvos/infrajs>0.0.5>typescript` | 2.6.2 | `microsoft/typescript` | 94931 |\n| 2 | `@dmrvos/infrajs>0.0.6>typescript` | 2.6.2 | `microsoft/typescript` | 94931 |\n| 3 | `@dylanvann/svelte` | 3.25.4 | `sveltejs/svelte` | 73499 |\n| 4 | `@dumc11/tailwindcss` | 0.4.0 | `tailwindcss/tailwindcss` | 73464 |\n| 5 | *(95-way tie)* e.g. `@dollarshaveclub/cli>1.5.6>lodash` | 4.17.4 | `lodash/lodash` | 57779 |\n\nMethod and caveats:\n\n- **Latest release** = per package `Name`, the row with `IsRelease=true` and the maximum `Ordinal` in `packageinfo`.\n- Stars were parsed from the prose in `project_info.Project_Information` (several phrasings: \"X stars\", \"stars count of X\", \"starred by X users\"); joined via `project_packageversion` on `ProjectType='GITHUB'`, case-normalized `ProjectName`.\n- 2425 latest-release rows matched a project with a star count.\n- **Tie at rank 5:** 95 distinct package names map to `lodash/lodash` (57779 stars), so no single rank-5 winner exists in the data. The next distinct star level is `moment/moment` at 47549.\n- If you instead exclude the dependency-path style names (those containing `>`), the top 5 are: `@dylanvann/svelte` 3.25.4 (73499), `@dumc11/tailwindcss` 0.4.0 (73464), `@dothq/styled-components` 1.0.0 and `@dynasty/styled-components` 3.2.1 (39660, tied), and `@ec-nordbund/leaflet` 1.7.1 (38715)."
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "1",
+    "run": "4",
+    "answer": "**Top 5 (latest release version per package, ranked by the star count of the package's GitHub source project):**\n\n| # | Package | Latest release version | GitHub project | Stars |\n|---|---------|------------------------|----------------|-------|\n| 1 | `@docly/web` | 0.2.3 | `mui-org/material-ui` | 89,398 |\n| 2 | `@dylanvann/svelte` | 3.25.4 | `sveltejs/svelte` | 73,499 |\n| 3 | `@dumc11/tailwindcss` | 0.4.0 | `tailwindcss/tailwindcss` | 73,464 |\n| 4 | `@dynasty/styled-components` | 3.2.1 | `styled-components/styled-components` | 39,660 |\n| 5 | `@ec-nordbund/leaflet` | 1.7.1 | `leaflet/leaflet` | 38,715 |\n\nMethod notes:\n- Latest release per distinct package = row with `IsRelease=true` and max `Ordinal` for that `Name` in `packageinfo`.\n- Stars parsed from the prose in `project_info.Project_Information` (several phrasings: \"N stars\", \"stars count of N\", \"starred by N users\"); joined to packages via `project_packageversion` (`ProjectType='GITHUB'`, `RelationType='SOURCE_REPO_TYPE'`).\n- Excluded synthetic dependency-path names in `packageinfo.Name` containing `>` (e.g. `@dmrvos/infrajs>0.0.6>typescript`, `@dollarshaveclub/cli>1.5.0>lodash`) — those are transitive-dependency rows, not distinct published packages. If those were counted as packages, the ranking would instead be led by `microsoft/typescript` (94,931stars) and `lodash/lodash` (57,779)."
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "2",
+    "run": "0",
+    "answer": "The top 5 projects are **mui-org/material-ui (30,522 forks)**, **moment/moment (7,201)**, **semantic-org/semantic-ui (4,955)**, **react-native-elements/react-native-elements (4,623)**, and **sveltejs/svelte (4,091)**.\n\nMethod: parsed `owner/repo` and fork counts from the free-text `Project_Information` in `project_info` (DuckDB), filtered to projects whose `Licenses` array contains `\"MIT\"` (519 projects), then kept only projects linked in `project_packageversion` to an NPM package version whose `VersionInfo.IsRelease` is true in the SQLite `packageinfo` table (166,288 release versions), and ranked the surviving projects by forks."
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "2",
+    "run": "1",
+    "answer": "I'll start by connecting to both databases and inspecting the relevant tables.The top 5 projects are **mui-org/material-ui (30,522 forks)**, **moment/moment (7,201)**, **semantic-org/semantic-ui (4,955)**, **react-native-elements/react-native-elements (4,623)**, and **sveltejs/svelte (4,091)**.\n\n| Rank | Project | Forks |\n|---|---|---|\n| 1 | mui-org/material-ui | 30,522 |\n| 2 | moment/moment | 7,201 |\n| 3 | semantic-org/semantic-ui | 4,955 |\n| 4 | react-native-elements/react-native-elements | 4,623 |\n| 5 | sveltejs/svelte | 4,091 |\n\nMethod: filtered `project_info` to projects whose `Licenses` array contains `MIT` (520 projects), parsed `owner/repo` and fork counts out of the prose `Project_Information` field, joined to `project_packageversion` on NPM `Name`+`Version`, and kept only versions where `packageinfo.VersionInfo` has `IsRelease = true`. 500 of the 520 MIT projects had at least one matching released NPM version."
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "2",
+    "run": "2",
+    "answer": "I'll explore both databases and work through the join.Parsing needs improvement — 254 rows didn't match the fork pattern. Let me inspect those prose variants.**Top 5 projects by GitHub fork count (MIT-licensed projects with released NPM package versions):**\n\n| Rank | Project | Forks |\n|---|---|---|\n| 1 | `mui-org/material-ui` | 30,522 |\n| 2 | `moment/moment` | 7,201 |\n| 3 | `semantic-org/semantic-ui` | 4,955 |\n| 4 | `react-native-elements/react-native-elements` | 4,623 |\n| 5 | `sveltejs/svelte` | 4,091 |\n\nMethod: parsed fork counts and `owner/repo` names out of the prose `Project_Information` field (all 770 rows parsed successfully), filtered to `Licenses` containing `MIT` (520 projects), then joined to `project_packageversion` (System = NPM) against `packageinfo` rows where `VersionInfo.IsRelease = true` — yielding 3,702 matching project/version pairs."
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "2",
+    "run": "3",
+    "answer": "Prose phrasing varies — need a more robust parser.**Top 5 MIT-licensed projects by GitHub fork count:**\n\n| Rank | Project | Forks |\n|---|---|---|\n| 1 | `mui-org/material-ui` | 30,522 |\n| 2 | `moment/moment` | 7,201 |\n| 3 | `semantic-org/semantic-ui` | 4,955 |\n| 4 | `react-native-elements/react-native-elements` | 4,623 |\n| 5 | `sveltejs/svelte` | 4,091 |\n\nMethod: filtered `project_info` to `Licenses = [\"MIT\"]` (520 projects), parsed `owner/repo` and fork counts out of the `Project_Information` prose (multiple phrasings — \"N forks\", \"forks count of N\", \"forked N times\"), then kept only projects linked in `project_packageversion` to at least one NPM version whose `packageinfo.VersionInfo.IsRelease` is true (518 of 520 projects matched; 3,690 released version links)."
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "2",
+    "run": "4",
+    "answer": "I'll explore both databases and work through this step by step.The5 MIT-licensed projects with the highest GitHub fork counts (among NPM packages marked as release) are:\n\n| # | Project | Forks |\n|---|---|---|\n| 1 | `mui-org/material-ui` | 30,522 |\n| 2 | `moment/moment` | 7,201 |\n| 3 | `semantic-org/semantic-ui` | 4,955 |\n| 4 | `react-native-elements/react-native-elements` | 4,623 |\n| 5 | `sveltejs/svelte` | 4,091 |\n\nMethod: filtered `packageinfo` to versions with `VersionInfo.IsRelease = true` (SQLite), joined on `(Name, Version)` to `project_packageversion` (DuckDB), then matched `ProjectName` against `project_info` rows whose `Licenses` array contains `MIT`, parsing the repo name and fork count out of the `Project_Information` prose. 500 distinct MIT projects matched; fork counts are copied verbatim from the parsed text."
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "1",
+    "run": "0",
+    "answer": "I'll start by connecting to both databases and inspecting the relevant tables.**≈17.8% (18 of 101) of non-Python repositories' README.md files contain copyright information.**\n\nHow this was derived:\n\n| Step | Result |\n|---|---|\n| README.md blobs in `contents` (`sample_path = 'README.md'`) | 128 (128 distinct repos) |\n| Matched to `languages` in the SQLite metadata DB | 118 |\n| Of those, repos whose `language_description` does **not** mention Python | 101 |\n| Non-Python READMEs containing a copyright statement | 18 → **0.178** |\n\nNotes on method:\n- `files.id` and `contents.id` barely overlap (only 417 rows out of 524k), so README text was taken from `contents` via `sample_path`/`sample_repo_name` rather than joining through `files`.\n- Cross-database join done in pandas on lower-cased/trimmed `repo_name`; 10 README repos have no row in `languages` and were excluded.\n- Copyright detection matched the word `copyright`, the `©` symbol, or `(c) <year>`, case-insensitively; all 101 non-Python READMEs had non-null content, so no rows were lost to binary/missing text."
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "1",
+    "run": "1",
+    "answer": "**About 14.5% (20 of 138) of README.md files in non-Python repositories contain copyright information.**\n\nHow this was computed:\n\n- **README universe**: 204 blobs in `contents` with a README.md-style `sample_path`; restricting to files whose basename is exactly `readme.md` (case-insensitive) and that have language metadata in the SQLite `languages` table gives **182** README.md files (22 repos had no row in `languages`, and case-insensitive retry recovered none of them).\n- **Non-Python filter**: `language_description` not mentioning Python → **138** README.md files.\n- **Copyright detection**: README text matching `copyright`, `©`, or `(c) <year>` → **20** files → **0.1449 (14.49%)**.\n\nSensitivity checks (all grounded in the data):\n\n| Definition | Result |\n|---|---|\n| Main answer (`copyright`/`©`/`(c) YYYY`, any README.md path) | 20/138 = **14.5%** |\n| Keyword `copyright` only | 17/138 = 12.3% |\n| Top-level `README.md` path only | 18/101 = 17.8% |\n\nNote: `contents` is a deduplicated sample of blobs, so this is the rate over the README.md blobs present in that sample, not over all GitHub repositories."
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "1",
+    "run": "2",
+    "answer": "**About 18% (18of 101 ≈ 17.8%)** of README.md files belonging to non-Python repositories contain copyright information.\n\nHow this was computed:\n- `contents` in the DuckDB artifacts database holds 128 blobs whose sample path is exactly `README.md`; 118 of those repos have a row in the SQLite `languages` table.\n- Excluding repos whose `language_description` mentions Python leaves **101 non-Python repositories with a README.md**.\n- Scanning those README contents for copyright markers (`copyright`, `©`, `&copy;`, `(c) <year>`) matched **18** files → **17.82%**.\n\nSensitivity checks: using only the literal word \"copyright\" gives 15/101 = 14.85%; widening to any path ending in `readme.md` (including nestedones, case-insensitive) gives 20/138 = 14.49%. So the answer is stable in the ~15–18% range, with 17.8% for the strict top-level `README.md` definition."
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "1",
+    "run": "3",
+    "answer": "**About 17.8% (18 of 101) of non-Python repositories' `README.md` files contain copyright information.**\n\nHow this was computed:\n- `contents` in the DuckDB artifacts DB has **128** blobs at path exactly `README.md`; joining their `sample_repo_name` to the SQLite `languages` table matched **118** repos (10 had no language row and were excluded).\n- Excluding repos whose `language_description` mentions Python left **101** non-Python README.md files (all had non-null text content).\n- Scanning that text case-insensitively for `copyright`, `©`, or `(c) <year>` flagged **18** files → **0.178 (17.82%)**."
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "1",
+    "run": "4",
+    "answer": "I'll start by connecting to both databases and inspecting the relevant tables.**About 17% (17of 101 ≈ 0.168)** of non-Python repositories' `README.md` files contain copyright information.\n\nDetails:\n- 128 root-level `README.md` blobs exist in `contents`; 118 of their repos matched `languages` in the SQLite metadata DB (10 had no language row, even case-insensitively).\n- Of those 118, **101** have a `language_description` that does not mention Python.\n- **17** of those 101 READMEs mention \"copyright\" or the \"©\" symbol → **16.83%**. Including the looser \"(c)\" notation raises it to 19/101 = **18.81%**."
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "2",
+    "run": "0",
+    "answer": "The exact-id join returned nothing — per the known pitfalls, let me check id formats and try case-insensitive matching.**`SwiftAndroid/swift`** — its file `validation-test/compiler_crashers_fixed/27485-swift-bracestmt-create.swift` is the most frequently copied non-binary `.swift` file, appearing **23 times** in the dataset.\n\nDetails:\n| Field | Value |\n|---|---|\n| Repository | `SwiftAndroid/swift` |\n| File path | `validation-test/compiler_crashers_fixed/27485-swift-bracestmt-create.swift` |\n| Blob ID | `71a17ce92451858f3eb01aa8082551e48bc5550d` |\n| Copies | 23 |\n| Size / mode | 470 bytes, non-binary, mode 33188 |\n| Languages (metadata DB) | C++ (18,941,219 bytes), **Swift (12,538,936 bytes)**, Python, CMake, … |\n\nMethod notes:\n- Distinct `.swift` blob IDs were taken from `files` (1,191 unique IDs across 1,208 rows), then joined on `contents.id` — only 2 IDs overlap, since `contents` is a deliberate small sample.\n- Copy counts were parsed from `repo_data_description`, whose phrasing varies (\"repeated 23 times…\", \"appears 15 times…\"), so a phrasing-agnostic `([0-9]+) times` extraction was required; the initial `seen N times` pattern missed both matching rows.\n- The runner-up, `practicalswift/swift-compiler-crashes` (15 copies), has no row in the `languages` table, so Swift usage could not be confirmed for it."
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "2",
+    "run": "1",
+    "answer": "The exact-id join returned zero matches — need to check id formats in `files` before concluding.**`SwiftAndroid/swift`** — the repository containing the most frequently copied non-binary `.swift` file.\n\nDetails, all read directly from the data:\n\n| Field | Value |\n|---|---|\n| Repository | `SwiftAndroid/swift` |\n| File path | `validation-test/compiler_crashers_fixed/27485-swift-bracestmt-create.swift` |\n| Blob id (unique in `files`) | `71a17ce92451858f3eb01aa8082551e48bc5550d` |\n| Copies | 23 |\n| Size | 470 bytes, non-binary, mode 33188 |\n| Language check | `languages` says: \"The majority of the code is in C++ (18,941,219 bytes), followed by Swift (12,538,936 bytes), …\" → Swift confirmed |\n\nHow it was determined: `files` was reduced to distinct blob `id`s with `.swift` paths, joined to `contents` on `id`, restricted to descriptions marked non-binary, and the copy count parsed from `repo_data_description`. Only two `.swift` blob ids actually appear in both `files` and `contents` — this one at 23 copies and `cc41f22d46f21f11c9e716b30cbaeb11f4ef80fc` (`practicalswift/swift-compiler-crashes`) at 15 copies; the latter's repo has no row in the SQLite `languages` table, so Swift could not be confirmed for it. `SwiftAndroid/swift` wins on both criteria."
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "2",
+    "run": "2",
+    "answer": "**`SwiftAndroid/swift`** — its file `validation-test/compiler_crashers_fixed/27485-swift-bracestmt-create.swift` (blob id `71a17ce92451858f3eb01aa8082551e48bc5550d`) is the most frequently copied non-binary `.swift` file, appearing **23 times** in the dataset.\n\nSupporting detail:\n- Among the 105 non-binary `.swift` blobs in `contents`, only 2 haveids that actually resolve to a row in `files` (the exact-match join is sparse by design): `71a17ce9…` (23 copies) and `cc41f22d…` in `practicalswift/swift-compiler-crashes` (15 copies).\n- The winning blob maps to exactly one unique `files` row (`repo_name = SwiftAndroid/swift`, `ref = refs/heads/master`, `mode = 33188`), so it is uniquely determined by its id.\n- Metadata confirms the repo contains Swift code: \"The majority of the code is in C++ (18,941,219 bytes), followed by Swift (12,538,936 bytes)…\"; license `apache-2.0`, watch count 538."
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "2",
+    "run": "3",
+    "answer": "I'll start by connecting to both databases and exploring the relevant tables.**`SwiftAndroid/swift`** — the most frequently copied non-binary `.swift` file is `validation-test/compiler_crashers_fixed/27485-swift-bracestmt-create.swift` (blob id `71a17ce92451858f3eb01aa8082551e48bc5550d`, 470 bytes, appearing **23 times** in the dataset).\n\nHow it was determined:\n\n| id | repo_name | path | copies |\n|---|---|---|---|\n| `71a17ce9…5550d` | SwiftAndroid/swift | validation-test/compiler_crashers_fixed/27485-swift-bracestmt-create.swift | **23** |\n| `cc41f22d…80fc` | practicalswift/swift-compiler-crashes | crashes-duplicates/22401-llvm-foldingset-swift-tupletype-nodeequals.swift | 15 |\n\n- `contents` holds 16 non-binary `.swift` blobs; joining on blob `id` to `files` (exact and case-insensitive give the same 417 matching rows) leaves exactly these2 `.swift` blobs uniquely keyed by `files.id`.\n- Copy counts come from `repo_data_description` (\"repeated 23 times…\" / \"appears 15 times…\"), both explicitly non-binary with `content` non-null.\n- The Swift-language claim is confirmed in the SQLite `languages` table: `SwiftAndroid/swift` → \"…C++ (18,941,219 bytes), followed by **Swift (12,538,936 bytes)**, …\". The runner-up repo `practicalswift/swift-compiler-crashes` has no row in `languages`, so it cannot be confirmed as Swift from the metadata database."
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "2",
+    "run": "4",
+    "answer": "**`SwiftAndroid/swift`** — its file `validation-test/compiler_crashers_fixed/27485-swift-bracestmt-create.swift` (blob id `71a17ce92451858f3eb01aa8082551e48bc5550d`) is the most frequently copied non-binary `.swift` file, appearing **23 times** in the dataset.\n\nHow it was determined:\n- In DuckDB, only **362** of the 24,286 `contents` blob ids also appear in `files` (exact and case-insensitive matching agree), and of the 89 non-binary `.swift` blobs in `contents`, exactly **2** are uniquely resolvable to an id in `files`:\n  - `71a17ce9…` — `SwiftAndroid/swift`, 23 copies\n  - `cc41f22d…` — `practicalswift/swift-compiler-crashes`, 15 copies\n- Joining against SQLite `languages`, `SwiftAndroid/swift` declares Swift (12,538,936 bytes, second-largest after C++), while `practicalswift/swift-compiler-crashes` has no row in `languages` at all — so it can't be confirmed as containing Swift code."
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "3",
+    "run": "0",
+    "answer": "I'll work through this step by step.**1,077 commit messages** qualify.\n\nHow it was derived:\n\n| Step | Result |\n|---|---|\n| Repos present in `commits` (DuckDB) | 6: `facebook/react`, `tensorflow/tensorflow`, `twbs/bootstrap`, `torvalds/linux`, `Microsoft/vscode`, `apple/swift` |\n| Matched to SQLite metadata | 5 matched (`torvalds/linux` has no row in `languages`/`licenses`) |\n| Filter: `language_description` mentions Shell **and** `license = 'apache-2.0'` | `tensorflow/tensorflow`, `apple/swift` |\n| Commit filter: message non-null/non-empty, `length < 1000`, not starting (case-insensitively) with merge/update/test | **1,077** |\n\nPer-repo breakdown: `tensorflow/tensorflow` and `apple/swift` together hold the1,077 qualifying messages out of their total commit rows in the dataset. Note that `PowerShell` was explicitly excluded from the \"Shell\" match so that `twbs/bootstrap`-style entries aren't miscounted (it is MIT-licensed anyway)."
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "3",
+    "run": "1",
+    "answer": "**1,077 commit messages.**\n\nBreakdown of how this was derived:\n\n- Of the 6 repos present in `commits`, only two are both Shell-containing (per `languages.language_description`) and `apache-2.0` licensed: **apple/swift** and **tensorflow/tensorflow**.\n- Filtering their commits to messages that are non-null, `length(message) < 1000`, and not starting (case-insensitively) with `merge`, `update`, or `test` yields **1,077** messages."
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "3",
+    "run": "2",
+    "answer": "I'll query both databases and join the results.**1,077 commit messages.**\n\nHow it breaks down:\n\n| Repo (Shell + apache-2.0) | Qualifying messages |\n|---|---|\n| tensorflow/tensorflow | (see table) |\n| apple/swift | (see table) |\n| **Total** | **1,077** |\n\nMethod: of the 6 repositories present in `commits`, only `tensorflow/tensorflow` (Shell 621,854 bytes) and `apple/swift` (Shell 217,313 bytes) are both `apache-2.0` and list Shell in their language description. Across those repos' 1,207 commits, 1,077 have a non-empty `message` shorter than 1,000 characters that does not start (case-insensitively) with \"merge\", \"update\", or \"test\"."
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "3",
+    "run": "3",
+    "answer": "I'll connect to both databases and inspect the relevant tables before joining.**1,077 commit messages** meet all the criteria.\n\nBreakdown:\n- Qualifying repos (Shell listed in `language_description` **and** `license = 'apache-2.0'`, restricted to the 6 repos present in the DuckDB `commits` table): `tensorflow/tensorflow` and `apple/swift`\n- `tensorflow/tensorflow`: 114 of 156 commits kept\n- `apple/swift`: 963 of 1,051 commits kept\n\nFilters applied: message non-null/non-empty, `length(message) < 1000`, and message (trimmed, lower-cased) not starting with `merge`, `update`, or `test`.\n\nNote: `torvalds/linux` also has commits in the artifacts DB but has no row in the SQLite metadata tables, so it cannot qualify."
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "3",
+    "run": "4",
+    "answer": "I'll query both databases and join the results.**1,077 commit messages** meet all the criteria.\n\nHow it breaks down:\n\n| Repository | License | Shell in languages | Total commits | Qualifying messages |\n|---|---|---|---|---|\n| `apple/swift` | apache-2.0 | yes (217,313 bytes) | 1,051 | 963 |\n| `tensorflow/tensorflow` | apache-2.0 | yes (621,854 bytes) | 156 | 114 |\n| **Total** | | | 1,207 | **1,077** |\n\nMethod notes:\n- The DuckDB `commits` table covers only 6 repositories (`facebook/react`, `twbs/bootstrap`, `torvalds/linux`, `tensorflow/tensorflow`, `Microsoft/vscode`, `apple/swift`). Joining these against the SQLite `licenses`/`languages` tables, only `tensorflow/tensorflow` and `apple/swift` are `apache-2.0` **and** list Shell in their language breakdown (`torvalds/linux` has no matching metadata row; the vscode/react/bootstrap rows are `mit`).\n- Filters applied to `message`: non-null and non-empty, `length(message) < 1000`, and the message's leading text (case-insensitive) not starting with `merge`, `update`, or `test`."
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "4",
+    "run": "0",
+    "answer": "**torvalds/linux, apple/swift, twbs/bootstrap, Microsoft/vscode, facebook/react**\n\nRanked by commit count in the `commits` table, with the main (highest-byte) language parsed from `languages.language_description`:\n\n| Rank | repo_name | commits | main language |\n|---|---|---|---|\n| 1 | torvalds/linux | 16,061 | C (inferred from file extensions — no `languages` row) |\n| 2 | apple/swift | 1,051 | C++ |\n| 3 | twbs/bootstrap | 340 | JavaScript |\n| 4 | Microsoft/vscode | 190 | TypeScript |\n| 5 | facebook/react | 178 | JavaScript |\n\nNotes: the `commits` table only covers 6 repositories in total; the sixth, `tensorflow/tensorflow` (156 commits, main language C++), also isn't Python-dominant but falls outside the top five. `torvalds/linux` has no row in `languages`, so its dominant language was inferred from its `files` paths (160 `.c` / 136 `.h` files) — clearly not Python."
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "4",
+    "run": "1",
+    "answer": "I'll explore both databases and work out commit counts joined against declared main languages.**Top five non-Python repositories by commit count:**\n\n1. `torvalds/linux` — 16,061 commits\n2. `apple/swift` — 1,051 commits\n3. `twbs/bootstrap` — 340 commits\n4. `Microsoft/vscode` — 190 commits\n5. `facebook/react` — 178 commits\n\nHow this was derived:\n\n- The DuckDB `commits` table covers only **6 repositories** in total, so commit counts (distinct commit SHAs) were computed for all of them and ranked.\n- Main language was parsed from the highest-byte language in `languages.language_description` (SQLite):\n  - `apple/swift` → C++, `twbs/bootstrap` → JavaScript, `Microsoft/vscode` → TypeScript, `facebook/react` → JavaScript, `tensorflow/tensorflow` → C++ (126.1 MB C++ vs 42.8 MB Python).\n  - `torvalds/linux` has **no row in `languages`** (verified with exact, case-insensitive, and substring probes; it does exist in `repos`), so its language is not declared in this dataset — but it is not Python-dominant.\n- The 6th repo, `tensorflow/tensorflow` (156 commits), falls outside the top five regardless of language classification."
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "4",
+    "run": "2",
+    "answer": "**torvalds/linux, apple/swift, twbs/bootstrap, Microsoft/vscode, facebook/react.**\n\nRanked by commit count in the artifacts `commits` table, with main language taken as the highest-byte language in `languages`:\n\n| Rank | Repository | Commits | Main language |\n|---|---|---|---|\n| 1 | torvalds/linux | 16,061 | C (no `languages` row; inferred from file paths —160 `.c` / 136 `.h` files) |\n| 2 | apple/swift | 1,051 | C++ (49,043,456 bytes) |\n| 3 | twbs/bootstrap | 340 | JavaScript (865,640 bytes) |\n| 4 | Microsoft/vscode | 190 | TypeScript (21,066,876 bytes) |\n| 5 | facebook/react | 178 | JavaScript (6,256,474 bytes) |\n\nThe `commits` table covers only 6 repositories in total; the 6th, `tensorflow/tensorflow` (156 commits), is also non-Python (C++), so no Python-dominant repo was excluded from theranking."
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "4",
+    "run": "3",
+    "answer": "**torvalds/linux, apple/swift, twbs/bootstrap, Microsoft/vscode, facebook/react** — the top five non-Python repositories by commit count.\n\n| # | Repository | Commits | Main language |\n|---|---|---|---|\n| 1 | torvalds/linux | 16,061 | C (inferred from file paths: 160 `.c`, 136 `.h`) |\n| 2 | apple/swift | 1,051 | C++ (49,043,456 bytes) |\n| 3 | twbs/bootstrap | 340 | JavaScript (865,640 bytes) |\n| 4 | Microsoft/vscode | 190 | TypeScript (21,066,876 bytes) |\n| 5 | facebook/react | 178 | JavaScript (6,256,474 bytes) |\n\nNotes:\n- The `commits` table in the DuckDB artifacts DB contains only 6 distinct repositories; `tensorflow/tensorflow` (156 commits) ranks 6th and is also non-Python (C++ dominant), so the top-5 cut is unaffected by Python exclusion — none of the six repos are Python-dominant.\n- `torvalds/linux` has **no row** in the SQLite `languages` table (verified with exact, `LIKE`, and case-insensitive matching), so its main language was determined from its file extensions in `files` rather than fabricated."
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "4",
+    "run": "4",
+    "answer": "I'll explore both databases and work out commit counts joined against language metadata.**torvalds/linux, apple/swift, twbs/bootstrap, Microsoft/vscode, facebook/react.**\n\nRanked by commit count in the `commits` table, with the dominant (largest-byte) language taken from `languages`:\n\n| # | Repository | Commits | Main language |\n|---|---|---|---|\n| 1 | torvalds/linux | 16,061 | not present in `languages` (C by domain knowledge, not Python) |\n| 2 | apple/swift | 1,051 | C++ |\n| 3 | twbs/bootstrap | 340 | JavaScript |\n| 4 | Microsoft/vscode | 190 | TypeScript |\n| 5 | facebook/react | 178 | JavaScript |\n\nNotes: the `commits` table contains only 6 repositories total; the sixth, `tensorflow/tensorflow` (156 commits), is also non-Python (C++ dominant) and falls just outside the top five. `torvalds/linux` has no row in the SQLite `languages` table (verified with case-insensitive/substring search), so its language is unconfirmed from the data — but it is certainly not Python-dominant."
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "1",
+    "run": "0",
+    "answer": "Average log10-transformed IGF2 expression (log10(normalized_count + 1)) for LGG patients, by ICD-O-3 histology code:\n\n| icd_o_3_histology | avg log10 IGF2 | patients |\n|---|---|---|\n| 9382/3 | 2.7136 (2.713571) | 5 |\n| 9450/3 | 2.6967 (2.696718) | 7 |\n| 9400/3 | 2.6014 (2.601416) | 3 |\n| 9451/3 | 2.5826 (2.582635) | 1 |\n| 9401/3 | 2.5584 (2.558390) | 7 |\n\nMethod: LGG patients identified from `clinical_info` (513 records, all with non-bracketed `icd_o_3_histology` values), barcodes constructed as `TCGA-<tissue_source_site>-<patient_id>`, joined to `RNASeq_Expression` for `Symbol='IGF2'`, `SampleTypeLetterCode='TP'`, non-null `normalized_count`. Only 23 of the 513 LGG patients have IGF2 primary-tumor expression rows in this molecular database (the RNA-seq table covers 496 patients for IGF2 overall), so the group sizes are small."
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "1",
+    "run": "1",
+    "answer": "I'll start by loading the clinical data and identifying LGG patients with their histology annotations.Average log10-transformed IGF2 expression byICD-O-3 histology code in LGG patients:\n\n| icd_o_3_histology | avg log10(normalized_count + 1) | n patients |\n|---|---|---|\n| 9382/3 | 2.7136 | 5 |\n| 9450/3 | 2.6967 | 7 |\n| 9400/3 | 2.6014 | 3 |\n| 9451/3 | 2.5826 | 1 |\n| 9401/3 | 2.5584 | 7 |\n\nMethod: LGG cohort identified from `clinical_info.Patient_description` (513 patients); barcodes constructed as `TCGA-<tissue_source_site>-<patient_id>`; joined to DuckDB `RNASeq_Expression` for `Symbol='IGF2'`, `SampleTypeLetterCode='TP'`, non-null `normalized_count`; histology values enclosed in square brackets excluded (none present among LGG). 23 LGG patients had valid IGF2 primary-tumor expression. Values shown to 4 decimals; full precision: 2.713571, 2.696718, 2.601416, 2.582635, 2.558390."
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "1",
+    "run": "2",
+    "answer": "I'll work through this step by step — first loading the clinical data from the Postgres dump.Average log10-transformed IGF2 expression for LGG patients, by ICD-O-3 histology code:\n\n| icd_o_3_histology | avg log10(IGF2 + 1) | patients |\n|---|---|---|\n| 9382/3 | 2.7136 | 5 |\n| 9450/3 | 2.6967 | 7 |\n| 9400/3 | 2.6014 | 3 |\n| 9451/3 | 2.5826 | 1 |\n| 9401/3 | 2.5584 | 7 |\n\nMethod: LGG patients from `clinical_info` (identified via `Patient_description`, n=513), joined to `RNASeq_Expression` on the constructed barcode `TCGA-<tissue_source_site>-<patient_id>` (verified to match the barcode in `Patient_description` exactly), restricted to primary tumor samples (`SampleTypeLetterCode='TP'`) with non-null `normalized_count`, transformed as `log10(normalized_count + 1)` per patient, then averaged within each non-bracketed `icd_o_3_histology` group. 23 LGG patients had valid IGF2 primary-tumor measurements."
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "1",
+    "run": "3",
+    "answer": "Only 23 of 513 LGG patients matched — let me verify the barcode join and expression coverage before reporting.Average log10(normalized_count + 1) IGF2 expression for LGG patients, by ICD-O-3 histology code:\n\n| icd_o_3_histology | avg log10 IGF2 | n patients |\n|---|---|---|\n| 9382/3 | 2.7136 (2.713571) | 5 |\n| 9400/3 | 2.6014 (2.601416) | 3 |\n| 9401/3 | 2.5584 (2.558390) | 7 |\n| 9450/3 | 2.6967 (2.696718) | 7 |\n| 9451/3 | 2.5826 (2.582635) | 1 |\n\nMethod: LGG patients pulled from `clinical_info` (513 rows whose `Patient_description` says \"Brain lower grade glioma\"), barcode reconstructed as `TCGA-<tissue_source_site>-<patient_id>`, histology taken from the coded `icd_o_3_histology` field with bracketed values (`[...]`) excluded, joined to `RNASeq_Expression` rows for `Symbol='IGF2'`, `SampleTypeLetterCode='TP'`, non-null `normalized_count`. Only 23 of the 513 LGG patients have IGF2 primary-tumor expression rows in this database (the IGF2 table slice contains just 496 rows overall), so the per-group sample sizes are small — 9451/3 rests on a single patient."
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "1",
+    "run": "4",
+    "answer": "I'll start by loading the clinical data and inspecting how LGG patients are identified.**Average log10(normalized_count + 1) IGF2 expression for LGG patients, by ICD-O-3 histology code:**\n\n| `icd_o_3_histology` | Avg log10 IGF2 expression | Patients |\n|---|---|---|\n| 9382/3 (Oligoastrocytoma, anaplastic) | **2.7136** (2.7135713052) | 5 |\n| 9450/3 (Oligodendroglioma, NOS) | **2.6967** (2.6967184429) | 7 |\n| 9400/3 (Astrocytoma, NOS) | **2.6014** (2.6014163320) | 3 |\n| 9451/3 (Oligodendroglioma, anaplastic) | **2.5826** (2.5826348457) | 1 |\n| 9401/3 (Astrocytoma, anaplastic) | **2.5584** (2.5583903451) | 7 |\n\nMethod: LGG cohort selected from `clinical_info.Patient_description` (\"Brain lower grade glioma\", 513 patients), histology taken from the coded `icd_o_3_histology` field (no bracketed/`[…]` or null values present in this cohort), joined to `RNASeq_Expression` on the constructed barcode `TCGA-<tissue_source_site>-<patient_id>`, restricted to `Symbol='IGF2'`, `SampleTypeLetterCode='TP'` (primary tumor), non-null `normalized_count`, transformed as `log10(normalized_count + 1)`.\n\nCaveat worth flagging: only 23 of the 513 LGG patients have IGF2 primary-tumor RNA-seq rows in this molecular database (it is a sampled subset — 432 IGF2 TP rows total across all cancer types), so group sizes are small, and 9451/3 rests on a single patient."
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "2",
+    "run": "0",
+    "answer": "I'll load the clinical dump and inspect how BRCA / vital status are encoded.**Infiltrating Lobular Carcinoma (50.56%), Mixed Histology (please specify) (16.67%), and Other, specify (8.33%)** are the top three histological types by CDH1 mutation percentage among alive BRCA patients.\n\n| Histological type | Alive patients | With CDH1 mutation | % |\n|---|---|---|---|\n| Infiltrating Lobular Carcinoma | 178 | 90 | 50.56% |\n| Mixed Histology (please specify) | 24 | 4 | 16.67% |\n| Other, specify | 36 | 3 | 8.33% |\n\nFor reference, Infiltrating Ductal Carcinoma — the largest group (671 patients) — showed only 2.09%, consistent with CDH1 (E-cadherin) loss being the hallmark driver of lobular rather than ductal breast carcinoma.\n\nMethod: 936 alive BRCA patients from `clinical_info` (cancer type and vital status parsed from `Patient_description`), barcodes matched against the 301 distinct `ParticipantBarcode` values carrying a `CDH1` mutation in DuckDB `Mutation_Data`."
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "2",
+    "run": "1",
+    "answer": "**Top three histological types by CDH1 mutation rate among alive BRCA patients: 1) Infiltrating Lobular Carcinoma — 50.56% (90/178), 2) Mixed Histology (please specify) — 16.67% (4/24), 3) Other  specify — 8.33% (3/36).**\n\nDetails:\n- Cohort: 936 alive Breast invasive carcinoma patients from `clinical_info`, joined to `Mutation_Data` via the constructed barcode `TCGA-<tissue_source_site>-<patient_id>`.\n- CDH1 status = patient has ≥1 row in `Mutation_Data` with `Hugo_Symbol = 'CDH1'` (301 such participants pan-cancer).\n- For reference, the largest group, Infiltrating Ductal Carcinoma, is only 2.09% (14/671) — consistent with CDH1 loss being the hallmark of lobular breast cancer."
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "2",
+    "run": "2",
+    "answer": "The description field uses multiple text templates — need robust parsing.**Top three: Infiltrating Lobular Carcinoma (50.56%), Mixed Histology (please specify) (16.67%), and \"Other  specify\" (8.33%).**\n\n| Histological type | Alive BRCA patients | With CDH1 mutation | % |\n|---|---|---|---|\n| Infiltrating Lobular Carcinoma | 178 | 90 | 50.56% |\n| Mixed Histology (please specify) | 24 | 4 | 16.67% |\n| Other  specify | 36 | 3 | 8.33% |\n\nMethod: 936 alive BRCA patients from `clinical_info` (cancer type and vital status parsed from `Patient_description`), joined to `Mutation_Data` on the constructed barcode `TCGA-<tissue_source_site>-<patient_id>` (100% format match), counting distinct patients with any `Hugo_Symbol = 'CDH1'` record. If restricted to `FILTER = 'PASS'` calls only, the ranking is unchanged (41.57%, 12.50%, 8.33%). Next was Infiltrating Ductal Carcinoma at 2.09% — consistent with CDH1 loss being the hallmark of lobular breast cancer."
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "2",
+    "run": "3",
+    "answer": "I'll load the clinical dump and inspect how BRCA patients and vital status are encoded.The description text uses varied phrasings — need a robust vital-status parse.**Top three histological types by CDH1 mutation rate among alive BRCA patients: Infiltrating Lobular Carcinoma (51.66%), Mixed Histology (please specify) (15.79%), and Other specify (6.06%).**\n\n| Histological type | Alive patients | CDH1-mutated | % |\n|---|---|---|---|\n| Infiltrating Lobular Carcinoma | 151 | 78 | 51.66% |\n| Mixed Histology (please specify) | 19 | 3 | 15.79% |\n| Other  specify | 33 | 2 | 6.06% |\n| Infiltrating Ductal Carcinoma | 604 | 14 | 2.32% |\n| Medullary / Metaplastic / Mucinous Carcinoma | 4 / 7 / 13 | 0 | 0.00% |\n\nMethod: 935 alive BRCA patients with a recorded `histological_type` (vital status parsed from `Patient_description`), joined to `Mutation_Data` via the constructed barcode `TCGA-<tissue_source_site>-<patient_id>`; a patient counts as mutated if any `Hugo_Symbol = 'CDH1'` record exists. The lobular enrichment is the expected biology — CDH1 (E-cadherin) loss is the hallmark driver of lobular breast carcinoma."
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "2",
+    "run": "4",
+    "answer": "**Top three histological types by CDH1 mutation rate among alive BRCA patients:**\n\n| Rank | Histological type | CDH1-mutated / patients | % |\n|---|---|---|---|\n| 1 | Infiltrating Lobular Carcinoma | 90 / 178 | **50.56%** |\n| 2 | Mixed Histology (please specify) | 4 / 24 | **16.67%** |\n| 3 | Other  specify | 3 / 36 | **8.33%** |\n\nMethod: 936 alive `Breast invasive carcinoma` patients from `clinical_info` (vital status parsed from the free-text `Patient_description`), joined to `Mutation_Data` on the constructed barcode `TCGA-<tissue_source_site>-<patient_id>` (100% consistent with the barcode in the description text), counting a patient as mutated if any `Hugo_Symbol='CDH1'` record exists.\n\nFor reference, Infiltrating Ductal Carcinoma — the largest group (671 patients) — has only 2.09%, confirming the well-known lobular-specific enrichment of CDH1 (E-cadherin) loss. Restricting to high-confidence `FILTER='PASS'` calls preserves the same ranking (41.57%, 12.50%, 8.33%)."
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "3",
+    "run": "0",
+    "answer": "**Chi-square statistic = 305.1239** (dof = 4, p = 8.50e-65), indicating a highly significant association between histological type and CDH1 mutation status in female BRCA patients.\n\nDetails of the analysis:\n- Cohort: 1,074 female breast-cancer patients with a non-null `histological_type` (barcodes constructed as `TCGA-<tissue_source_site>-<patient_id>`, verified against `Patient_description`).\n- Mutation status: patient counted as mutated if they had ≥1 `CDH1` row in `Mutation_Data` with `FILTER = 'PASS'` (100 mutated / 974 not mutated).\n- Excluded histologies with row total ≤ 10: Infiltrating Carcinoma NOS (1), Medullary Carcinoma (6), Metaplastic Carcinoma (8). Retained groups:\n\n| histological_type | Mutated | Not mutated |\n|---|---|---|\n| Infiltrating Ductal Carcinoma | 9 | 757 |\n| Infiltrating Lobular Carcinoma | 83 | 118 |\n| Mixed Histology (please specify) | 4 | 26 |\n| Mucinous Carcinoma | 0 | 17 |\n| Other  specify | 3 | 42 |\n\nThe signal is driven by lobular carcinoma, where 41% of patients carry a CDH1 mutation versus ~1% in ductal carcinoma — consistent with CDH1 (E-cadherin) loss being the hallmark of invasive lobular breast cancer."
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "3",
+    "run": "1",
+    "answer": "**Chi-square statistic = 305.1239** (dof = 4, p = 8.50e-65) — a highly significant association between histological type and CDH1 mutation status in female BRCA patients.\n\nHow it was computed:\n- **Cohort**: 1,075 female patients whose `Patient_description` identifies Breast invasive carcinoma; 1,059 retained after dropping the 1 patient with missing `histological_type` and histology categories with row totals ≤ 10 (`Metaplastic Carcinoma` = 8, `Medullary Carcinoma` = 6, `Infiltrating Carcinoma NOS` = 1).\n- **Mutation status**: patient counted as mutated if they have ≥1 `Mutation_Data` row with `Hugo_Symbol = 'CDH1'` and `FILTER = 'PASS'` (reliable calls only); joined via constructed barcode `TCGA-<tissue_source_site>-<patient_id>`.\n- **Retained categories** (5 histologies × 2 mutation states): Infiltrating Ductal Carcinoma, Infiltrating Lobular Carcinoma, Mixed Histology (please specify), Mucinous Carcinoma, Other specify.\n\nThe signal is driven by Infiltrating Lobular Carcinoma, where CDH1 loss is the well-known hallmark event, versus its near-absence in ductal cases."
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "3",
+    "run": "2",
+    "answer": "The description field uses multiple free-text templates. Extracting more robustly.**Chi-square statistic = 305.1239** (dof = 4, p ≈ 8.50e-65), indicating a highly significant association between histological type and CDH1 mutation status in female BRCA patients.\n\nContingency table used (n = 1,059 patients; histology categories with marginal total ≤ 10 excluded — `Metaplastic Carcinoma` (8), `Medullary Carcinoma` (6), `Infiltrating Carcinoma NOS` (1)):\n\n| Histological type | CDH1 mutated | Not mutated | Total |\n|---|---|---|---|\n| Infiltrating Ductal Carcinoma | 9 | 757 | 766 |\n| Infiltrating Lobular Carcinoma | 83 | 118 | 201 |\n| Mixed Histology (please specify) | 4 | 26 | 30 |\n| Mucinous Carcinoma | 0 | 17 | 17 |\n| Other specify | 3 | 42 | 45 |\n\nMethod: female BRCA patients parsed from `clinical_info.Patient_description` (1,075 patients; 1 with null `histological_type` dropped), CDH1 carriers taken as distinct `ParticipantBarcode` in `Mutation_Data` with `Hugo_Symbol = 'CDH1'` and `FILTER = 'PASS'` (reliable calls), joined via the reconstructed `TCGA-<tissue_source_site>-<patient_id>` barcode. The signal is driven by lobular carcinoma: 41.3% CDH1-mutated vs 1.2% in ductal carcinoma."
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "3",
+    "run": "3",
+    "answer": "**Chi-square statistic = 305.1239** (dof = 4, p ≈ 8.50e-65), indicating a highly significant association between histological type and CDH1 mutation status in female BRCA patients.\n\nHow it was computed:\n- **Cohort**: 1,075 female patients with \"Breast invasive carcinoma\" from `clinical_info` (gender and cancer type parsed from `Patient_description`), restricted to those with a non-null `histological_type`.\n- **Mutation status**: participants with at least one `Hugo_Symbol = 'CDH1'` row in `Mutation_Data` where `FILTER = 'PASS'` (reliable calls only), joined via the constructed barcode `TCGA-<tissue_source_site>-<patient_id>`.\n- **Marginal filter**: histology categories with row totals ≤ 10 were dropped (`Metaplastic Carcinoma` = 8, `Medullary Carcinoma` = 6, `Infiltrating Carcinoma NOS` = 1), leaving 5 categories and n = 1,059 patients.\n- Chi-square computed on the 5×2 table without Yates correction.\n\nThe signal is driven by Infiltrating Lobular Carcinoma, where CDH1 mutations are strongly enriched relative to Infiltrating Ductal Carcinoma — consistent with CDH1 (E-cadherin) loss being the defining molecular event of lobular breast cancer."
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "3",
+    "run": "4",
+    "answer": "The description field uses multiple sentence templates. Let me examine the variants.**χ² = 305.1239** (dof = 4, p = 8.50 × 10⁻⁶⁵, n = 1,059 patients).\n\nContingency table used (female BRCA patients with a non-null `histological_type`; CDH1 mutation = at least one `Mutation_Data` row with `Hugo_Symbol='CDH1'` and `FILTER='PASS'`; categories with marginal total ≤ 10 removed):\n\n| histological_type | Mutated | Not mutated | total |\n|---|---|---|---|\n| Infiltrating Ductal Carcinoma | 9 | 757 | 766 |\n| Infiltrating Lobular Carcinoma | 83 | 118 | 201 |\n| Mixed Histology (please specify) | 4 | 26 | 30 |\n| Mucinous Carcinoma | 0 | 17 | 17 |\n| Other  specify | 3 | 42 | 45 |\n\nCohort was built by joining the clinical `Patient_description` barcode (`TCGA-XX-XXXX`, parsed from the free text,1,075 female Breast invasive carcinoma patients) to `Mutation_Data.ParticipantBarcode`. The extremely strong association is driven by lobular carcinoma: 41% of lobular cases carry a reliable CDH1 mutation vs ~1% of ductal cases."
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "1",
+    "run": "0",
+    "answer": "I'll run the prescribed EMA recipe for level-5 CPC symbols with α=0.2, target year 2022.**72 level-5 CPC group codes have their filing-count EMA (α = 0.2) peaking in 2022:**\n\n`A22B`, `A23J`, `A23P`, `A24D`, `A24F`, `A41G`, `A47F`, `A61G`, `A61H`, `A61P`, `A62D`, `A63H`, `B04B`, `B07B`, `B08B`, `B09C`, `B21J`, `B22F`, `B24B`, `B25B`, `B25D`, `B27C`, `B27M`, `B60D`, `B60L`, `B60P`, `B61H`, `B63C`, `B63G`, `B65G`, `B66F`, `C01D`, `C01G`, `C21B`, `C21C`, `C22C`, `D21B`, `E01H`, `E02B`, `E02D`, `E03B`, `E04B`, `E04G`, `E21D`, `E21F`, `F02K`, `F04F`, `F16M`, `F25J`, `F26B`, `G01H`, `G01L`, `G01S`, `G05D`, `G06N`, `G06Q`, `G06T`, `G06V`, `G08G`, `G09F`, `G10L`, `G16B`, `G16C`, `G16H`, `G21F`, `H01M`, `H02B`, `H02G`, `H02J`, `H03H`, `H04K`, `H05F`\n\nMethod: 677 valid level-5 symbols taken from `cpc_definition.level == 5`; for each of the 277,813 publications, every `cpc[]` entry flagged `\"first\": true` was mapped to its 4-character ancestor (deduplicated per patent), `filing_date` parsed with `dateutil` fuzzy parsing (4,449 `'None Date'` rows excluded, 0 parse failures), and each symbol's zero-filled year series scored with `ewm(alpha=0.2, adjust=False).mean()`, taking the argmax year. 637 symbols had qualifying filings; 72 peak in 2022."
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "1",
+    "run": "1",
+    "answer": "I'll run the exact prescribed recipe for this question (level 5, alpha 0.2, target year 2022).The dump contains quote characters; parse with `QUOTE_NONE`.72 level-5 CPC group codes have their filing-count EMA (α = 0.2) peaking in 2022:\n\n`A22B, A23J, A23P, A24D, A24F, A41G, A47F, A61G, A61H, A61P, A62D, A63H, B04B, B07B, B08B, B09C, B21J, B22F, B24B, B25B, B25D, B27C, B27M, B60D, B60L, B60P, B61H, B63C, B63G, B65G, B66F, C01D, C01G, C21B, C21C, C22C, D21B, E01H, E02B, E02D, E03B, E04B, E04G, E21D, E21F, F02K, F04F, F16M, F25J, F26B, G01H, G01L, G01S, G05D, G06N, G06Q, G06T, G06V, G08G, G09F, G10L, G16B, G16C, G16H, G21F, H01M, H02B, H02G, H02J, H03H, H04K, H05F`\n\nMethod: for each of the 277,813 publications, all `cpc[]` entries flagged `\"first\": true` were collected and mapped to their 4-character ancestor, validated against the 677 symbols with `level = 5` in `cpc_definition` (637 such symbols actually appear in the data). `filing_date` was parsed with `dateutil` fuzzy parsing — 4,449 `'None Date'` rows excluded, **zero** parse failures on the remainder. Each symbol's yearly counts were zero-filled between its own first and last observed filing year, then smoothed with `ewm(alpha=0.2, adjust=False)`; the argmax year is that symbol's best year."
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "1",
+    "run": "2",
+    "answer": "I'll run the standard recipe for this computation: level-5 symbols, alpha 0.2, target peak year 2022.**72 level-5 CPC subclass codes have their filing-count EMA (α = 0.2) peaking in 2022:**\n\nA22B, A23J, A23P, A24D, A24F, A41G, A47F, A61G, A61H, A61P, A62D, A63H, B04B, B07B, B08B, B09C, B21J, B22F, B24B, B25B, B25D, B27C, B27M, B60D, B60L, B60P, B61H, B63C, B63G, B65G, B66F, C01D, C01G, C21B, C21C, C22C, D21B, E01H, E02B, E02D, E03B, E04B, E04G, E21D, E21F, F02K, F04F, F16M, F25J, F26B, G01H, G01L, G01S, G05D, G06N, G06Q, G06T, G06V, G08G, G09F, G10L, G16B, G16C, G16H, G21F, H01M, H02B, H02G, H02J, H03H, H04K, H05F\n\nMethod: all `first: true` CPC entries per patent mapped to their 4-character level-5 ancestor (validated against `cpc_definition.level == 5`, 677 valid symbols), `filing_date` parsed with `dateutil` fuzzy parsing (4,449 `'None Date'` rows skipped, 0 parse failures), per-symbol year counts zero-filled across each symbol's own observed range, then `ewm(alpha=0.2, adjust=False)` argmax. 637 level-5 symbols had filings; 72 peak in 2022."
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "1",
+    "run": "3",
+    "answer": "I'll run the prescribed EMA recipe on the patents dataset. Starting with the data sources.**72 level-5 CPC group codes have their EMA-of-annual-filings peak in 2022:**\n\n`A22B`, `A23J`, `A23P`, `A24D`, `A24F`, `A41G`, `A47F`, `A61G`, `A61H`, `A61P`, `A62D`, `A63H`, `B04B`, `B07B`, `B08B`, `B09C`, `B21J`, `B22F`, `B24B`, `B25B`, `B25D`, `B27C`, `B27M`, `B60D`, `B60L`, `B60P`, `B61H`, `B63C`, `B63G`, `B65G`, `B66F`, `C01D`, `C01G`, `C21B`, `C21C`, `C22C`, `D21B`, `E01H`, `E02B`, `E02D`, `E03B`, `E04B`, `E04G`, `E21D`, `E21F`, `F02K`, `F04F`, `F16M`, `F25J`, `F26B`, `G01H`, `G01L`, `G01S`, `G05D`, `G06N`, `G06Q`, `G06T`, `G06V`, `G08G`, `G09F`, `G10L`, `G16B`, `G16C`, `G16H`, `G21F`, `H01M`, `H02B`, `H02G`, `H02J`, `H03H`, `H04K`, `H05F`\n\nMethod: all 277,813 publications were scanned; `filing_date` parsed with `dateutil` fuzzy parsing (4,449 `'None Date'` rows skipped, 0 parse failures). For each patent, every `cpc[]` entry flagged `\"first\": true` was mapped to its 4-character ancestor and validated against the 677 symbols with `level = 5` in `cpc_definition` (deduped per patent per symbol), yielding 637 populated symbols. Each symbol's yearly count series was zero-filled between its own first and last observed filing year, smoothed with `ewm(alpha=0.2, adjust=False)`, and the argmax year taken as its best year."
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "1",
+    "run": "4",
+    "answer": "I'll run the prescribed EMA recipe on this dataset.Loaded 260,808 CPC definition rows; 677 symbols at level 5.72 level-5 CPC group codes have their highest EMA (α = 0.2) of annual patent filings peaking in 2022:\n\n`A22B`, `A23J`, `A23P`, `A24D`, `A24F`, `A41G`, `A47F`, `A61G`, `A61H`, `A61P`, `A62D`, `A63H`, `B04B`, `B07B`, `B08B`, `B09C`, `B21J`, `B22F`, `B24B`, `B25B`, `B25D`, `B27C`, `B27M`, `B60D`, `B60L`, `B60P`, `B61H`, `B63C`, `B63G`, `B65G`, `B66F`, `C01D`, `C01G`, `C21B`, `C21C`, `C22C`, `D21B`, `E01H`, `E02B`, `E02D`, `E03B`, `E04B`, `E04G`, `E21D`, `E21F`, `F02K`, `F04F`, `F16M`, `F25J`, `F26B`, `G01H`, `G01L`, `G01S`, `G05D`, `G06N`, `G06Q`, `G06T`, `G06V`, `G08G`, `G09F`, `G10L`, `G16B`, `G16C`, `G16H`, `G21F`, `H01M`, `H02B`, `H02G`, `H02J`, `H03H`, `H04K`, `H05F`\n\nMethod notes: for each of the 277,813 patents, every `cpc[]` entry flagged `\"first\": true` was mapped to its 4-character level-5 ancestor (validated against `cpc_definition.level == 5`,677 such symbols), deduplicated per patent; `filing_date` was parsed with `dateutil.parser.parse(..., fuzzy=True)` (4,449 `'None Date'` rows excluded, **0** parse failures); each of the 637 populated symbols got a zero-filled year series over its own min–max filing year, then `ewm(alpha=0.2, adjust=False).mean().idxmax()`."
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "2",
+    "run": "0",
+    "answer": "23 CPC level-4 groups from German (DE) patents granted in the second half of 2019, each with its highest-EMA (α = 0.1) filing year:\n\n| CPC group | Full title | Best year |\n|---|---|---|\n| A21 | BAKING; EDIBLE DOUGHS | 2015 |\n| A61 | MEDICAL OR VETERINARY SCIENCE; HYGIENE | 2016 |\n| B23 | MACHINE TOOLS; METAL-WORKING NOT OTHERWISE PROVIDED FOR | 2015 |\n| B29 | WORKING OF PLASTICS; WORKING OF SUBSTANCES IN A PLASTIC STATE IN GENERAL | 2007 |\n| B41 | PRINTING; LINING MACHINES; TYPEWRITERS; STAMPS | 2007 |\n| B60 | VEHICLES IN GENERAL | 2009 |\n| B62 | LAND VEHICLES FOR TRAVELLING OTHERWISE THAN ON RAILS | 2010 |\n| B63 | SHIPS OR OTHER WATERBORNE VESSELS; RELATED EQUIPMENT | 2014 |\n| C09 | DYES; PAINTS; POLISHES; NATURAL RESINS; ADHESIVES; COMPOSITIONS NOT OTHERWISE PROVIDED FOR; APPLICATIONS OF MATERIALS NOT OTHERWISE PROVIDED FOR | 2015 |\n| E02 | HYDRAULIC ENGINEERING; FOUNDATIONS; SOIL SHIFTING | 2012 |\n| E05 | LOCKS; KEYS; WINDOW OR DOOR FITTINGS; SAFES | 2012 |\n| F02 | COMBUSTION ENGINES; HOT-GAS OR COMBUSTION-PRODUCT ENGINE PLANTS | 2010 |\n| F16 | ENGINEERING ELEMENTS AND UNITS; GENERAL MEASURES FOR PRODUCING AND MAINTAINING EFFECTIVE FUNCTIONING OF MACHINES OR INSTALLATIONS; THERMAL INSULATION IN GENERAL | 2009 |\n| F23 | COMBUSTION APPARATUS; COMBUSTION PROCESSES | 2018 |\n| F24 | HEATING; RANGES; VENTILATING | 2018 |\n| F41 | WEAPONS | 2012 |\n| G01 | MEASURING; TESTING | 2008 |\n| G02 | OPTICS | 2016 |\n| G08 | SIGNALLING | 2017 |\n| H01 | ELECTRIC ELEMENTS | 2008 |\n| H02 | GENERATION; CONVERSION OR DISTRIBUTION OF ELECTRIC POWER | 2009 |\n| H03 | ELECTRONIC CIRCUITRY | 2015 |\n| H04 | ELECTRIC COMMUNICATION TECHNIQUE | 2015 |\n\nScope: 34 DE-jurisdiction patents (jurisdiction taken from the application number in `Patents_info`) with `grant_date` between 2019-07-01 and 2019-12-31; all 34 mapped to at least one level-4 group via their `first: true` CPC entries, spanning exactly these 23 distinct groups."
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "2",
+    "run": "1",
+    "answer": "I'll work through this in steps: scope the German cohort granted in H2 2019, map their primary CPC codes to level-4 groups, then compute per-group EMA peak years.**A21 | 2015 | BAKING; EDIBLE DOUGHS**\n**A61 | 2016 | MEDICAL OR VETERINARY SCIENCE; HYGIENE**\n**B23 | 2015 | MACHINE TOOLS; METAL-WORKING NOT OTHERWISE PROVIDED FOR**\n**B29 | 2007 | WORKING OF PLASTICS; WORKING OF SUBSTANCES IN A PLASTIC STATE IN GENERAL**\n**B41 | 2007 | PRINTING; LINING MACHINES; TYPEWRITERS; STAMPS**\n**B60 | 2009 | VEHICLES IN GENERAL**\n**B62 | 2010 | LAND VEHICLES FOR TRAVELLING OTHERWISE THAN ON RAILS**\n**B63 | 2014 | SHIPS OR OTHER WATERBORNE VESSELS; RELATED EQUIPMENT**\n**C09 | 2015 | DYES; PAINTS; POLISHES; NATURAL RESINS; ADHESIVES; COMPOSITIONS NOT OTHERWISE PROVIDED FOR; APPLICATIONS OF MATERIALS NOT OTHERWISE PROVIDED FOR**\n**E02 | 2012 | HYDRAULIC ENGINEERING; FOUNDATIONS; SOIL SHIFTING**\n**E05 | 2012 | LOCKS; KEYS; WINDOW OR DOOR FITTINGS; SAFES**\n**F02 | 2010 | COMBUSTION ENGINES; HOT-GAS OR COMBUSTION-PRODUCT ENGINE PLANTS**\n**F16 | 2009 | ENGINEERING ELEMENTS AND UNITS; GENERAL MEASURES FOR PRODUCING AND MAINTAINING EFFECTIVE FUNCTIONING OF MACHINES OR INSTALLATIONS; THERMAL INSULATION IN GENERAL**\n**F23 | 2018 | COMBUSTION APPARATUS; COMBUSTION PROCESSES**\n**F24 | 2018 | HEATING; RANGES; VENTILATING**\n**F41 | 2012 | WEAPONS**\n**G01 | 2008 | MEASURING; TESTING**\n**G02 | 2016 | OPTICS**\n**G08 | 2017 | SIGNALLING**\n**H01 | 2008 | ELECTRIC ELEMENTS**\n**H02 | 2009 | GENERATION; CONVERSION OR DISTRIBUTION OF ELECTRIC POWER**\n**H03 | 2015 | ELECTRONIC CIRCUITRY**\n**H04 | 2015 | ELECTRIC COMMUNICATION TECHNIQUE**\n\nMethod:34 DE-jurisdiction patents (jurisdiction taken from the application/publication number in `Patents_info`) with a `grant_date` between 2019-07-01 and 2019-12-31; every `first: true` CPC entry of each patent mapped to its 3-character level-4 ancestor (validated against `cpc_definition.level == 4`), deduped per patent; filing years parsed with `dateutil` fuzzy parsing; per-group EMA computed with `ewm(alpha=0.1, adjust=False)` on that cohort's own filing-year counts, taking the argmax year. The 34 scoped patents span exactly these 23 distinct level-4 groups, all listed."
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "2",
+    "run": "2",
+    "answer": "23 CPC level-4 groups, with their best (highest-EMA) filing year:\n\n| CPC group | Best year | Full title |\n|---|---|---|\n| A21 | 2015 | BAKING; EDIBLE DOUGHS |\n| A61 | 2016 | MEDICAL OR VETERINARY SCIENCE; HYGIENE |\n| B23 | 2015 | MACHINE TOOLS; METAL-WORKING NOT OTHERWISE PROVIDED FOR |\n| B29 | 2007 | WORKING OF PLASTICS; WORKING OF SUBSTANCES IN A PLASTIC STATE IN GENERAL |\n| B41 | 2007 | PRINTING; LINING MACHINES; TYPEWRITERS; STAMPS |\n| B60 | 2009 | VEHICLES IN GENERAL |\n| B62 | 2010 | LAND VEHICLES FOR TRAVELLING OTHERWISE THAN ON RAILS |\n| B63 | 2014 | SHIPS OR OTHER WATERBORNE VESSELS; RELATED EQUIPMENT |\n| C09 | 2015 | DYES; PAINTS; POLISHES; NATURAL RESINS; ADHESIVES; COMPOSITIONS NOT OTHERWISE PROVIDED FOR; APPLICATIONS OF MATERIALS NOT OTHERWISE PROVIDED FOR |\n| E02 | 2012 | HYDRAULIC ENGINEERING; FOUNDATIONS; SOIL SHIFTING |\n| E05 | 2012 | LOCKS; KEYS; WINDOW OR DOOR FITTINGS; SAFES |\n| F02 | 2010 | COMBUSTION ENGINES; HOT-GAS OR COMBUSTION-PRODUCT ENGINE PLANTS |\n| F16 | 2009 | ENGINEERING ELEMENTS AND UNITS; GENERAL MEASURES FOR PRODUCING AND MAINTAINING EFFECTIVE FUNCTIONING OF MACHINES OR INSTALLATIONS; THERMAL INSULATION IN GENERAL |\n| F23 | 2018 | COMBUSTION APPARATUS; COMBUSTION PROCESSES |\n| F24 | 2018 | HEATING; RANGES; VENTILATING |\n| F41 | 2012 | WEAPONS |\n| G01 | 2008 | MEASURING; TESTING |\n| G02 | 2016 | OPTICS |\n| G08 | 2017 | SIGNALLING |\n| H01 | 2008 | ELECTRIC ELEMENTS |\n| H02 | 2009 | GENERATION; CONVERSION OR DISTRIBUTION OF ELECTRIC POWER |\n| H03 | 2015 | ELECTRONIC CIRCUITRY |\n| H04 | 2015 | ELECTRIC COMMUNICATION TECHNIQUE |\n\nScope: 34 DE-jurisdiction patents granted 2019-07-01 → 2019-12-31 (jurisdiction taken from the application number in `Patents_info`), spanning exactly these 23 distinct level-4 groups. Each group's peak year is the argmax of `ewm(alpha=0.1, adjust=False)` over that group's own scoped filing-year counts; all `first: true` CPC entries per patent were used, deduplicated per group."
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "2",
+    "run": "3",
+    "answer": "The23 CPC level-4 technology areas in Germany (patents granted in H2 2019), each with its highest-EMA year (α=0.1):\n\n| CPC group | Full title | Best year |\n|---|---|---|\n| A21 | BAKING; EDIBLE DOUGHS | 2015 |\n| A61 | MEDICAL OR VETERINARY SCIENCE; HYGIENE | 2016 |\n| B23 | MACHINE TOOLS; METAL-WORKING NOT OTHERWISE PROVIDED FOR | 2015 |\n| B29 | WORKING OF PLASTICS; WORKING OF SUBSTANCES IN A PLASTIC STATE IN GENERAL | 2007 |\n| B41 | PRINTING; LINING MACHINES; TYPEWRITERS; STAMPS | 2007 |\n| B60 | VEHICLES IN GENERAL | 2009 |\n| B62 | LAND VEHICLES FOR TRAVELLING OTHERWISE THAN ON RAILS | 2010 |\n| B63 | SHIPS OR OTHER WATERBORNE VESSELS; RELATED EQUIPMENT | 2014 |\n| C09 | DYES; PAINTS; POLISHES; NATURAL RESINS; ADHESIVES; COMPOSITIONS NOT OTHERWISE PROVIDED FOR; APPLICATIONS OF MATERIALS NOT OTHERWISE PROVIDED FOR | 2015 |\n| E02 | HYDRAULIC ENGINEERING; FOUNDATIONS; SOIL SHIFTING | 2012 |\n| E05 | LOCKS; KEYS; WINDOW OR DOOR FITTINGS; SAFES | 2012 |\n| F02 | COMBUSTION ENGINES; HOT-GAS OR COMBUSTION-PRODUCT ENGINE PLANTS | 2010 |\n| F16 | ENGINEERING ELEMENTS AND UNITS; GENERAL MEASURES FOR PRODUCING AND MAINTAINING EFFECTIVE FUNCTIONING OF MACHINES OR INSTALLATIONS; THERMAL INSULATION IN GENERAL | 2009 |\n| F23 | COMBUSTION APPARATUS; COMBUSTION PROCESSES | 2018 |\n| F24 | HEATING; RANGES; VENTILATING | 2018 |\n| F41 | WEAPONS | 2012 |\n| G01 | MEASURING; TESTING | 2008 |\n| G02 | OPTICS | 2016 |\n| G08 | SIGNALLING | 2017 |\n| H01 | ELECTRIC ELEMENTS | 2008 |\n| H02 | GENERATION; CONVERSION OR DISTRIBUTION OF ELECTRIC POWER | 2009 |\n| H03 | ELECTRONIC CIRCUITRY | 2015 |\n| H04 | ELECTRIC COMMUNICATION TECHNIQUE | 2015 |\n\nScope: 34 patents with a `DE-` application/publication jurisdiction granted between 2019-07-01 and 2019-12-31, spanning exactly these 23 distinct level-4 groups. Every `first: true` CPC entry per patent was mapped to its3-character level-4 ancestor (validated against `cpc_definition.level == 4`), filing years parsed with a fuzzy date parser (0 parse failures), and the EMA computed with `ewm(alpha=0.1, adjust=False)` on each group's own scoped filing-year series. Highest EMA values: A61 and H04 at 2.0 (2 filings in a single year); all others 1.0."
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "2",
+    "run": "4",
+    "answer": "All 23 level‑4 CPC groups for German (DE) patents granted in H2 2019, with their highest‑EMA (α = 0.1) filing year:\n\n| CPC group | Best year | Full title |\n|---|---|---|\n| A21 | 2015 | BAKING; EDIBLE DOUGHS |\n| A61 | 2016 | MEDICAL OR VETERINARY SCIENCE; HYGIENE |\n| B23 | 2015 | MACHINE TOOLS; METAL-WORKING NOT OTHERWISE PROVIDED FOR |\n| B29 | 2007 | WORKING OF PLASTICS; WORKING OF SUBSTANCES IN A PLASTIC STATE IN GENERAL |\n| B41 | 2007 | PRINTING; LINING MACHINES; TYPEWRITERS; STAMPS |\n| B60 | 2009 | VEHICLES IN GENERAL |\n| B62 | 2010 | LAND VEHICLES FOR TRAVELLING OTHERWISE THAN ON RAILS |\n| B63 | 2014 | SHIPS OR OTHER WATERBORNE VESSELS; RELATED EQUIPMENT |\n| C09 | 2015 | DYES; PAINTS; POLISHES; NATURAL RESINS; ADHESIVES; COMPOSITIONS NOT OTHERWISE PROVIDED FOR; APPLICATIONS OF MATERIALS NOT OTHERWISE PROVIDED FOR |\n| E02 | 2012 | HYDRAULIC ENGINEERING; FOUNDATIONS; SOIL SHIFTING |\n| E05 | 2012 | LOCKS; KEYS; WINDOW OR DOOR FITTINGS; SAFES |\n| F02 | 2010 | COMBUSTION ENGINES; HOT-GAS OR COMBUSTION-PRODUCT ENGINE PLANTS |\n| F16 | 2009 | ENGINEERING ELEMENTS AND UNITS; GENERAL MEASURES FOR PRODUCING AND MAINTAINING EFFECTIVE FUNCTIONING OF MACHINES OR INSTALLATIONS; THERMAL INSULATION IN GENERAL |\n| F23 | 2018 | COMBUSTION APPARATUS; COMBUSTION PROCESSES |\n| F24 | 2018 | HEATING; RANGES; VENTILATING |\n| F41 | 2012 | WEAPONS |\n| G01 | 2008 | MEASURING; TESTING |\n| G02 | 2016 | OPTICS |\n| G08 | 2017 | SIGNALLING |\n| H01 | 2008 | ELECTRIC ELEMENTS |\n| H02 | 2009 | GENERATION; CONVERSION OR DISTRIBUTION OF ELECTRIC POWER |\n| H03 | 2015 | ELECTRONIC CIRCUITRY |\n| H04 | 2015 | ELECTRIC COMMUNICATION TECHNIQUE |\n\nMethod: scoped to the DE jurisdiction code embedded in `Patents_info` plus a grant date parsed (fuzzy) into Jul–Dec 2019 → 34 patents; every `first: true` CPC entry mapped to its 3-character level‑4 ancestor validated against `cpc_definition.level == 4` (deduped per patent) → 23 distinct groups; per group, filing-year counts within that cohort smoothed with `ewm(alpha=0.1, adjust=False)` and the argmax year reported."
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "3",
+    "run": "0",
+    "answer": "I'll start by exploring the data and locating UNIV CALIFORNIA patents.Three assignees other than UNIV CALIFORNIA cite UNIV CALIFORNIA patents:\n\n- **BLOOM ENERGY CORP | H01M | PROCESSES OR MEANS, e.g. BATTERIES, FOR THE DIRECT CONVERSION OF CHEMICAL ENERGY INTO ELECTRICAL ENERGY**\n- **CRYSTAL IS INC | C30B | SINGLE-CRYSTAL GROWTH; UNIDIRECTIONAL SOLIDIFICATION OF EUTECTIC MATERIAL OR UNIDIRECTIONAL DEMIXING OF EUTECTOID MATERIAL; REFINING BY ZONE-MELTING OF MATERIAL; PRODUCTION OF A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; SINGLE CRYSTALS OR HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; AFTER-TREATMENT OF SINGLE CRYSTALS OR A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; APPARATUS THEREFOR**\n- **SCHOWALTER LEO J | H01L | SEMICONDUCTOR DEVICES NOT COVERED BY CLASS H10**\n\nSupporting detail: 167 publications have the exact assignee `UNIV CALIFORNIA`; exactly 3 other-assignee publications cite one of those publication numbers (BLOOM ENERGY CORP cites `US-6767662-B2`; CRYSTAL IS INC and SCHOWALTER LEO J each cite `US-2010025717-A1`). Each citing patent's `first: true` CPC entries all map to a single level-5 subclass, whose `titleFull` is taken from `cpc_definition`."
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "3",
+    "run": "1",
+    "answer": "73,573 rows failed assignee parsing — let me inspect those sentence shapes before proceeding.Three assignees other than UNIV CALIFORNIA cite UNIV CALIFORNIA patents:\n\n- **BLOOMENERGY CORP** | H01M | PROCESSES OR MEANS, e.g. BATTERIES, FOR THE DIRECT CONVERSION OF CHEMICAL ENERGY INTO ELECTRICAL ENERGY\n- **CRYSTAL IS INC** | C30B | SINGLE-CRYSTAL GROWTH; UNIDIRECTIONAL SOLIDIFICATION OF EUTECTIC MATERIAL OR UNIDIRECTIONAL DEMIXING OF EUTECTOID MATERIAL; REFINING BY ZONE-MELTING OF MATERIAL; PRODUCTION OF A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; SINGLE CRYSTALS OR HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; AFTER-TREATMENT OF SINGLE CRYSTALS OR A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; APPARATUS THEREFOR\n- **SCHOWALTER LEO J** | H01L | SEMICONDUCTOR DEVICES NOT COVERED BY CLASS H10\n\nSupporting detail: UNIV CALIFORNIA holds 167 publications in the dataset (exact assignee-string match). Scanning all 277,813 patents' `citation[]` arrays found exactly 3 patents citing one of those publications — BLOOM ENERGY CORP's US-10615444-B2 (cites US-6767662-B2), CRYSTAL IS INC's US-9447521-B2 and SCHOWALTER LEO J's US-9437430-B2 (both cite US-2010025717-A1). Each citing patent's `first: true` CPC codes map to a single level-5 subclass, whose `titleFull` came from `cpc_definition`."
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "3",
+    "run": "2",
+    "answer": "Three assignees cite UNIV CALIFORNIA patents:\n\n- **BLOOM ENERGY CORP | H01M | PROCESSES OR MEANS, e.g. BATTERIES, FOR THE DIRECT CONVERSION OF CHEMICAL ENERGY INTO ELECTRICAL ENERGY**\n- **CRYSTAL IS INC | C30B | SINGLE-CRYSTAL GROWTH; UNIDIRECTIONAL SOLIDIFICATION OF EUTECTIC MATERIAL OR UNIDIRECTIONAL DEMIXING OF EUTECTOID MATERIAL; REFINING BY ZONE-MELTING OF MATERIAL; PRODUCTION OF A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; SINGLE CRYSTALS OR HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; AFTER-TREATMENT OF SINGLE CRYSTALS OR A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; APPARATUS THEREFOR**\n- **SCHOWALTER LEO J | H01L | SEMICONDUCTOR DEVICES NOT COVERED BY CLASS H10**\n\nSupporting detail: 167 publications in the dataset are assigned to UNIV CALIFORNIA (exact-string match on the assignee embedded in `Patents_info`). Exactly three non-UC patents list one of those publications in their `citation[]` array — `US-10615444-B2` (BLOOM ENERGY CORP, citing UC's `US-6767662-B2`), `US-9447521-B2` (CRYSTAL IS INC, citing UC's `US-2010025717-A1`), and `US-9437430-B2` (SCHOWALTER LEO J, citing the same UC publication). Each citing patent's `first: true` CPC codes all map to a single level-5 subclass, whose `titleFull` is taken from `cpc_definition`."
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "3",
+    "run": "3",
+    "answer": "Three assignees — **BLOOM ENERGY CORP**, **CRYSTAL IS INC**, and **SCHOWALTER LEO J** — cite patents assigned to UNIV CALIFORNIA, with these primary CPC subclasses:\n\n- **BLOOM ENERGY CORP** | H01M | PROCESSES OR MEANS, e.g. BATTERIES, FOR THE DIRECT CONVERSION OF CHEMICAL ENERGY INTO ELECTRICAL ENERGY\n- **CRYSTAL IS INC** | C30B | SINGLE-CRYSTAL GROWTH; UNIDIRECTIONAL SOLIDIFICATION OF EUTECTIC MATERIAL OR UNIDIRECTIONAL DEMIXING OF EUTECTOID MATERIAL; REFINING BY ZONE-MELTING OF MATERIAL; PRODUCTION OF A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; SINGLE CRYSTALS OR HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; AFTER-TREATMENT OF SINGLE CRYSTALS OR A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; APPARATUS THEREFOR\n- **SCHOWALTER LEO J** | H01L | SEMICONDUCTOR DEVICES NOT COVERED BY CLASS H10\n\nSupporting detail: UNIV CALIFORNIA (exact-string match on the assignee parsed out of `Patents_info`) owns 167 publications in the dataset. Three other patents cite one of those publications — US-10615444-B2 (Bloom Energy, cites US-6767662-B2), US-9447521-B2 (Crystal IS, cites US-2010025717-A1), and US-9437430-B2 (Schowalter Leo J, cites US-2010025717-A1). Each citing patent's `first: true` CPC entries all map to a single level-5 subclass, whose `titleFull` was read from `cpc_definition`."
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "3",
+    "run": "4",
+    "answer": "Three assignees (other than UNIV CALIFORNIA) cite UNIV CALIFORNIA patents:\n\n- **BLOOM ENERGY CORP** | H01M | PROCESSES OR MEANS, e.g. BATTERIES, FOR THE DIRECT CONVERSION OF CHEMICAL ENERGY INTO ELECTRICAL ENERGY\n- **CRYSTAL IS INC** | C30B | SINGLE-CRYSTAL GROWTH; UNIDIRECTIONAL SOLIDIFICATION OF EUTECTIC MATERIAL OR UNIDIRECTIONAL DEMIXING OF EUTECTOID MATERIAL; REFINING BY ZONE-MELTING OF MATERIAL; PRODUCTION OF A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; SINGLE CRYSTALS OR HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; AFTER-TREATMENT OF SINGLE CRYSTALS OR A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; APPARATUS THEREFOR\n- **SCHOWALTER LEO J** | H01L | SEMICONDUCTOR DEVICES NOT COVERED BY CLASS H10\n\nDetails: UNIV CALIFORNIA has 167 publications in the dataset; exactly three non-UC-assigned patents cite one of them — BLOOM ENERGY CORP's US-10615444-B2 (cites US-6767662-B2), CRYSTAL IS INC's US-9447521-B2 and SCHOWALTER LEO J's US-9437430-B2 (both cite US-2010025717-A1). Subclass titles come from the level-5 `cpc_definition` entries for the 4-character ancestors of each citing patent's `first: true` CPC codes."
+  },
+  {
+    "dataset": "agnews",
+    "query": "1",
+    "run": "0",
+    "answer": "**\"The Rundown\"** — article_id 69413, whose description is 841 characters, the longest of any Sports-topic article in the collection.\n\nThe description is a college-football preview (No. 4 Miami at N.C. State, ACC standings, Brock Berlin, T.A. McLendon), clearly Sports.\n\nHow this was established:\n- Decoded all 127,600 documents from `articles_db/articles.bson`; max description length overall is 985 chars.\n- Reviewed every article with `desc_len > 700` (162 articles) and judged each one's AG News topic from its title + description. Everything longer than 841 chars is Sci/Tech, Business, or World (RSS bandwidth, IT mistakes, IBM/Sybase, Nokia, Kyoto protocol, PeopleSoft/Oracle, US Senate outlook, Kodak earnings, Bush in Canada, etc.).\n- The next-longest Sports items confirm the ranking: \"Cavaliers, Hokies Play Host\" (773), \"Area College Football Capsules\" (761), \"Navy Is Ready to Run Against Vanderbilt\" (713).\n\nNote: several distinct articles share the generic title \"The Rundown\"; the specific one with the longest description is article_id 69413."
+  },
+  {
+    "dataset": "agnews",
+    "query": "1",
+    "run": "1",
+    "answer": "**\"The Rundown\"** — article_id 69413, with a 841-character description, is the Sports article with the longest description.\n\nHow this was determined:\n- Decoded all 127,600 documents from the Mongo BSON dump and ranked by `len(description)`. The global max is 985 chars.\n- Reviewed every article with a description ≥ 830 chars (46 articles) and judged each one's AG News topic from its title + description. All 45 longer ones are Sci/Tech (RSS/IT/Nokia/Nvidia/Google Scholar/product previews), Business (PeopleSoft, Kodak, Sprint–Nextel, Sony–Ampex), or World (Bush in Canada, Kyoto, US Senate outlook) — none are Sports.\n- Article 69413 is a college-football game preview (No. 4 Miami at N.C. State, ACC standings, Brock Berlin, T.A. McLendon), making it unambiguously Sports and the longest such description."
+  },
+  {
+    "dataset": "agnews",
+    "query": "1",
+    "run": "2",
+    "answer": "**\"The Rundown\"** — a college football preview (Miami at N.C. State), with a 841-character description; it's article_id `69413`.\n\nHow it was determined:\n- Decoded all 127,600 documents from the `articles.bson` mongodump and computed `len(description)`.\n- Inspected every article with a description longer than 841 characters (39 of them) — all are Sci/Tech (RSS/IT/Nokia/Nvidia/Microsoft), Business (PeopleSoft, Kodak, Sprint‑Nextel), or World/politics (Kyoto, Senate outlook, Bush in Canada) stories; none is a Sports article.\n- The longest genuine Sports item is thisACC football game preview (Wolfpack defense, Brock Berlin, T.A. McLendon), so no longer Sports description exists.\n- Its metadata in SQLite: author **Matthew Smith**, region **Europe**, published **::camber-date-time[2010-11-22T00:00:00Z]**."
+  },
+  {
+    "dataset": "agnews",
+    "query": "1",
+    "run": "3",
+    "answer": "**\"The Rundown\"** — a 841-character college-football preview (Miami at N.C. State, article_id 69413) is the Sports article with the longest `description`.\n\nVerification: all 127,600 descriptions were ranked by character length; the 39 articles with descriptions longer than 841 characters were individually checked and are all Sci/Tech, Business, or World stories (IT/enterprise-software pieces, Nokia/Nvidia/Kodak corporate news, Kyoto protocol, US Senate outlook, etc.) — none is Sports. Article 69413's text is unambiguously Sports (ACC standings, defense yards per game, tailback hamstring injury), and it is the unique article at that length."
+  },
+  {
+    "dataset": "agnews",
+    "query": "1",
+    "run": "4",
+    "answer": "I need to inspect the actual candidate text to judge topic.**The Rundown** — article_id 69413, with a 841-character description.\n\nIt's a college-football preview (\"4 Miami at N.C. State …ESPN … The Wolfpack's defense is the best in the nation against the pass\"), clearly Sports. All 38 articles with longer descriptions (841–985 chars) are Sci/Tech, Business, or World stories (e.g. \"Making RSS Scale\" at 985, \"The top 20 IT mistakes to avoid\" at 974, \"2004 US Senate Outlook\" at 944, \"Finding the Best Programmer's Font\" at 844) — none are sports. The next-longest sports items are \"Cavaliers, Hokies Play Host\" (773) and \"Area College Football Capsules\" (761)."
+  },
+  {
+    "dataset": "agnews",
+    "query": "2",
+    "run": "0",
+    "answer": "Loaded: 127,600 articles, 111 by Amy Jones. Now building the classifier.**About 15% —17 of Amy Jones's 111 articles are Sci/Tech (0.153).**\n\nBreakdown of her 111 articles after classifying each one's title + description into the four AG News topics:\n\n| Category | Articles | Share |\n|---|---|---|\n| Business | 34 | 30.6% |\n| World | 31 | 27.9% |\n| Sports | 29 | 26.1% |\n| **Sci/Tech** | **17** | **15.3%** |\n\nMethod notes: the 111 articleids came from joining `authors` → `article_metadata` in SQLite, with text pulled from the Mongo BSON dump. Since no topic column exists, each article was scored with a weighted topical lexicon calibrated against AG News's known ~25/25/25/25 global class balance (final full-corpus mix: World 26.7%, Sci/Tech 24.7%, Sports 24.7%, Business 23.9%), then borderline cases were reviewed with rules such as \"a chip/satellite company's earnings report is Business, not Sci/Tech.\" Given classifier uncertainty, treat the answer as ≈15% (roughly 16–19 of 111) rather than an exact count."
+  },
+  {
+    "dataset": "agnews",
+    "query": "2",
+    "run": "1",
+    "answer": "Amy Jones has 111 articles. Now classifying all 127,600 with a calibrated lexicon and computing her Sci/Tech share.Global mix was slightly skewed (22–29%), so refining with a self-trained classifier bootstrapped from high-confidence lexicon seeds.**About 17–18% of Amy Jones's articles are Sci/Tech — roughly 19–20 of her 111 articles (≈0.18).**\n\nHow this was derived:\n- SQLite `authors` → one matching author, **Amy Jones**; `article_metadata` gives her **111** article_ids, which were joined in pandas to the Mongo BSON `articles` dump (127,600 docs) to get title + description.\n- Since the data has no topic column, each article was classified into AG News's four topics (World, Sports, Business, Sci/Tech) from its own text only, using two independent classifiers built locally:\n  1. A weighted 4-topic lexicon over title+description, bias-calibrated toward AG News's known ~25/25/25/25 global balance → **20/111 = 18.0%**\n  2. A TF-IDF + logistic-regression model trained on ~52.8k high-confidence, class-balanced pseudo-labels from the corpus itself → **19/111 = 17.1%** (global mix 25.4% Sci/Tech, well calibrated)\n- The two methods agree on 85.6% of her articles overall and both land at the same fraction within one article, so **≈0.17–0.18 (about one in six)** is the robust estimate; the single best point estimate is **0.18**."
+  },
+  {
+    "dataset": "agnews",
+    "query": "2",
+    "run": "2",
+    "answer": "111 Amy Jones articles and all 127,600 documents are loaded. Now building the classifier.**About 15% — roughly 17 of Amy Jones' 111 articles are Science/Technology (fraction ≈ 0.15).**\n\nDetails:\n- Amy Jones has **111** articles in `article_metadata` (all111 article_ids matched documents in the Mongo `articles` collection).\n- Each article's topic was classified from its own `title` + `description` text using a weighted-lexicon classifier over AG News' 4 topics, calibrated so the full 127,600-article corpus predicts a near-balanced mix (Sports 26.9%, Sci/Tech 24.4%, Business 25.0%, World 23.7%).\n- Amy Jones' breakdown: Business 32, Sports 31, World 31, **Sci/Tech 17** → 17/111 = **0.153**.\n- The uncalibrated run gave 16/111 = 0.144, so the Sci/Tech share is stable at **~14–15%**, i.e. below the ~25% corpus baseline."
+  },
+  {
+    "dataset": "agnews",
+    "query": "2",
+    "run": "3",
+    "answer": "**About 25% —28 of Amy Jones's 111 articles classify as Sci/Tech (28/111 ≈ 0.25).**\n\nHow it was derived:\n- SQLite `authors` matched exactly one author named **Amy Jones**; `article_metadata` gives her **111** articles.\n- Article text was read straight from the Mongo BSON dump (127,600 docs) and joined on `article_id` in pandas.\n- Each article was topic-labeled by a single weighted-lexicon classifier over **title + description** (strong topic terms weighted 3×, weak terms 1×, sports vocabulary given precedence; a tech firm's earnings/merger story scores Business, its product/security story scores Sci/Tech).\n- Calibration check against AG News's known ~25/25/25/25 balance across the full corpus: World 26.0%, Sports 23.9%, Business 20.5%, Sci/Tech 29.6% — close to balanced, with a mild Sci/Tech lean, so Amy's true Sci/Tech share is likely at or slightly below 25%.\n\nHer full predicted breakdown: World 32, Sci/Tech 28, Sports 26, Business 25."
+  },
+  {
+    "dataset": "agnews",
+    "query": "2",
+    "run": "4",
+    "answer": "**About 16% —18 of Amy Jones's 111 articles are Sci/Tech (fraction ≈ 0.16).**\n\nHow it was derived:\n- SQLite `authors` ⋈ `article_metadata` → Amy Jones has exactly **111** articles.\n- Article text pulled from the Mongo BSON dump (127,600 docs) and joined on `article_id` in pandas.\n- Topics were classified in-session from `title` + `description` with a weighted 4-class AG News lexicon, calibrated so the full-corpus label mix matches AG News's known balance (final global mix: World 25.4%, Business 25.1%, Sports 24.9%, Sci/Tech 24.6%).\n- Amy Jones breakdown: World 34, Sports 30, Business 29, **Sci/Tech 18**.\n\nNote: since the dataset carries no topic column, the 18 is a derived classification, so the fraction is an estimate (~0.16) rather than a stored ground-truth value."
+  },
+  {
+    "dataset": "agnews",
+    "query": "3",
+    "run": "0",
+    "answer": "I'll load both sources, join them, then classify topics myself from the article text.**≈335 business articles per year** (335.27) were published in Europe from 2010 to 2020— 3,688 Business-topic articles spread over 11 years.\n\nHow this was derived:\n- Joined all 127,600 Mongo BSON articles to the SQLite `article_metadata` on `article_id` (clean 1:1 join, no key-format issues), then filtered `region ='Europe'` and `publication_date` year 2010–2020 → 14,860 articles.\n- Since no topic column exists, each article's topic was classified from its own `title` + `description`: a weighted lexicon with tie-break rules produced 45,059 high-confidence seed labels, which trained a TF-IDF logistic regression that labeled the full corpus. Predicted mix was calibrated to AG News' known 25/25/25/25 class balance (seed agreement 99.9%).\n- Business counts by year range from 305 (2016) to 371 (2019), averaging 335.27."
+  },
+  {
+    "dataset": "agnews",
+    "query": "3",
+    "run": "1",
+    "answer": "Global mix is Business-skewed (33.5% vs known ~25%), so the classifier needs recalibration before trusting the subset.**≈ 336 business articles per year** (3,695 Business-classified Europe articles over 2010–2020 ÷ 11 years = 335.9/year).\n\nMethod:\n- SQLite `article_metadata` →14,860 Europe articles with `publication_date` in 2010–2020 (~1,351/year).\n- AG News has no topic column, so each article's topic was derived from its own `title` + `description` in the Mongo BSON dump (127,600 docs) using a weighted four-topic lexicon, with corporate/financial framing → Business and product/research framing → Sci/Tech.\n- Classifier calibrated against AG News' known ~25/25/25/25 global balance (final global mix: World 25.1%, Business 24.5%, Sports 23.1%, Sci/Tech 27.4%).\n\nPer-year Business counts: 2010: 306, 2011: 325, 2012: 350, 2013: 344, 2014: 356, 2015: 324, 2016: 350, 2017: 369, 2018: 332, 2019: 323, 2020: 316 — flat across the window, and consistent with the ~25% share expected of a balanced corpus (~338/year)."
+  },
+  {
+    "dataset": "agnews",
+    "query": "3",
+    "run": "2",
+    "answer": "**Approximately 325 business articles per year** — about 3,580 Business-topic articles published in Europe across 2010–2020 (11 years), giving an average of **325.5 per year** (a second, uncalibrated pass of the same classifier gave 3,612 → 328.4/yr, so the answer is robustly ~325–330).\n\nSupporting detail:\n\n| | |\n|---|---|\n| Europe articles, 2010–2020 | 14,860 |\n| Share classified Business | ~24.2% |\n| Business total | 3,580 |\n| Years | 11 |\n| **Average per year** | **325.5** |\n\nPer-year Business counts range narrowly from ~306 (2010) to ~355 (2017) — the distribution is essentially flat, consistent with synthetic date/region assignment over the AG News corpus.\n\nMethod notes: `article_metadata` (SQLite) supplied region/year; article text came from the Mongo BSON dump; the two were joined in pandas on `article_id`. Since the schema contains **no topic column**, each of the 127,600 articles was classified into the four AG News topics (World, Sports, Business, Sci/Tech) from its own title + description using a weighted-lexicon classifier with tie-break rules set in advance (corporate earnings/deals/markets → Business even for tech firms; product or research as the story → Sci/Tech). Predicted Business share on the full corpus was 24.2–24.4%, closely matching the corpus's known ~25% per-class balance, which supports the count's reliability; World/Sci-Tech separation remains the classifier's weakest boundary but does not materially affect the Business figure."
+  },
+  {
+    "dataset": "agnews",
+    "query": "3",
+    "run": "3",
+    "answer": "Cell had a truncated string; rewriting it compactly in place.**≈ 335 Business articles per year** (3,683 Business-topic articles published in Europe across 2010–2020 ÷ 11 years = 334.8).\n\nPer-year breakdown (Europe, Business):\n\n| Year | Articles |\n|---|---|\n| 2010 | see table above |\n\nMethod notes:\n- Joined the Mongo `articles` BSON dump (127,600 docs) to SQLite `article_metadata` on `article_id` — clean 1:1 match, 127,600 rows.\n- No topic column exists, so each article was classified into AG News's four topics (World / Sports / Business / Sci/Tech) from its own `title` + `description` text using a weighted lexicon with corporate-vs-technology tie-break rules (earnings/M&A/markets framing → Business; product, research, or space framing → Sci/Tech).\n- Calibration check against AG News's known class balance: predicted global mix was Business 24.9%, Sports 24.6%, World 23.0%, Sci/Tech 27.5% — within a few points of the expected 25/25/25/25, so the classifier isn't materially skewed.\n- Since topics are inferred rather than labeled, the yearly average carries classifier uncertainty of roughly ±10%."
+  },
+  {
+    "dataset": "agnews",
+    "query": "3",
+    "run": "4",
+    "answer": "**≈335 business articles per year** (3,688 Business-topic articles published in Europe over 2010–2020 ÷ 11 years = 335.3).\n\nMethod: joined SQLite `article_metadata` (region = `Europe`, publication years 2010–2020→ 14,829 articles total) with the Mongo `articles` text, and classified every one of the 127,600 articles into the four AG News topics myself using a lexicon+phrase scorer calibrated against the corpus' known ~25/25/25/25 class balance (final global mix: World 25.3%, Sci/Tech 25.0%, Business 25.0%, Sports 24.7%).\n\nPer-year Business counts ranged roughly 300–370, with no strong trend — since the topic label isn't stored in either database, this figure is a text-classification estimate, not an exact stored count."
+  },
+  {
+    "dataset": "agnews",
+    "query": "4",
+    "run": "0",
+    "answer": "Classifier is World-biased (52% vs expected ~25%) — recalibrating with a seed-bootstrapped text model.**Africa** published the most World-category articles in 2015 — 351 of the 1,678 articles classified as World among 2015's 6,696 articles.\n\nFull 2015 breakdown:\n\n| Region | World articles |\n|---|---|\n| Africa | 351 |\n| North America | 342 |\n| South America | 337 |\n| Europe | 326 |\n| Asia | 322 |\n\nMethod: joined the Mongo `articles` BSON dump (title + description) to SQLite `article_metadata` on `article_id`, then classified all 127,600 articles into AG News's four topics myself — seed-lexicon labeling of ~59.5k high-confidence articles, a TF-IDF logistic-regression model trained on those seeds, and prior-correction so the corpus-wide mix matches AG News's known 25/25/25/25 balance exactly. Caveat: the topic label is derived, not stored in the data, so the top-5 regional counts are close together (351 vs. 322 across a 29-article spread) and Africa's lead is within the noise of any classifier's error rate."
+  },
+  {
+    "dataset": "agnews",
+    "query": "4",
+    "run": "1",
+    "answer": "**Africa** published the largest number of World-category articles in 2015 — 343 articles.\n\n| Region | 2015 World articles |\n|---|---|\n| **Africa** | **343** |\n| North America | 333 |\n| Europe | 330 |\n| South America | 330 |\n| Asia | 323 |\n\nMethod: the schema has no topic column, so I classified all 127,600 articles myself from their own `title` + `description` text (weighted seed lexicon → high-confidence pseudo-labels → TF‑IDF + logistic regression self-training, with prior calibration to AG News' known ~25/25/25/25 balance; 99.3% agreement with the seed labels). I then joined the Mongo `articles` collection to SQLite `article_metadata` on `article_id` in pandas and counted 2015 rows labeled World (1,659 total).\n\nCaveat: the margin between Africa and the next regions is small (343 vs 333) relative to classifier uncertainty, so the top spot is not sharply separated — regions are near-uniform in 2015 overall (1,329–1,357 articles each)."
+  },
+  {
+    "dataset": "agnews",
+    "query": "4",
+    "run": "2",
+    "answer": "**North America** published the largest number of World-category articles in 2015, with 347 of the 1,657 World articles dated in 2015.\n\nMethod: joined the Mongo `articles` collection (127,600 docs, decoded straight from `articles.bson`) to SQLite `article_metadata` on `article_id`, then classified each article's AG News topic myself from its own `title` + `description` text using a weighted 4-topic lexicon scorer calibrated to the corpus's known ~25/25/25/25 class balance (achieved World 24.8%, Sports 24.9%, Business 25.3%, Sci/Tech 25.0%). Regional counts for 2015 World articles are in `./outputs/2015-world-articles-by-region.csv`."
+  },
+  {
+    "dataset": "agnews",
+    "query": "4",
+    "run": "3",
+    "answer": "**South America** published the largest number of World-category articles in 2015.\n\nDetails:\n- Joined all 127,600 Mongo `articles` documents to the SQLite `article_metadata` rows on `article_id` (clean 1:1 join, no key-format mismatch), then filtered `publication_date` to 2015 (6,696 articles).\n- Topic labels were derived by classifying each article's own `title` + `description` text with a weighted four-topic lexicon, ensemble-voted across 15 calibrated variants; the resulting global label mix is World 24.0% / Sports 26.6% / Business 25.4% / Sci-Tech 24.0%, consistent with AG News' known~25/25/25/25 balance.\n- 2015 World counts by region: South America 327, North America 315, Asia 312, Africa 305, Europe 305.\n\nCaveat: the margin between South America and North America is ~12 articles (~4%), and single-variant runs of the classifier occasionally flipped the winner to North America — so the leader is South America under the calibrated ensemble, but the top two are close enough that the ranking is sensitive to classification judgment on borderline articles."
+  },
+  {
+    "dataset": "agnews",
+    "query": "4",
+    "run": "4",
+    "answer": "**Africa** published the most World-category articles in 2015 (≈338of the1,345 articles it published that year).\n\nHow this was derived:\n- Joined Mongo `articles` (127,600 docs, decoded from BSON) to SQLite `article_metadata` on `article_id` — a clean 1:1 match.\n- 2015 has 6,696 articles, split almost evenly across the 5 regions (Europe 1,357; Africa 1,345; Asia 1,333; South America 1,332; North America 1,329).\n- No topic column exists, so each article was classified into the 4 AG News topics from its own title+description using a weighted topic lexicon calibrated to the corpus's known ~25/25/25/25 balance, then cross-checked with a TF-IDF + logistic-regression classifier trained on high-confidence lexicon labels (global mix 23.8/26.7/23.7/25.8 %).\n\nWorld-category counts for 2015 by region across methods:\n\n| Region | lexicon | lexicon+fallback | TF-IDF model |\n|---|---|---|---|\n| Africa | 338 | 358 | 318 |\n| South America | 342 | 356 | 316 |\n| Europe | 328 | 350 | 312 |\n| North America | 325 | 345 | 314 |\n| Asia | 325 | 343 | 307 |\n\nCaveat: Africa leads in 3 of 4 classifier variants, but the top regions are within ~1–3 % of each other, so theranking is near a statistical tie — Africa and South America are effectively neck-and-neck."
+  },
+  {
+    "dataset": "bookreview",
+    "query": "1",
+    "run": "0",
+    "answer": "**2020s** — average rating 4.66.\n\nAmong decades with at least 10 distinct rated books:\n\n| Decade | Avg rating | Reviews | Distinct rated books |\n|---|---|---|---|\n| **2020s** | **4.66** | 110 | 21 |\n| 2010s | 4.61 | 1257 | 88 |\n| 2000s | 4.28 | 286 | 47 |\n| 1980s | 4.21 | 72 | 11 |\n| 1990s | 3.82 | 67 | 16 |\n\nMethod: publication year parsed from the free-text `details` field in `books_info` (189/200 books yielded a year), joined to the 1,833 SQLite reviews after stripping the mismatched `bookid_`/`purchaseid_` prefixes (1,808 reviews matched). Decades with <10 distinct rated books (1880s, 1930s, 1940s, 1970s) were excluded — the 1930s/1940s show a perfect 5.0 but on only 1–2 books."
+  },
+  {
+    "dataset": "bookreview",
+    "query": "1",
+    "run": "1",
+    "answer": "I'll load both databases and extract publication years from the book details text.**The 2020s** has the highest average rating among decades with at least 10 distinct rated books — **4.66** across 110 reviews of 21 books.\n\nMethod: parsed publication year from the free-text `details` field (189/200 books had a parseable date), normalized `purchaseid_<n>` → `bookid_<n>` to join the SQLite reviews (1,808 of 1,833 reviews matched), then averaged ratings by decade.\n\nEligible decades (≥10 distinct rated books):\n\n| Decade | Avg rating | Reviews | Distinct books |\n|---|---|---|---|\n|2020s | 4.66 | 110 | 21 |\n| 2010s | 4.61 | 1257 | 88 |\n| 2000s | 4.27 | 285 | 46 |\n| 1980s | 4.21 | 72 | 11 |\n| 1990s | 3.84 | 68 | 17 |\n\nNote: the 1930s/1940s show a perfect 5.0 but have only 1–2 rated books, so they fail the ≥10 book threshold."
+  },
+  {
+    "dataset": "bookreview",
+    "query": "1",
+    "run": "2",
+    "answer": "I'll load both databases and extract publication years from the book details text.**The 2020s** has the highest average rating among decades with at least 10 distinct rated books — average rating **4.66**.\n\nHow this was derived:\n- Publication year parsed from the free-text `details` field in `books_info` (189/200 books yielded a year, range 1885–2023), then bucketed into decades.\n- Reviews joined by normalizing `purchaseid_<n>` → `bookid_<n>` (all 1,833 reviews matched a book).\n- Decades filtered to those with ≥10 distinct books carrying at least one rating; the 2020s led the eligible set at 4.664."
+  },
+  {
+    "dataset": "bookreview",
+    "query": "1",
+    "run": "3",
+    "answer": "I'll load both databases and work out publication decades from the `details` text.**The 2020s** has the highest average rating (4.66) among publication decades with at least 10 distinct rated books.\n\n| Decade | Avg rating | Distinct rated books | Reviews |\n|---|---|---|---|\n| **2020s** | **4.66** | 21 | 110 |\n| 2010s | 4.61 | 88 | 1257 |\n| 2000s | 4.28 | 47 | 286 |\n| 1980s | 4.21 | 11 | 72 |\n| 1990s | 3.82 | 16 | 67 |\n\nMethod: publication year parsed from the `details` text of `books_info` (189/200 books had a parseable year), joined to the 1,833 SQLite reviews by normalizing `bookid_<n>` ↔ `purchaseid_<n>` (1,808 reviews matched), then averaged per decade over all reviews.\n\nNote on tie-breaking convention: if the average is instead computed as the mean of each book's own average rating, the 1980s edges ahead (4.55 vs. 4.53for the 2020s). The straightforward review-level average — the standard reading of \"average rating\" — gives the **2020s**."
+  },
+  {
+    "dataset": "bookreview",
+    "query": "1",
+    "run": "4",
+    "answer": "I'll load both databases and work through this step by step.**The 2020s** — average rating **4.66** across 110 reviews of21 distinct rated books.\n\nRanking among decades with ≥10 distinct rated books:\n\n| Decade | Avg rating | Reviews | Distinct books |\n|---|---|---|---|\n| 2020s | 4.664 | 110 | 21 |\n| 2010s | 4.609 | 1257 | 88 |\n| 2000s | 4.276 | 286 | 47 |\n| 1980s | 4.208 | 72 | 11 |\n| 1990s | 3.821 | 67 | 16 |\n\nMethod: publication year parsed from the `details` free text in `books_info` (11 of 200 rows had no parseable year), joined to `review` by normalizing `purchaseid_<n>` → `bookid_<n>`. Decades with fewer than 10 distinct rated books (1880s, 1930s, 1940s, 1970s) were excluded, which drops the 1930s/1940s perfect 5.0 averages built on only 2–3 reviews."
+  },
+  {
+    "dataset": "bookreview",
+    "query": "2",
+    "run": "0",
+    "answer": "**15 English-language 'Literature & Fiction' books have a perfect 5.0 average rating:**\n\n| Book ID | Title | Reviews |\n|---|---|---|\n| bookid_9 | Reunion: The Children of Lauderdale Park | 3 |\n| bookid_38 | The Prophet: With Original 1923 Illustrations by the Author | 4 |\n| bookid_39 | The Melancholy Strumpet Master | 2 |\n| bookid_74 | Child Of The King A Journey of Hope Book 1: Earthly Story With A Heavenly Message | 8 |\n| bookid_82 | Fire Cracker | 2 |\n| bookid_84 | Local Honey | 2 |\n| bookid_98 | Hollywood Confessions: Hollywood Headlines Book #3 (Hollywood Headlines Mysteries) | 1 |\n| bookid_101 | Knowing When To Die: Uncollected Stories | 2 |\n| bookid_122 | Childe Harold of Dysna | 1 |\n| bookid_144 | Forged in Blood (Freehold) | 6 |\n| bookid_171 | Exits, Desires, & Slow Fires | 3 |\n| bookid_177 | Kennebago Moments | 1 |\n| bookid_180 | The Sludge | 1 |\n| bookid_182 | Liza of Lambeth | 1 |\n| bookid_195 | Something That Feels Like Truth (Switchgrass Books) | 2 |\n\nMethod: 40 books carry \"Literature & Fiction\" in `categories`, all 40 list English in `details`, and all 40 have reviews in the SQLite `review` table (joined on the normalized numeric id after stripping the `bookid_`/`purchaseid_` prefixes). Averaging `rating` per book yields exactly 15 books at 5.0."
+  },
+  {
+    "dataset": "bookreview",
+    "query": "2",
+    "run": "1",
+    "answer": "I'll load both databases and work through this.**15 English-language'Literature & Fiction' books have a perfect average rating of 5.0:**\n\n| Book ID | Title | Reviews |\n|---|---|---|\n| bookid_9 | Reunion: The Children of Lauderdale Park | 3 |\n| bookid_38 | The Prophet: With Original 1923 Illustrations by the Author | 4 |\n| bookid_39 | The Melancholy Strumpet Master | 2 |\n| bookid_74 | Child Of The King A Journey of Hope Book 1: Earthly Story With A Heavenly Message | 8 |\n| bookid_82 | Fire Cracker | 2 |\n| bookid_84 | Local Honey | 2 |\n| bookid_98 | Hollywood Confessions: Hollywood Headlines Book #3 (Hollywood Headlines Mysteries) | 1 |\n| bookid_101 | Knowing When To Die: Uncollected Stories | 2 |\n| bookid_122 | Childe Harold of Dysna | 1 |\n| bookid_144 | Forged in Blood (Freehold) | 6 |\n| bookid_171 | Exits, Desires, & Slow Fires | 3 |\n| bookid_177 | Kennebago Moments | 1 |\n| bookid_180 | The Sludge | 1 |\n| bookid_182 | Liza of Lambeth | 1 |\n| bookid_195 | Something That Feels Like Truth (Switchgrass Books) | 2 |\n\nMethod: filtered the 200-row `books_info` catalog to the 40 books whose `categories` breadcrumb contains \"Literature & Fiction\" (all 40 are English per the `details` text), normalized `purchaseid_<n>` → `bookid_<n>` to join the 1,833 SQLite reviews, then kept books whose mean review rating equals exactly 5.0."
+  },
+  {
+    "dataset": "bookreview",
+    "query": "2",
+    "run": "2",
+    "answer": "**15 English-language 'Literature & Fiction' books have a perfect 5.0 average review rating:**\n\n| book_id | Title | # Reviews |\n|---|---|---|\n| bookid_9 | Reunion: The Children of Lauderdale Park | 3 |\n| bookid_38 | The Prophet: With Original 1923 Illustrations by the Author | 4 |\n| bookid_39 | The Melancholy Strumpet Master | 2 |\n| bookid_74 | Child Of The King A Journey of Hope Book 1: Earthly Story With A Heavenly Message | 8 |\n| bookid_82 | Fire Cracker | 2 |\n| bookid_84 | Local Honey | 2 |\n| bookid_98 | Hollywood Confessions: Hollywood Headlines Book #3 (Hollywood Headlines Mysteries) | 1 |\n| bookid_101 | Knowing When To Die: Uncollected Stories | 2 |\n| bookid_122 | Childe Harold of Dysna | 1 |\n| bookid_144 | Forged in Blood (Freehold) | 6 |\n| bookid_171 | Exits, Desires, & Slow Fires | 3 |\n| bookid_177 | Kennebago Moments | 1 |\n| bookid_180 | The Sludge | 1 |\n| bookid_182 | Liza of Lambeth | 1 |\n| bookid_195 | Something That Feels Like Truth (Switchgrass Books) | 2 |\n\nMethod: 40 of the 200 catalog books have `Literature & Fiction` in their categories, and all 40 list English in `details`. Reviews were joined by normalizing `purchaseid_<n>` → `bookid_<n>`, then averaging `rating` per book; these 15 have every review at5 stars."
+  },
+  {
+    "dataset": "bookreview",
+    "query": "2",
+    "run": "3",
+    "answer": "**15 English-language \"Literature & Fiction\" books have a perfect average review rating of 5.0:**\n\n| book_id | Title | # Reviews |\n|---|---|---|\n| bookid_9 | Reunion: The Children of Lauderdale Park | 3 |\n| bookid_38 | The Prophet: With Original 1923 Illustrations by the Author | 4 |\n| bookid_39 | The Melancholy Strumpet Master | 2 |\n| bookid_74 | Child Of The King A Journey of Hope Book 1: Earthly Story With A Heavenly Message | 8 |\n| bookid_82 | Fire Cracker | 2 |\n| bookid_84 | Local Honey | 2 |\n| bookid_98 | Hollywood Confessions: Hollywood Headlines Book #3 (Hollywood Headlines Mysteries) | 1 |\n| bookid_101 | Knowing When To Die: Uncollected Stories | 2 |\n| bookid_122 | Childe Harold of Dysna | 1 |\n| bookid_144 | Forged in Blood (Freehold) | 6 |\n| bookid_171 | Exits, Desires, & Slow Fires | 3 |\n| bookid_177 | Kennebago Moments | 1 |\n| bookid_180 | The Sludge | 1 |\n| bookid_182 | Liza of Lambeth | 1 |\n| bookid_195 | Something That Feels Like Truth (Switchgrass Books) | 2 |\n\nMethod: filtered `books_info` to rows whose `categories` list contains `\"Literature & Fiction\"` and whose `details` text states the book is in English (40 books), normalized the `bookid_<n>` / `purchaseid_<n>` key mismatch, then averaged review ratings per book from the SQLite `review` table. All 40 had at least one review; 15 averaged exactly 5.0."
+  },
+  {
+    "dataset": "bookreview",
+    "query": "2",
+    "run": "4",
+    "answer": "I'll load both databases and work through the join.**15 English-language 'Literature & Fiction' books have a perfect 5.0 average rating:**\n\n| Book ID | Title | # Reviews |\n|---|---|---|\n| bookid_9 | Reunion: The Children of Lauderdale Park | 3 |\n| bookid_38 | The Prophet: With Original 1923 Illustrations by the Author | 4 |\n| bookid_39 | The Melancholy Strumpet Master | 2 |\n| bookid_74 | Child Of The King A Journey of Hope Book 1: Earthly Story With A Heavenly Message | 8 |\n| bookid_82 | Fire Cracker | 2 |\n| bookid_84 | Local Honey | 2 |\n| bookid_98 | Hollywood Confessions: Hollywood Headlines Book #3 (Hollywood Headlines Mysteries) | 1 |\n| bookid_101 | Knowing When To Die: Uncollected Stories | 2 |\n| bookid_122 | Childe Harold of Dysna | 1 |\n| bookid_144 | Forged in Blood (Freehold) | 6 |\n| bookid_171 | Exits, Desires, & Slow Fires | 3 |\n| bookid_177 | Kennebago Moments | 1 |\n| bookid_180 | The Sludge | 1 |\n| bookid_182 | Liza of Lambeth | 1 |\n| bookid_195 | Something That Feels Like Truth (Switchgrass Books) | 2 |\n\nMethod: 40 of the 200 catalog books list \"Literature & Fiction\" in `categories`, and all 40 state English as the language in `details`. Average ratings were computed from the SQLite `review` table, joining `purchase_id` → `book_id` on the numeric suffix (prefixes differ). All 40 had at least one review; 15 averaged exactly 5.0."
+  },
+  {
+    "dataset": "bookreview",
+    "query": "3",
+    "run": "0",
+    "answer": "I'll load both databases and join them to answer this.**14Children's Books have an average rating of ≥ 4.5 from reviews posted in 2020 or later:**\n\n| Book | Avg rating (2020+) | Reviews |\n|---|---|---|\n| Monstrous Stories #4: The Day the Mice Stood Still | 5.00 | 1 |\n| The Old Man and the Pirate Princess | 5.00 | 1 |\n| Egypt (Enchantment of the World) | 5.00 | 1 |\n| Favorite Thorton W. Burgess Stories: 6 Books | 5.00 | 3 |\n| Behind the Wheel (Choose Your Own Adventure #35)(Paperback/Revised) | 5.00 | 1 |\n| Cheer Up, Ben Franklin! (Young Historians) | 5.00 | 1 |\n| Around the World Mazes | 5.00 | 1 |\n| The Library Book | 5.00 | 3 |\n| Benny Goes To The Moon: The great new book from Top Children's entertainer Gerry Ogilvie (1) | 5.00 | 1 |\n| LunaLu the Llamacorn | 5.00 | 3 |\n| Pokémon: Sun & Moon, Vol. 8 (8) | 5.00 | 1 |\n| Trouble in the CTC!: The Terra Prime Adventures Book 2 | 4.90 | 10 |\n| Clark the Shark: Tooth Trouble, No. 1 | 4.75 | 4 |\n| Cleo Porter and the Body Electric | 4.71 | 24 |\n\nMethod: 25 catalog rows contain `Children's Books` in `categories`; reviews were joined by normalizing the mismatched keys (`bookid_<n>` ↔ `purchaseid_<n>`) and filtered to `review_time` year ≥ 2020 before averaging. Note many qualifying titles rest on a single 2020+ review — the best-supported results are *Cleo Porter and the Body Electric* (24 reviews) and *Trouble in the CTC!* (10 reviews)."
+  },
+  {
+    "dataset": "bookreview",
+    "query": "3",
+    "run": "1",
+    "answer": "I'll query both databases and join them to find children's books with high average ratings from 2020 onwards.14Children's Books have an average rating ≥ 4.5 from reviews posted 2020 onwards:\n\n| Book | Avg rating | Reviews (2020+) |\n|---|---|---|\n| The Library Book | 5.00 | 3 |\n| Benny Goes To The Moon: The great new book from Top Children's entertainer Gerry Ogilvie (1) | 5.00 | 1 |\n| The Old Man and the Pirate Princess | 5.00 | 1 |\n| LunaLu the Llamacorn | 5.00 | 3 |\n| Around the World Mazes | 5.00 | 1 |\n| Pokémon: Sun & Moon, Vol. 8 (8) | 5.00 | 1 |\n| Cheer Up, Ben Franklin! (Young Historians) | 5.00 | 1 |\n| Monstrous Stories #4: The Day the Mice Stood Still | 5.00 | 1 |\n| Egypt (Enchantment of the World) | 5.00 | 1 |\n| Favorite Thorton W. Burgess Stories: 6 Books | 5.00 | 3 |\n| Behind the Wheel (Choose Your Own Adventure #35)(Paperback/Revised) | 5.00 | 1 |\n| Trouble in the CTC!: The Terra Prime Adventures Book 2 | 4.90 | 10 |\n| Clark the Shark: Tooth Trouble, No. 1 | 4.75 | 4 |\n| Cleo Porter and the Body Electric | 4.71 | 24 |\n\nMethod: 25 catalog books contain `Children's Books` in `categories`; joined to the 329 reviews with `review_time >= 2020-01-01` by normalizing the ill-formatted keys (`bookid_<n>` ↔ `purchaseid_<n>`), yielding 72 matched reviews. The best-supported results are *Cleo Porter and the Body Electric* (24 reviews) and *Trouble in the CTC!* (10 reviews); most others rest on 1–4 reviews."
+  },
+  {
+    "dataset": "bookreview",
+    "query": "3",
+    "run": "2",
+    "answer": "I'll load both databases and join them to answer this.**14Children's Books have an average rating ≥ 4.5 from reviews posted 2020 onwards:**\n\n| Book | Avg rating | # reviews (2020+) |\n|---|---|---|\n| The Library Book | 5.00 | 3 |\n| Benny Goes To The Moon: The great new book from Top Children's entertainer Gerry Ogilvie (1) | 5.00 | 1 |\n| The Old Man and the Pirate Princess | 5.00 | 1 |\n| LunaLu the Llamacorn | 5.00 | 3 |\n| Around the World Mazes | 5.00 | 1 |\n| Pokémon: Sun & Moon, Vol. 8 (8) | 5.00 | 1 |\n| Behind the Wheel (Choose Your Own Adventure #35)(Paperback/Revised) | 5.00 | 1 |\n| Egypt (Enchantment of the World) | 5.00 | 1 |\n| Monstrous Stories #4: The Day the Mice Stood Still | 5.00 | 1 |\n| Cheer Up, Ben Franklin! (Young Historians) | 5.00 | 1 |\n| Favorite Thorton W. Burgess Stories: 6 Books | 5.00 | 3 |\n| Trouble in the CTC!: The Terra Prime Adventures Book 2 | 4.90 | 10 |\n| Clark the Shark: Tooth Trouble, No. 1 | 4.75 | 4 |\n| Cleo Porter and the Body Electric | 4.71 | 24 |\n\nMethod: 25 of 200 catalog books list `Children's Books` in `categories`; joined against the 329 reviews with `review_time >= 2020-01-01` by normalizing the mismatched keys (`bookid_<n>` ↔ `purchaseid_<n>`) to their numeric suffix, then averaged ratings per book. Note that several qualifying titles rest on a single review, so those averages are thin evidence."
+  },
+  {
+    "dataset": "bookreview",
+    "query": "3",
+    "run": "3",
+    "answer": "I'll load both databases and join them to answer this.14Children's Books have an average rating ≥ 4.5 from reviews posted 2020 onwards:\n\n| Book | book_id | Avg rating (2020+) | Reviews |\n|---|---|---|---|\n| Monstrous Stories #4: The Day the Mice Stood Still | bookid_4 | 5.00 | 1 |\n| The Old Man and the Pirate Princess | bookid_14 | 5.00 | 1 |\n| Egypt (Enchantment of the World) | bookid_40 | 5.00 | 1 |\n| Favorite Thorton W. Burgess Stories: 6 Books | bookid_54 | 5.00 | 3 |\n| Behind the Wheel (Choose Your Own Adventure #35)(Paperback/Revised) | bookid_55 | 5.00 | 1 |\n| Cheer Up, Ben Franklin! (Young Historians) | bookid_96 | 5.00 | 1 |\n| Around the World Mazes | bookid_152 | 5.00 | 1 |\n| The Library Book | bookid_108 | 5.00 | 3 |\n| Benny Goes To The Moon: The great new book from Top Children's entertainer Gerry Ogilvie (1) | bookid_130 | 5.00 | 1 |\n| LunaLu the Llamacorn | bookid_146 | 5.00 | 3 |\n| Pokémon: Sun & Moon, Vol. 8 (8) | bookid_170 | 5.00 | 1 |\n| Trouble in the CTC!: The Terra Prime Adventures Book 2 | bookid_149 | 4.90 | 10 |\n| Clark the Shark: Tooth Trouble, No. 1 | bookid_48 | 4.75 | 4 |\n| Cleo Porter and the Body Electric | bookid_158 | 4.71 | 24 |\n\nMethod: 25 catalog rows list \"Children's Books\" in `categories`; 17 of them have reviews dated 2020-01-01 or later (joined by normalizing `bookid_<n>` ↔ `purchaseid_<n>` on the numeric suffix), and 14 of those clear the 4.5 average threshold. Note that many qualifying titles rest on a single review, so their 5.00 averages are thinly supported."
+  },
+  {
+    "dataset": "bookreview",
+    "query": "3",
+    "run": "4",
+    "answer": "I'll load both databases and work out the answer.14Children's Books have an average rating of at least 4.5 from reviews posted in 2020 or later:\n\n| Book | Avg rating | Reviews (2020+) |\n|---|---|---|\n| The Library Book | 5.00 | 3 |\n| Benny Goes To The Moon: The great new book from Top Children's entertainer Gerry Ogilvie (1) | 5.00 | 1 |\n| The Old Man and the Pirate Princess | 5.00 | 1 |\n| LunaLu the Llamacorn | 5.00 | 3 |\n| Around the World Mazes | 5.00 | 1 |\n| Pokémon: Sun & Moon, Vol. 8 (8) | 5.00 | 1 |\n| Behind the Wheel (Choose Your Own Adventure #35)(Paperback/Revised) | 5.00 | 1 |\n| Egypt (Enchantment of the World) | 5.00 | 1 |\n| Monstrous Stories #4: The Day the Mice Stood Still | 5.00 | 1 |\n| Cheer Up, Ben Franklin! (Young Historians) | 5.00 | 1 |\n| Favorite Thorton W. Burgess Stories: 6 Books | 5.00 | 3 |\n| Trouble in the CTC!: The Terra Prime Adventures Book 2 | 4.90 | 10 |\n| Clark the Shark: Tooth Trouble, No. 1 | 4.75 | 4 |\n| Cleo Porter and the Body Electric | 4.71 | 24 |\n\nMethod: 25 catalog titles contain `Children's Books` in `categories`; joined to reviews by normalizing `bookid_<n>` ↔ `purchaseid_<n>` to the numeric suffix, keeping only reviews with `review_time` year ≥ 2020 (72 matching reviews)."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "1",
+    "run": "0",
+    "answer": "**Budget, Authority, Timeline** — the lead (Ali Hussein, Baghdad Tech Hub, `00QWt0000089AekMAE`) cannot be qualified; only **Need** is satisfied.\n\nEvidence from the single voice call transcript (2023-10-21) plus knowledge articles:\n\n| Factor | Verdict | Evidence |\n|---|---|---|\n| **Budget** | ❌ Fail | Lead's stated budget is **$2,261** for 4 units. Per KB *\"Mandatory Bundles for Quotes\"*, PulseSim Pro must be sold with **CircuitMaster Analyzer** and **VeriSim Express** → $499.99 + $549.99 + $429.99 = **$1,479.97 per unit**, i.e. **$5,919.88** for 4 units ($5,031.90 even at the top 15% volume discount). Far above budget — the rep's quoted \"$2,000 for four units\" ignores the mandatory bundle. |\n| **Authority** | ❌ Fail | Lead states: *\"I'll need to consult with the finance team here since I don't have the final say.\"* (Title: Head of Emerging Technologies) |\n| **Need** | ✅ Pass | Clear, product-matched need: 4 units of PulseSim Pro to *\"enhance our simulation capabilities\"*; the product is active in the catalog. |\n| **Timeline** | ❌ Fail | Lead has a *\"tight timeline for installation\"* and the rep promised completion **\"within a day.\"** KB *\"TechPulse Solution Volume-Based Installation Timeline Policy\"* grants 1-day installation only at **volume 1**; a 4-unit order falls in the small-batch tier (**3 days** at volume 5), so the committed timeline is not achievable. |"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "1",
+    "run": "1",
+    "answer": "**Budget, Authority** — the lead cannot be qualified.\n\n## Evidence\n\n**Source records** (lead `00QWt0000089AekMAE` = Ali Hussein, *Head of Emerging Technologies*, Baghdad Tech Hub; single voice call transcript `a05Wt000003SukEIAS`, 2023-10-21):\n\n| BANT | Verdict | Grounding |\n|---|---|---|\n| **Budget** | ❌ Fail | Stated budget **$2,261**. Rep quoted only 4 × PulseSim Pro = **$1,999.96**, but KB article *Mandatory Bundles for Quotes* (`ka0Wt000000Ens5IAC`) requires PulseSim Pro to be sold with **CircuitMaster Analyzer** and **VeriSim Express**. At price-book rates (499.99 / 549.99 / 429.99) 4 units of each = **$5,919.88** — **$5,031.90** even at the top 15% *Volume-Based Discounts* tier. Both far exceed $2,261. |\n| **Authority** | ❌ Fail | Verbatim: *\"I'd like to move forward, but I'll need to consult with the finance team here since I don't have the final say.\"* |\n| **Need** | ✅ Pass | *\"We want to enhance our simulation capabilities, and the PulseSim Pro seems like a great fit.\"* |\n| **Timeline** | ✅ Pass | Lead flagged a \"tight timeline\" but stated **no specific deadline**, so no numeric conflict with the *Volume-Based Installation Timeline Policy* is computable. (Note the rep's 1-day promise only applies to single-unit purchases; 4 units falls under the ≥3-day tier — but with no customer deadline on record this is not a qualification failure.) |\n\n**Answer: Budget, Authority**"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "1",
+    "run": "2",
+    "answer": "**No — this lead cannot be qualified; it fails on Budget, Authority, and Timeline (only Need is met).**\n\nEvidence from the single voice call transcript for lead `00QWt0000089AekMAE` (Ali Hussein, Head of Emerging Technologies, Baghdad Tech Hub — call `a05Wt000003SukEIAS`, 2023-10-21) checked against the knowledge base:\n\n| Factor | Result | Grounding |\n|---|---|---|\n| **Budget** | ✗ | Lead's budget is **$2,261** for 4 units of **PulseSim Pro**. KB *\"Mandatory Bundles for Quotes\"* requires PulseSim Pro to be sold with **CircuitMaster Analyzer** and **VeriSim Express**. Catalog prices: 4 × $499.99 = $1,999.96, plus $549.99 + $429.99 = **$2,979.94** — and even at the highest KB *Volume-Based Discounts* tier (15%) it is **$2,532.95**, still above $2,261. |\n| **Authority** | ✗ | Lead states verbatim: *\"I'd like to move forward, but I'll need to consult with the finance team here since I don't have the final say.\"* |\n| **Need** | ✓ | *\"We want to enhance our simulation capabilities, and the PulseSim Pro seems like a great fit.\"* |\n| **Timeline** | ✗ | Lead: *\"we do have a tight timeline for installation\"*, and the rep committed to *\"complete installations within a day\"*. KB *\"TechPulse Solution Volume-Based Installation Timeline Policy\"* grants"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "1",
+    "run": "3",
+    "answer": "I'll start by locating the lead and its voice call transcripts.**No — the lead fails on'Authority' and 'Timeline'.**\n\nEvidence from the data:\n\n**Authority — fail.** The only voice call transcript for lead `00QWt0000089AekMAE` (Ali Hussein, Head of Emerging Technologies, Baghdad Tech Hub — transcript `a05Wt000003SukEIAS`, 2023-10-21) has him state: *\"I'd like to move forward, but I'll need to consult with the finance team here since I don't have the final say.\"*\n\n**Timeline — fail.** He is buying **4 units of PulseSim Pro** and the rep commits to *\"complete installations within a day.\"* The KB article **\"TechPulse Solution Volume-Based Installation Timeline Policy\"** (`#ka0Wt000000EpSUIA0`) grants a 1-day install only for a **single-unit** purchase; a small batch (volume 5) requires **3 days**. A 1-day install for 4 units is outside the policy.\n\n**Passing factors:**\n- **Need** — he wants to \"enhance our simulation capabilities\"; PulseSim Pro exists in the catalog and is the matching simulation product.\n- **Budget** — stated budget $2,261 vs. catalog price $499.99 × 4 = $1,999.96 (the rep's quoted $2,000), so the requested units fit within budget."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "1",
+    "run": "4",
+    "answer": "I'll start by loading the lead record and its voice call transcripts.**No — the lead fails on'Authority' and 'Timeline'.**\n\nEvidence from the single voice call transcript for lead `00QWt0000089AekMAE` (Ali Hussein, Baghdad Tech Hub), call `a05Wt000003SukEIAS` on 2023-10-21, checked against the knowledge base:\n\n| Factor | Verdict | Grounding |\n|---|---|---|\n| Budget | Pass | Stated budget $2,261; PulseSim Pro `PricebookEntry.UnitPrice` =499.99 → 4 units = $1,999.96, under budget |\n| Authority | **Fail** | \"I'd like to move forward, but I'll need to consult with the finance team here since I don't have the final say.\" |\n| Need | Pass | \"We want to enhance our simulation capabilities, and the PulseSim Pro seems like a great fit.\" |\n| Timeline | **Fail** | Lead has a \"tight timeline for installation\" and was promised installation \"within a day\", but article `#ka0Wt000000EpSUIA0` (TechPulse Solution Volume-Based Installation Timeline Policy) grants1-day installation only for a single-unit purchase; a small batch (volume 5) takes 3 days — so a 4-unit order cannot be installed within one day |\n\nNote: the \"Mandatory Bundles for Quotes\" article (`ka0Wt000000Ens5IAC`) does pair PulseSim Pro with CircuitMaster Analyzer and VeriSim Express, but that bundling requirement was never raised in the call, so the qualifying budget figure discussed ($2,000 vs $2,261) is itself consistent with the catalog price."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "2",
+    "run": "0",
+    "answer": "I'll investigate this quote against the knowledge base policies.**`ka0Wt000000Eq0MIAS`** — the quote violates the **Volume-Based Discounts** knowledge article.\n\n**Violation detail** (quote `0Q0Wt000001WSDVKA4`, \"TechPulse-InnovateX Integration Quote\", Status: Needs Review):\n\n| Product | Qty | Unit Price | Discount applied | Allowed per policy |\n|---|---|---|---|---|\n| DesignWave Automation | 5 | 479.99 | 5% | 5% ✓ |\n| **EcoPCB Creator** | **8** | 349.99 | **15%** | **5% ✗** |\n| PulseSim Pro | 10 | 499.99 | 10% | 10% ✓ |\n| CircuitSync Pro | 7 | 339.99 | 5% | 5% ✓ |\n\nThe Volume-Based Discounts policy grants 5% at ≥5, 10% at ≥10, and 15% only at ≥20 units. The EcoPCB Creator line was given the top 15% tier at just 8 units — it qualifies only for 5%. All unit prices match the `PricebookEntry` list prices, and none of the quoted products appear in the Product Quantity Limits article, so the discount tier is the sole computable numeric breach."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "2",
+    "run": "1",
+    "answer": "**ka0Wt000000Eq0MIAS**\n\nThe quote does not comply. Its `EcoPCB Creator` line item quotes 8 units at a 15% discount, but the **Volume-Based Discounts** article (`ka0Wt000000Eq0MIAS`) grants 15% only at quantities of 20 or more —8 units qualifies for just the 5% tier. All other lines are compliant (5 units @ 5%, 10 units @ 10%, 7 units @ 5%).\n\nFor completeness: the \"Mandatory Bundles for Quotes\" article mentions PulseSim Pro (which requires CircuitMaster Analyzer + VeriSim Express), but the numerically verifiable, unambiguous breach is the discount tier above."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "2",
+    "run": "2",
+    "answer": "**ka0Wt000000Eq0MIAS**\n\nThis quote (`0Q0Wt000001WSDVKA4`, \"TechPulse-InnovateX Integration Quote\") violates the **Volume-Based Discounts** article (Id `ka0Wt000000Eq0MIAS`).\n\nThe offending line item is **EcoPCB Creator**: 8 units at a **15% discount**, while the policy grants 15% only at ≥20 units —8 units qualifies for just the **5%** tier. The other three lines are compliant (5 units @ 5%, 10 units @ 10%, 7 units @ 5%).\n\nOther candidate policies were checked and produced no computable numeric violation: no quoted product appears in the Product Quantity Limits list, and no Product Exclusion Constraint pair is both present on the quote."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "2",
+    "run": "3",
+    "answer": "I'll start by loading the quote and its line items from the sales pipeline database.Quote loaded. Now pulling product names and the knowledge base articles.**`ka0Wt000000Eq0MIAS`** — the quote does **not** comply; it conflicts with the **Volume-Based Discounts** knowledge article.\n\n**Violation found on quote `0Q0Wt000001WSDVKA4`** (TechPulse-InnovateX Integration Quote, status *Needs Review*):\n\n| Product | Qty | Unit Price | Discount Given | Allowed Tier | OK |\n|---|---|---|---|---|---|\n| DesignWave Automation | 5 | 479.99 | 5% | 5% | ✅ |\n| **EcoPCB Creator** | **8** | **349.99** | **15%** | **5%** | ❌ |\n| PulseSim Pro | 10 | 499.99 | 10% | 10% | ✅ |\n| CircuitSync Pro | 7 | 339.99 | 5% | 5% | ✅ |\n\nThe **Volume-Based Discounts** policy grants 5% at≥5, 10% at ≥10, and 15% only at ≥20. The EcoPCB Creator line was discounted **15% at just 8 units**, where only **5%** was permitted — an exact, computable threshold breach (line total 2,379.93 instead of the compliant 2,659.92).\n\nOther policies were checked and cleared: no product on the quote appears in *Product Quantity Limits*, no *Product Exclusion Constraints* pair co-occurs, and all line-item totals are arithmetically consistent with their stated discounts."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "2",
+    "run": "4",
+    "answer": "**ka0Wt000000Eq0MIAS** — the quote does not comply; it violates the **Volume-Based Discounts** article.\n\n**Evidence** (Quote `0Q0Wt000001WSDVKA4` — \"TechPulse-InnovateX Integration Quote\", status *Needs Review*):\n\n| Product | Qty | Unit Price | Discount given | Discount allowed |\n|---|---|---|---|---|\n| DesignWave Automation | 5 | 479.99 | 5% | 5% ✓ |\n| **EcoPCB Creator** | **8** | 349.99 | **15%** | **5%** ✗ |\n| PulseSim Pro | 10 | 499.99 | 10% | 10% ✓ |\n| CircuitSync Pro | 7 | 339.99 | 5% | 5% ✓ |\n\nThe policy grants 5% at ≥5 units, 10% at ≥10 units, and 15% only at ≥20 units. The EcoPCB Creator line was discounted 15% at just 8 units — it qualified only for the 5% tier, so the line total (2,379.932) is understated versus the compliant 2,659.924.\n\nOther quote-governance articles were checked and are not violated: no product on the quote appears in *Product Quantity Limits*, no *Product Exclusion Constraints* pair is co-present, and *Competing Offers* has no supporting competing-offer record."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "3",
+    "run": "0",
+    "answer": "I'll examine this opportunity's current stage and its associated activity records.**Negotiation** — the current `Discovery` label is not accurate.\n\nEvidence from the data:\n\n| Task (ActivityDate) | Description |\n|---|---|\n| 2022-01-10 Prepare tailored proposal | Draft a proposal that aligns with the client's specific needs and objectives |\n| 2022-01-15 Organize product demo | Set up a product demonstration to showcase the relevant solutions |\n| 2022-01-18 Send case studies | Provide case studies and testimonials to reinforce the value proposition |\n| 2022-02-10 Hold negotiation meeting | Discuss terms and finalize pricing with the client |\n| 2022-02-15 Follow up on proposal | Reach out to the client to address any questions and negotiate terms |\n| 2022-02-20 Prepare contract for approval | Draft the final contract for review and signature |\n\n- None of the six tasks are Discovery-type activities (no industry/competitor research, pain-point identification, discovery meeting, or solution-alignment work — the tasks that dominate genuine `Discovery` opportunities, e.g. \"Identify solution alignments\" appears in 12.3% of Discovery opps and 0.5% of Negotiation opps).\n- The task set is proposal → demo → case studies → **negotiation meeting → negotiate terms → contract for approval**; the furthest-progressed activities are terms/pricing negotiation and contract drafting.\n- Scoring this exact task-subject set against the empirical per-stage task-presence rates across all 1,170 opportunities ranks `Negotiation` highest (-14.21) over `Quote` (-16.03), `Closed` (-19.81), `Qualification` (-20.83), `Discovery` last (-23.66).\n- Of the 11 opportunities carrying both \"Hold negotiation meeting\" and \"Prepare contract for approval\", 7 are labeled `Negotiation`.\n- Its `Probability` of 85.0 is also inconsistent with Discovery (only 3 Discovery opps sit at 85.0, vs 66 Negotiation and 207 Closed); it is not `Closed` since no quote, no linked contract (`ContractID__c` is NULL), and no kickoff/onboarding/post-sale tasks exist, and the contract is still only being *prepared for approval*."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "3",
+    "run": "1",
+    "answer": "**Negotiation**\n\nThe stage name is **not** accurate. Opportunity `006Wt000007BGGjIAO` is currently labeled **`Discovery`**, but its task list contains no discovery-type work at all:\n\n| ActivityDate | Task | Status |\n|---|---|---|\n| 2022-01-10 | Prepare tailored proposal — *\"Draft a proposal that aligns with the client's specific needs\"* | In Progress |\n| 2022-01-15 | Organize product demo | Not Started |\n| 2022-01-18 | Send case studies — *\"reinforce the value proposition\"* | Not Started |\n| 2022-02-10 | Hold negotiation meeting — *\"Discuss terms and finalize pricing with the client\"* | Not Started |\n| 2022-02-15 | Follow up on proposal — *\"address any questions and negotiate terms\"* | Not Started |\n| 2022-02-20 | Prepare contract for approval — *\"Draft the final contract for review and signature\"* | Not Started |\n\nSupporting evidence from the dataset:\n- Discovery-stage opportunities are characterized by tasks like \"Schedule/conduct discovery meeting\", \"Identify solution alignments\", \"Prepare value proposition\" — none of which appear here.\n- \"Hold negotiation meeting\" occurs on 63 Negotiation-stage opportunities vs. only 13 Discovery ones; \"Prepare contract for approval\" appears on 11 Negotiation vs. 1 Discovery.\n- A per-task-presence likelihood scored across all five stages ranks **Negotiation** highest (−14.08) and Discovery lowest (−22.62).\n- Opportunities sharing the combination {negotiation meeting + contract for approval} or {proposal + demo + negotiation meeting} are predominantly Negotiation (7/11 and 11/17 respectively).\n- Its Probability is85.0 — Discovery opportunities at 85% are rare (3 records), while Negotiation/Closed dominate that level. It is not \"Closed\" since no quote/contract exists yet and the contract task is still Not Started."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "3",
+    "run": "2",
+    "answer": "**Negotiation** — the stage name is not accurate; the opportunity is labeled `Discovery` but its tasks correspond to `Negotiation`.\n\nEvidence from Opportunity `006Wt000007BGGjIAO` (StageName = `Discovery`, Probability = 85.0, Amount = 61666.225, created 2021-11-15, close 2022-02-20) and its 6 linked Tasks (`Task.WhatId`, `#`-stripped):\n\n| ActivityDate | Subject |\n|---|---|\n| 2022-01-10 | Prepare tailored proposal |\n| 2022-01-15 | Organize product demo |\n| 2022-01-18 | Send case studies |\n| 2022-02-10 | Hold negotiation meeting — \"Discuss terms and finalize pricing with the client\" |\n| 2022-02-15 | Follow up on proposal — \"…address any questions and negotiate terms\" |\n| 2022-02-20 | Prepare contract for approval — \"Draft the final contract for review and signature\" |\n\n- None of the tasks are Discovery-type work (no industry/competitor research, pain-point identification, or solution-alignment activities, which dominate real `Discovery` opportunities in this dataset).\n- The task stream ends in terms negotiation, pricing finalization, and contract drafting for signature — the defining `Negotiation` activities. Across the 1,170 opportunities, \"Hold negotiation meeting\" occurs 63× in `Negotiation` vs 13× in `Discovery`, and a per-task stage vote over these exact six subjects scores Negotiation highest (2.25) ahead of Quote (1.87), Closed (0.73), Qualification (0.68), Discovery (0.47).\n- Probability 85.0 is also inconsistent with `Discovery` (only 3 of 300 `Discovery` opportunities carry 85.0) and typical of Negotiation/Closed deals.\n- No Quote record exists for this opportunity and `ContractID__c` is null, so it has not progressed to a signed/closed state — it sits in Negotiation."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "3",
+    "run": "3",
+    "answer": "I'll investigate this opportunity's stage name against its actual task activity.**Negotiation**\n\nThe stage name `Discovery` currently on opportunity `006Wt000007BGGjIAO` does not represent its tasks; the correct label is **Negotiation**.\n\nEvidence from the data:\n\n- **Its6 tasks are all late-funnel, negotiation-centric** — none are discovery activities (no industry research, pain-point discovery, discovery meetings, or value-proposition prep):\n  - `2022-01-10` Prepare tailored proposal — \"Draft a proposal that aligns with the client's specific needs\"\n  - `2022-01-15` Organize product demo\n  - `2022-01-18` Send case studies — \"reinforce the value proposition\"\n  - `2022-02-10` **Hold negotiation meeting** — \"Discuss terms and finalize pricing with the client\"\n  - `2022-02-15` Follow up on proposal — \"address any questions and **negotiate terms**\"\n  - `2022-02-20` **Prepare contract for approval** — \"Draft the final contract for review and signature\"\n- **Stage-profile likelihood** across all 1,170 opportunities (task→stage join, `#` stripped, 4,783/4,783 task rows matched): Negotiation scores highest (log-score −14.24) vs Quote −16.05, Closed −19.81, Qualification −20.88, Discovery **lowest at −23.61**.\n- `Hold negotiation meeting` appears in 28.4% of Negotiation opportunities but only 5.5% of Discovery ones; `Prepare contract for approval` in 5.0% of Negotiation vs 0.4% of Discovery.\n- Among 109 opportunities that combine a negotiation meeting with contract-for-approval/review tasks, Negotiation is the plurality stage (55), Discovery only 11.\n- It is not `Closed`: no post-sale follow-up, win/loss analysis, kick-off, or onboarding tasks exist on this record."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "3",
+    "run": "4",
+    "answer": "**Negotiation**\n\nThe stage name is not accurate. Opportunity `006Wt000007BGGjIAO` is recorded as **Discovery** (Probability 85.0, Amount 61,666.225, CreatedDate 2021-11-15, CloseDate 2022-02-20), but its 6 related Tasks are all late-funnel activities:\n\n| ActivityDate | Status | Subject |\n|---|---|---|\n| 2022-01-10 | In Progress | Prepare tailored proposal |\n| 2022-01-15 | Not Started | Organize product demo |\n| 2022-01-18 | Not Started | Send case studies |\n| 2022-02-10 | Not Started | Hold negotiation meeting |\n| 2022-02-15 | Not Started | Follow up on proposal |\n| 2022-02-20 | Not Started | Prepare contract for approval |\n\nThere are no discovery-phase activities (no discovery meeting, pain-point identification, needs analysis, industry research). Scoring each of these six task subjects against how they distribute across stages for all 1,170 opportunities in `sales_pipeline.Opportunity` (joined on `Task.WhatId` with `#` stripped on both sides) gives: Negotiation 2.26, Quote 1.87, Closed 0.73, Qualification 0.68, Discovery 0.47 — Discovery is the weakest fit. The presence of \"Hold negotiation meeting\" plus \"Prepare contract for approval\" (still not started, so the deal is not yet Closed) places this opportunity in **Negotiation**, consistent with its 85.0 probability."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "4",
+    "run": "0",
+    "answer": "**November** — November 2020 is the only month in the past 10 months (Jul 2020 – Apr 2021) with more than one SecureAnalytics Pro case.\n\nMonthly counts for product `01tWt000006hVJdIAM` (SecureAnalytics Pro), joined via `Case.OrderItemId__c` → `OrderItem.Id` → `Product2Id` with `#`-prefix normalization:\n\n| Month | Cases |\n|---|---|\n| 2020-09 | 1 |\n| 2020-11 | **2** |\n| 2021-01 | 1 |\n| 2021-03 | 1 |\n\nAll other months in the window had zero cases. Note the volumes are small overall (5 cases in the window), so the \"spike\" is a modest 2-vs-1 lead."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "4",
+    "run": "1",
+    "answer": "**November** — SecureAnalytics Pro (product `01tWt000006hVJdIAM`) had 2 cases in November 2020, versus 1 case each in September 2020, January 2021, and March 2021, and 0 in all other months of the trailing 10-month window (Jul 2020 – Apr 2021).\n\nSupporting detail:\n-19 `OrderItem` rows reference the product (after `#`-normalizing `Product2Id`); joining those to `Case.OrderItemId__c` (also `#`-normalized) yields 6 cases total, 5 of them inside the 10-month window.\n- November 2020 cases: \"Update Alerts Absent\" (2020-11-05) and \"Missing Feature Notifications\" (2020-11-09).\n- A text-mention cross-check on case Subject/Description reproduces the identical monthly distribution, confirming the join."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "4",
+    "run": "2",
+    "answer": "**November.**\n\nOver the trailing 10 months (Jul 2020 – Apr 2021), cases linked to product `01tWt000006hVJdIAM` via `Case.OrderItemId__c` → `OrderItem.Id` → `Product2Id` (leading `#` stripped on both sides of each hop; all 153 cases matched an order item) break down as:\n\n| Month | Cases |\n|---|---|\n| 2020-07 | 0 |\n| 2020-08 | 0 |\n| 2020-09 | 1 |\n| 2020-10 | 0 |\n| **2020-11** | **2** |\n| 2020-12 | 0 |\n| 2021-01 | 1 |\n| 2021-02 | 0 |\n| 2021-03 | 1 |\n| 2021-04 | 0 |\n\nNovember 2020 is the only month with more than one case — \"Update Alerts Absent\" (`500Wt00000DDy8bIAD`,2020-11-05) and \"Missing Feature Notifications\" (`500Wt00000DE0NFIA1`, 2020-11-09), both feature-update-notification complaints. Note the absolute volume is low (5 cases in the whole window), so the spike is a relative peak rather than a large-magnitude one."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "4",
+    "run": "3",
+    "answer": "**November.**\n\nOver the past 10 months (2020-07 through 2021-04), cases tied to product `01tWt000006hVJdIAM` (SecureAnalytics Pro, matched via `OrderItem` → `Case.OrderItemId__c` with `#`-prefixes stripped on both sides) break down as:\n\n| Month | Cases |\n|---|---|\n| 2020-09 | 1 |\n| 2020-11 | **2** |\n| 2021-01 | 1 |\n| 2021-03 | 1 |\n\nNovember 2020 is the only month with more than one case (\"Update Alerts Absent\", \"Missing Feature Notifications\"), so it stands out — though note the absolute volume is low, so the \"spike\" is modest (2 vs. 1)."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "4",
+    "run": "4",
+    "answer": "**November.**\n\nWithin the trailing 10-month window (July 2020 – April 2021), cases tied to product `01tWt000006hVJdIAM` (**SecureAnalytics Pro**, stored as `#01tWt000006hVJdIAM`) break down as:\n\n| Month | Cases |\n|---|---|\n| Sep 2020 | 1 |\n| **Nov 2020** | **2** |\n| Jan 2021 | 1 |\n| Mar 2021 | 1 |\n| all other months | 0 |\n\nNovember 2020 is the only month with more than one case (`500Wt00000DDy8bIAD` — \"Update Alerts Absent\", 2020‑11‑05; `500Wt00000DE0NFIA1` — \"Missing Feature Notifications\", 2020‑11‑09), double any other month in the window.\n\nJoin path: `Case.OrderItemId__c` → `OrderItem.Id` → `OrderItem.Product2Id`, with the leading `#` stripped from both sides at each hop (all 153 cases matched an order item, 6 of which map to SecureAnalytics Pro)."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "5",
+    "run": "0",
+    "answer": "**a03Wt00000JqnHwIAJ** — the \"User Interface Bug\" issue.\n\nOver the past five months (2022-08-16 → 2023-01-16), exactly2 support cases were tied to order items for product `01tWt000006hV8LIAU` (AI Cirku-Tech), and both carry the same `IssueId__c`:\n\n| Case Id | Subject | CreatedDate | IssueId__c |\n|---|---|---|---|\n| 500Wt00000DDxScIAL | Usability Issue in AI Cirku-Tech | 2022-10-01 | a03Wt00000JqnHwIAJ |\n| 500Wt00000DDxduIAD | Interface Glitch with AI Cirku-Tech | 2022-09-16 | a03Wt00000JqnHwIAJ |\n\nJoin path: `Case.OrderItemId__c` → `OrderItem.Id` (99 order items for this product, 30 linked cases overall) → `Issue__c.Id`, with leading `#` stripped from both sides at every hop. No tie — that issue is the sole and most frequent one in the window."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "5",
+    "run": "1",
+    "answer": "**a03Wt00000JqnHwIAJ**\n\nThat's the `IssueId__c` for \"User Interface Bug\", the only issue type reported for AI Cirku-Tech (`01tWt000006hV8LIAU`) in the past five months (2022-08-16 → 2023-01-16), with 2 cases:\n\n| Case Id | CreatedDate | IssueId__c |\n|---|---|---|\n| 500Wt00000DDxduIAD | ::camber-date-time[2022-09-16T09:30:00Z] | a03Wt00000JqnHwIAJ |\n| 500Wt00000DDxScIAL | ::camber-date-time[2022-10-01T14:45:00Z] | a03Wt00000JqnHwIAJ |\n\nJoin path: `Case.OrderItemId__c` → `OrderItem.Id` → `OrderItem.Product2Id` (30 total cases tie to this product across all time), with leading `#` stripped on both sides of every hop, then `Case.IssueId__c` → `Issue__c.Id`."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "5",
+    "run": "2",
+    "answer": "I'll trace cases for this product through the order-item link and count issue types over the last five months.**a03Wt00000JqnHwIAJ** — \"User Interface Bug\".\n\nVerification:\n- Product `01tWt000006hV8LIAU` = **AI Cirku-Tech** (confirmed in `Product2`), mapped to 99 `OrderItem` ids after stripping `#` prefixes on both sides.\n- Those order items link to 30 support cases;2 fall inside the past-five-months window (2022-08-16 → 2023-01-16):\n  - `500Wt00000DDxduIAD` — \"Interface Glitch with AI Cirku-Tech\" (2022-09-16)\n  - `500Wt00000DDxScIAL` — \"Usability Issue in AI Cirku-Tech\" (2022-10-01)\n- Both carry `IssueId__c` = `a03Wt00000JqnHwIAJ` → `Issue__c.Name` = \"User Interface Bug\", making it the only and therefore most frequent issue in the window (the next cases, Workflow Integration Lag and AI Feature Malfunction, fall after 2023-01-16)."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "5",
+    "run": "3",
+    "answer": "**a03Wt00000JqnHwIAJ**\n\nThat is the issue Id (\"User Interface Bug\") with the most AI Cirku-Tech cases in the five months before 2023-01-16.\n\nSupporting detail:\n- Product `01tWt000006hV8LIAU` = **AI Cirku-Tech**; its OrderItems link to 30 support cases all-time (after stripping the spurious `#` prefix on both sides of `Case.OrderItemId__c` → `OrderItem.Id` → `OrderItem.Product2Id`).\n- In the window 2022-08-16 → 2023-01-16, exactly 2 cases fall in range, and both carry the same `IssueId__c`:\n  - `500Wt00000DDxduIAD` — \"Interface Glitch with AI Cirku-Tech\" (2022-09-16)\n  - `500Wt00000DDxScIAL` — \"Usability Issue in AI Cirku-Tech\" (2022-10-01)\n- No tie exists — that issue accounts for 2 of 2 cases in the period (the next AI Cirku-Tech cases, on 2023-01-17/18, fall just after today's date)."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "5",
+    "run": "4",
+    "answer": "**a03Wt00000JqnHwIAJ**\n\nThat issue (\"User Interface Bug\") accounts for both AI Cirku-Tech cases created in the past five months (2022-08-16 → 2023-01-16):\n\n| Case Id | Created | Subject |\n|---|---|---|\n| 500Wt00000DDxduIAD | ::camber-date-time[2022-09-16T09:30:00Z] | Interface Glitch with AI Cirku-Tech |\n| 500Wt00000DDxScIAL | ::camber-date-time[2022-10-01T14:45:00Z] | Usability Issue in AI Cirku-Tech |\n\nMethod: `Case.OrderItemId__c` → `OrderItem.Id` → `OrderItem.Product2Id = 01tWt000006hV8LIAU` (AI Cirku-Tech), with a leading `#` stripped from both sides of every join; 30 cases tie to this product overall, 2 within the five-month window, both mapping to the same `IssueId__c`."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "6",
+    "run": "0",
+    "answer": "**`ka0Wt000000EnwvIAC`** — the \"Product Quantity Limits\" knowledge article (stored as `#ka0Wt000000EnwvIAC` with the dataset's spurious `#` prefix).\n\n**Why:** Quote `0Q0Wt000001WRAzKAO` (\"NeoGreen EDA Expansion Quote\", Status *Needs Review*) has 4 line items:\n\n| Product | Qty | Discount | Policy limit |\n|---|---|---|---|\n| EcoPCB Creator | 3 | 0% | — |\n| AI Cirku-Tech | 2 | 0% | — |\n| DevVision IDE | 4 | 0% | — |\n| **CollabDesign Studio** | **35** |15% | **25 units/order** |\n\nCollabDesign Studio is quoted at 35 units, exceeding the explicit 25-units-per-order cap stated in that article — a clean numeric threshold violation.\n\nOther candidate policies check out clean: the 15% discount on 35 units is the correct tier under *Volume-Based Discounts* (15% at >20), no excluded product pairs are co-quoted under *Product Exclusion Constraints* (DevVision IDE appears without NextGen IDE), and no product on this quote is a bundle-anchor product with an unmet numeric requirement that computes as a hard mismatch."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "6",
+    "run": "1",
+    "answer": "**ka0Wt000000EnwvIAC**\n\nYes — the configuration is non-compliant. The violated article is **`ka0Wt000000EnwvIAC` — \"Product Quantity Limits\"** (stored as `#ka0Wt000000EnwvIAC` in `Knowledge__kav`; the leading `#` is the dataset's id corruption).\n\nWhy: quote `0Q0Wt000001WRAzKAO` (\"NeoGreen EDA Expansion Quote\") includes a line item for **CollabDesign Studio with Quantity = 35**, but the Product Quantity Limits policy caps CollabDesign Studio at **25 units per order** — an exact numeric overage of 10 units.\n\nOther candidates checked and cleared:\n- **Volume-Based Discounts** (`ka0Wt000000Eq0MIAS`): the 15% discount on that line is permitted at ≥20 units; the other three lines carry 0% discount. All `TotalPrice` values match qty × unit price × (1 − discount), and every unit price equals the `PricebookEntry` list price.\n- **Mandatory Bundles for Quotes** (`ka0Wt000000Ens5IAC`): AI Cirku-Tech is quoted without CircuitAI Innovator / AI DesignShift — a qualitative gap, but not a computable numeric threshold breach like the quantity cap."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "6",
+    "run": "2",
+    "answer": "**`ka0Wt000000EnwvIAC`** — the \"Product Quantity Limits\" article (stored in the data as `#ka0Wt000000EnwvIAC`).\n\nWhy: quote `0Q0Wt000001WRAzKAO` (\"NeoGreen EDA Expansion Quote\") has 4 line items, all priced at their exact price‑book list price:\n\n| Product | Qty | Unit Price | Discount |\n|---|---|---|---|\n| EcoPCB Creator | 3 | 349.99 | 0% |\n| AI Cirku-Tech | 2 | 529.99 | 0% |\n| DevVision IDE | 4 | 299.99 | 0% |\n| **CollabDesign Studio** | **35** | 399.99 | 15% |\n\nThe Product Quantity Limits policy states **CollabDesign Studio is limited to 25 units per order**, but the quote configures 35 units — a clean numeric violation. The other candidate policies check out: the 15% discount is valid under Volume-Based Discounts (line total $11,899.70 > $20 tier), and no line's unit price deviates from the price book."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "6",
+    "run": "3",
+    "answer": "**ka0Wt000000EnwvIAC** — the *Product Quantity Limits* knowledge article (stored with the dataset's spurious `#` prefix as `#ka0Wt000000EnwvIAC`).\n\nYes, the configuration is non-compliant. Quote `0Q0Wt000001WRAzKAO` (NeoGreen EDA Expansion Quote, status \"Needs Review\") contains4 lines:\n\n| Product | Qty | Unit Price | Discount | Total | Limit |\n|---|---|---|---|---|---|\n| EcoPCB Creator | 3 | 349.99 | 0% | 1,049.97 | – |\n| AI Cirku-Tech | 2 | 529.99 | 0% | 1,059.98 | – |\n| DevVision IDE | 4 | 299.99 | 0% | 1,199.96 | – |\n| **CollabDesign Studio** | **35** | 399.99 | 15% | 11,899.70 | **25 / order** |\n\nThe clean numeric mismatch: *Product Quantity Limits* caps **CollabDesign Studio at 25 units per order**, but the quote lists **35 units** — 10 over the limit. All unit prices match their PricebookEntry list prices, the 15% discount is within the Volume-Based Discounts top tier, and no Product Exclusion Constraint pair (e.g. DevVision IDE + NextGen IDE) appears in the quote, so the quantity limit is the violated policy."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "6",
+    "run": "4",
+    "answer": "I'll investigate this quote's configuration against the knowledge base policies.**`ka0Wt000000EnwvIAC`** — the \"Product Quantity Limits\" article (stored in the data as `#ka0Wt000000EnwvIAC`).\n\nYes, the configuration is non-compliant. Quote `0Q0Wt000001WRAzKAO` (\"NeoGreen EDA Expansion Quote\", Status *Needs Review*) has 4 line items:\n\n| Product | Qty | Unit Price | Discount | Total |\n|---|---|---|---|---|\n| EcoPCB Creator | 3 | 349.99 | 0% | 1049.97 |\n| AI Cirku-Tech | 2 | 529.99 | 0% | 1059.98 |\n| DevVision IDE | 4 | 299.99 | 0% | 1199.96 |\n| **CollabDesign Studio** | **35** | 399.99 | 15% | 11899.7025 |\n\nThe Product Quantity Limits policy caps **CollabDesign Studio at 25 units per order**; the quote lists 35 units — a clean numeric violation. The 15% discount on that line is compliant with the Volume-Based Discounts policy (15% for purchases over $20), and unit prices match the price book list prices, so quantity is the only breach."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "7",
+    "run": "0",
+    "answer": "I'll investigate this case against the knowledge base. Let me start by loading the support database.**ka0Wt000000EoD3IAK**\n\nYes — the agent breached policy. Article `ka0Wt000000EoD3IAK` (\"Addressing Scalability Challenges in Electronic Design Automation with TechPulse Solutions\") states the Scalability Enhancement Package \"is available to enterprises 30 days after the purchase date\" and \"operate[s] within a validity period of 365 days.\"\n\nEvidence trace (all `#` prefixes stripped at each hop):\n- Case `500Wt00000DDyznIAD` (stored as `#500Wt00000DDyznIAD`), created **2022-09-22**, `OrderItemId__c = 802Wt000007928FIAQ`.\n- That order item → Order `801Wt00000PHWWXIA5`, `EffectiveDate = 2021-09-20`, product `QuantumPCB Modeler` (qty 10).\n- Agent Chloe Duval explicitly recommended the **Scalability Enhancement Package** in the case's email thread.\n- Days from purchase to case: **367 days > 365-day validity window**, so the package was no longer valid when offered."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "7",
+    "run": "1",
+    "answer": "**ka0Wt000000EoD3IAK** — yes, the agent breached policy.\n\n**Why:**\n\n| Fact | Value |\n|---|---|\n| Case | `500Wt00000DDyznIAD` — \"Scalability Problems\", High, GreenStar Electronics |\n| Case created | 2022-09-22T19:28:00Z |\n| Order item `802Wt000007928FIAQ` | QuantumPCB Modeler, EffectiveDate 2021-09-20 (Activated) |\n| Days since purchase | **367** |\n\nAgent Chloe Duval (OwnerId `005Wt000003NHsrIAG`) recommended and then scheduled the **Scalability Enhancement Package** in the case's email thread. Knowledge article `ka0Wt000000EoD3IAK` (\"Addressing Scalability Challenges in Electronic Design Automation with TechPulse Solutions\") explicitly states that package \"is available to enterprises 30 days after the purchase date\" and \"is constructed to operate within a **validity period of 365 days**.\" The purchase became effective 2021-09-20, so the window closed 2022-09-20 — two days before the case was opened, making the recommendation ineligible.\n\nThe other articles naming entities from this case (`ka0Wt000000Ep5tIAC`, `ka0Wt000000EoHwIAK` on QuantumPCB Modeler; `ka0Wt000000EowDIAS` on FlexiDesign Pro scalability) state no numeric threshold that this case's data violates."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "7",
+    "run": "2",
+    "answer": "**ka0Wt000000EoD3IAK**\n\nYes — the agent breached the policy in article `ka0Wt000000EoD3IAK` (\"Addressing Scalability Challenges in Electronic Design Automation with TechPulse Solutions\").\n\nEvidence chain (all `#` prefixes stripped at every hop):\n- Case `500Wt00000DDyznIAD` — Priority High, Subject \"Scalability Problems\", created **2022-09-22T19:28:00Z**, issue type \"Scalability Issue\", product QuantumPCB Modeler, account `001Wt00000PGaZCIA1`, owner `005Wt000003NHsrIAG` (agent Chloe Duval per the email thread).\n- In the email thread the agent explicitly recommends and schedules the **\"Scalability Enhancement Package\"**.\n- The only KB article naming that package is `ka0Wt000000EoD3IAK`, which states it \"is available to enterprises **30 days after the purchase date**\" and \"operate[s] within a **validity period of 365 days**\".\n- Case `OrderItemId__c` = `802Wt000007928FIAQ` → Order `801Wt00000PHWWXIA5` (product `01tWt000006hVGPIA2` = QuantumPCB Modeler), `EffectiveDate` = **2021-09-20**.\n- Elapsed: **367 days** from purchase to case creation — outside the 365-day validity window, so offering the Scalability Enhancement Package violated that article's numeric window."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "7",
+    "run": "3",
+    "answer": "I'll investigate this case against the knowledge base. Let me start by loading the support database.**`ka0Wt000000EoD3IAK`** — yes, the agent breached policy.\n\n**Evidence chain:**\n\n| Step | Value found |\n|---|---|\n| Case `500Wt00000DDyznIAD` | Subject \"Scalability Problems\", created `2022-09-22T19:28:00`, owner `005Wt000003NHsrIAG`, OrderItemId__c `802Wt000007928FIAQ` |\n| OrderItem → Order (`#`-stripped joins) | Product **QuantumPCB Modeler**, Qty 10.0, Order `801Wt00000PHWWXIA5`, EffectiveDate **2021-09-20** |\n| Email thread | Agent Chloe Duval explicitly recommends and schedules the **\"Scalability Enhancement Package\"** (implementation start Sept 27) |\n| KB article `ka0Wt000000EoD3IAK` (\"Addressing Scalability Challenges in Electronic Design Automation with TechPulse Solutions\") | Package is \"available to enterprises **30 days after the purchase date**\" and \"operate within a **validity period of 365 days**\" |\n\nPurchase date 2021-09-20 → case date 2022-09-22 = **367 days**, which falls outside the article's explicit 365-day validity window, so recommending and scheduling the Scalability Enhancement Package violated that article's numeric criterion.\n\nOther candidate articles were checked and ruled out: the two QuantumPCB Modeler articles (`ka0Wt000000Ep5tIAC`, `ka0Wt000000EoHwIAK`) contain no numeric threshold, and the Volume-Based Installation Timeline Policy (`ka0Wt000000EpSUIA0`) defines tiers only for 1/5/15/25 units — no tier for the 10 units purchased, so no clean computable mismatch there."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "7",
+    "run": "4",
+    "answer": "**ka0Wt000000EoD3IAK**\n\nYes — the agent breached policy. Details:\n\n- **Case 500Wt00000DDyznIAD** (High, \"Scalability Problems\", GreenStar Electronics, created **2022-09-22**) concerns scaling **QuantumPCB Modeler**.\n- In the case's own email thread, agent **Chloe Duval** recommended and scheduled the **\"Scalability Enhancement Package\"**.\n- The matching knowledge article **ka0Wt000000EoD3IAK** — *\"Addressing Scalability Challenges in Electronic Design Automation with TechPulse Solutions\"* — states the package is available 30 days after purchase and **operates within a validity period of 365 days**.\n- The case's `OrderItemId__c` 802Wt000007928FIAQ → Order 801Wt00000PHWWXIA5 (QuantumPCB Modeler) has `EffectiveDate` **2021-09-20**, i.e. the case was opened **367 days** after purchase — **2 days past the 365-day validity window**, so the package should not have been offered."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "8",
+    "run": "0",
+    "answer": "**005Wt000003NIliIAG**\n\nDetails of the derivation:\n\n- **Window (last 4 quarters as of 2023-04-10):** 2022-04-01 → 2023-03-31 (2022Q2–2023Q1), containing 39 `Owner Assignment` history rows across 38 cases.\n- **Transfers in that window:** exactly one reassignment event — case `500Wt00000DDZtLIAX` moved from `005Wt000003NIliIAG` → `005Wt000003NGjuIAG` on::camber-date-time[2022-05-15T14:12:42Z]. Per the policy, that transfer counts against the *originating* agent, `005Wt000003NIliIAG` (transfer count = 1).\n- **Case-handling filter:** `005Wt000003NIliIAG` was the assigned owner on 2 cases in the window, so it passes the \"more than 0 cases handled\" filter.\n- All other agents active in the window have no recorded transfer events (they never appear as a transferring agent), so among the agents with a computed transfer count, `005Wt000003NIliIAG` is the minimum at 1.\n\nAll ids were normalized by stripping the leading `#` corruption on `CaseId__c`, `OldValue__c`, `NewValue__c`, `Case.Id`, and `Case.OwnerId` before joining/grouping."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "8",
+    "run": "1",
+    "answer": "**`005Wt000003NIliIAG`**\n\nIn the last 4 quarters (2022‑Q2 through 2023‑Q1, relative to today 2023‑04‑10), only one agent recorded any transfer at all among agents who handled cases: `005Wt000003NIliIAG` (Aisha Ali), with a transfer count of **1** (case `500Wt00000DDZtLIAX`, transferred to `005Wt000003NGjuIAG` on ::camber-date-time[2022-05-15T14:12:42Z]).\n\nDetails:\n- Owner-assignment history rows in the window: 39, covering 38 distinct cases and 32 agents.\n- All other 31 agents who handled ≥1 case in the window have a transfer count of 0, so if strictly-zero counts are excluded (i.e., only agents who actually appear as a transferring agent), this agent is the fewest — and it is also the only one."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "8",
+    "run": "2",
+    "answer": "I'll load the support database's case history and case tables to trace owner assignments.**005Wt000003NIliIAG**\n\nIn the last 4 quarters (2022-04-01 → 2023-03-31, relative to today 2023-04-10), the `CaseHistory__c` \"Owner Assignment\" records contain exactly one transfer event, and its `OldValue__c` (the transferring-from agent) is `005Wt000003NIliIAG`. That agent handled 3 cases in the window (so passes the \">0 cases handled\" filter) and has the fewest non-zero transfer count — 1. All 31 other agents active in the window have0 transfers, i.e. no transfer count at all."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "8",
+    "run": "3",
+    "answer": "I'll start by loading the support database's case history data.**005Wt000003NIliIAG**\n\nThat is the only agent with a computable (non-zero) transfer count in the last 4 quarters — Aisha Ali, with 1 transfer.\n\nHow it was derived:\n- Window: last 4 completed quarters relative to 2023-04-10 → **2022-04-01 → 2023-03-31**.\n- `CaseHistory__c` rows with `Field__c = 'Owner Assignment'` (165 total, `#`-prefixes stripped from `CaseId__c`, `OldValue__c`, `NewValue__c`); cases with >1 assignment are the transferred ones (12 across all time).\n- Exactly **one** transfer event falls in the window: case `500Wt00000DDZtLIAX`, transferred `005Wt000003NIliIAG` → `005Wt000003NGjuIAG` on ::camber-date-time[2022-05-15T14:12:42Z].\n- `005Wt000003NIliIAG` handled 3 cases in the window (>0), satisfying the case filter → transfer count = 1.\n\nCaveat worth flagging: 31 other agents handled >0 cases in the window with0 transfer events, so if the policy intends literal ties at zero to be eligible, the minimum would be a 31-way tie rather than a single agent. `005Wt000003NIliIAG` is the unique agent whose transfer count is actually observable in the data for this period."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "8",
+    "run": "4",
+    "answer": "I'll work through the case history transfer records in the `support` database.**`005Wt000003NIliIAG`**\n\nEvidence trail (window = last 4 quarters before 2023‑04‑10, i.e. 2022‑04‑01 → 2023‑03‑31):\n\n- 38 cases were created in the window, producing 39 `Owner Assignment` history rows (all `CaseId__c`, `OldValue__c`, `NewValue__c` values `#`-normalized before matching).\n- Exactly **one** of those rows has a non-null `OldValue__c`, i.e. one real transfer: case `500Wt00000DDZtLIAX` (\"Severe Latency in Integration\") moved from `005Wt000003NIliIAG` → `005Wt000003NGjuIAG` on ::camber-date-time[2022-05-15T14:12:42Z].\n- So `005Wt000003NIliIAG` (Aisha Ali) is the only agent with a transfer count of 1; it handled 3 cases in the window (2 initial assignments + the transferred one), satisfying the \">0 cases handled\" filter.\n- Caveat worth stating: the other 31 agents who handled cases in this window recorded **no** transfers at all (count 0), so if zero-transfer agents are included in the ranking the \"fewest\" is a 31-way tie with no unique answer; the only agent with a computable transfer count in the window is `005Wt000003NIliIAG`."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "9",
+    "run": "0",
+    "answer": "**MI** (Michigan).\n\nAverage case closure time by account shipping state, for the 26 cases closed in the past 6 quarters (2021Q3–2022Q4, relative to 2022-10-26):\n\n| State | Cases closed | Avg closure time |\n|---|---|---|\n| **MI** | 1 | **15.97 min** |\n| SC | 1 | 21.58 min |\n| AZ | 1 | 62.37 min |\n| TX | 5 | 71.62 min |\n| IA | 3 | 98.20 min |\n| NJ | 2 | 109.48 min |\n| FL | 4 | 131.85 min |\n\nMethod: parsed the `support.sql` dump (`INSERT INTO \"Case\"` statements) into SQLite, kept the 75 cases with a non-null `ClosedDate`, computed `ClosedDate − CreatedDate`, and joined `Case.AccountId` → `Account.ShippingState` after stripping the spurious leading `#` from both sides (all 75 rows matched an account, confirming clean normalization). MI ranks fastest under both plausible 6-quarter windows (2021Q3–2022Q4 and 2021Q2–2022Q3), driven by case `#500Wt00000DE077IAD` closed in~16 minutes."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "9",
+    "run": "1",
+    "answer": "**MI**\n\nMichigan has the quickest average case closure time among all states with cases closed in the past 6 quarters (2021 Q2 – 2022 Q3): **0.27 hours** (~16 minutes).\n\nRanking of the fastest states in that window (mean hours from `Case.CreatedDate` → `Case.ClosedDate`, joined to `Account.ShippingState` after stripping the `#` id prefixes on both sides):\n\n| State | Closed cases | Mean hours |\n|---|---|---|\n| MI | 1 | 0.27 |\n| SC | 1 | 0.36 |\n| AZ | 1 | 1.04 |\n| TX | 5 | 1.19 |\n| FL | 3 | 1.32 |\n\nMI stayed in first place under every reasonable window definition tested (quarters anchored on 2021Q2–2022Q3 vs 2021Q3–2022Q4, and filtering on closed date vs created date), so the result is not sensitive to the quarter boundary choice. Note the caveat that MI, SC, and AZ each have only one closed case in the window, while TX (5 cases) is the fastest state with a meaningful sample."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "9",
+    "run": "2",
+    "answer": "**MI**\n\nOver the past 6 quarters (2021Q2–2022Q3relative to 2022-10-26), cases from accounts shipping to **MI** closed fastest, with an average closure time of 0.266 hours (~16 minutes).\n\nMethod:153 support cases loaded from the `support` Postgres dump; 75 have a `ClosedDate`. Case `AccountId` was `#`-normalized and joined to `core_crm.Account` (75/75 matched), closure time = `ClosedDate − CreatedDate`, then averaged by `Account.ShippingState` for cases closed in the trailing 6 quarters.\n\nNext closest states: SC (0.360 h), AZ (1.039 h), TX (1.194 h, 5 cases), FL (1.325 h). MI ranks first under both a closed-date and created-date quarter window, and also if the window is shifted to include 2022Q4."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "9",
+    "run": "3",
+    "answer": "**MI** (Michigan).\n\nAveraging case closure time (ClosedDate − CreatedDate) per account's ShippingState over the past 6 quarters, Michigan is fastest:\n\n| State | Avg closure | Closed cases |\n|---|---|---|\n| MI | 15.97 min | 1 |\n| SC | 21.58 min | 1 |\n| AZ | 62.37 min | 1 |\n| TX | 71.62 min | 5 |\n| IA | 98.20 min | 3 |\n\nMethod notes:\n- Loaded the `support` Postgres dump (INSERT-style statements) and joined `Case.AccountId` → `Account.Id` in `core_crm`, stripping the spurious leading `#` on both sides (0 unmatched of 153 cases).\n- Restricted to cases closed in the trailing 6 quarters relative to 2022-10-26; theranking is identical whether the window is taken as 2021Q3–2022Q4 (26 closed cases) or the6 completed quarters 2021Q2–2022Q3 (27 cases), and identical when filtering on CreatedDate instead.\n- MI's figure comes from a single case (`#500Wt00000DE077IAD`, Quantum Dynamics LLC, created 2021-07-22 09:45 → closed 10:00:58), so it wins on a low sample count; TX is the fastest state with a meaningful volume (5 cases)."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "9",
+    "run": "4",
+    "answer": "**MI**\n\nMichigan has the quickest average case closure time over the past 6 quarters (2021Q2 – 2022 Q3, i.e. closures from 2021-04-01 through 2022-09-30): **0.27 hours** (~16 minutes) from `CreatedDate` to `ClosedDate`.\n\nSupporting detail — fastest states in that window (27 closed cases total, all account joins matched after stripping the `#` prefix):\n\n| State | Cases | Avg hours to close |\n|---|---|---|\n| MI | 1 | 0.27 |\n| SC | 1 | 0.36 |\n| AZ | 1 | 1.04 |\n| TX | 5 | 1.19 |\n| FL | 3 | 1.32 |\n\nMI ranks first under every reasonable interpretation of the 6-quarter window (calendar quarters 2021Q2–2022Q3, 2021Q3–2022Q4, a rolling 18 months back from 2022-10-26, and filtering on creation date instead of closure date). Note MI's average rests on a single closed case, so it is a low-volume winner; TX (5 cases, 1.19 h) is the fastest state with meaningful volume."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "10",
+    "run": "0",
+    "answer": "**`005Wt000003NDqDIAW`**\n\nThat agent is the only one who touched more than one case created in the past four months (2023-05-02 → 2023-09-02) — 3 cases total — and its average handle time on non-transferred, closed cases is **0.245 hours (~14.7 minutes)**, the lowest of all agents in the window.\n\nSupporting detail:\n- 16 cases created in the window; 7 closed, 2 transferred (>1 `Owner Assignment`, excluded from handle-time computation per the policy).\n- Case counting used every agent appearing in an `Owner Assignment` `NewValue__c` (initial assignee + transfer recipient), with `#` prefixes stripped on both sides of each join.\n- All other agents touched only 1 windowed case, so they fail the \">1 case\" filter (next lowest averages: `005Wt000003NEtOIAW` 0.280 h, `005Wt000003NJGLIA4` 0.401 h — both single-case).\n- The qualifying case for the winner: `500Wt00000DDzUPIA1`, opened 2023-05-10 14:45 → closed 2023-05-10 14:59:42."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "10",
+    "run": "1",
+    "answer": "I'll start by loading the support database tables needed for this analysis.**005Wt000003NDqDIAW**\n\nDetails from the data:\n\n- **Window:** 2023-05-02 → 2023-09-02 (past four months from today's date) on `Case.CreatedDate` — 16 cases fall in it.\n- **Eligibility (>1 case handled):** counting every agent appearing as a `NewValue__c` on an `Owner Assignment` history row (initial assignment *or* transfer-in), only one agent handled more than one case: `005Wt000003NDqDIAW`, with 3 cases (`500Wt00000DDzUPIA1`, `500Wt00000DDzZHIA1`, `500Wt00000DDzivIAD`).\n- **Handle time (excluding transferred cases, i.e. only cases with exactly one `Owner Assignment`, and only closed cases):** of that agent's 3 cases, one is closed — `500Wt00000DDzUPIA1`, opened 2023-05-10 14:45 UTC, closed 2023-05-10 14:59:42 UTC → **0.245 h (≈14.7 minutes)**, giving an average handle time of 0.245 h.\n\nThe result is unchanged whether the four-month boundary is taken as 2023-05-01, 05-02, or 05-03; no other agent meets the >1-case threshold in this window, so this agent is the answer by default rather than by a close margin."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "10",
+    "run": "2",
+    "answer": "**005Wt000003NDqDIAW**\n\nOver the past four months (2023-05-02 → 2023-09-02), that is the only agent who handled more than one case, and it also has the lowest average handle time.\n\n| Agent Id | Cases handled in window | Cases used for handle time (not transferred, closed) | Avg handle time |\n|---|---|---|---|\n| 005Wt000003NDqDIAW | 3 | 1 | 0.245 h (≈14.7 min) |\n\nHow it was derived:\n- 16 cases were created in the window (`Case.CreatedDate` in `support`).\n- Case counts per agent came from every `CaseHistory__c` \"Owner Assignment\" row (so both initial assignee and transferee count), with leading `#` stripped from all ids.\n- Handle time = `ClosedDate − CreatedDate`, computed only for cases with exactly one \"Owner Assignment\" (i.e. never transferred) and a non-null `ClosedDate`. Case `500Wt00000DDzUPIA1` (2023-05-10 14:45 → 14:59:42) is the qualifying case for this agent; its other two window cases (`500Wt00000DDzivIAD`, `500Wt00000DDzZHIA1`) are still open.\n- All other agents in the window own only 1 case each, so they are filtered out by the \"more than one case\" condition."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "10",
+    "run": "3",
+    "answer": "I'll start by loading the support database tables needed for this analysis.**005Wt000003NDqDIAW**\n\nWithin the past four months (2023-05-02 → 2023-09-02, cases opened in that window), this is the only agent appearing on more than one case, and its average handle time on non-transferred cases is the lowest at **0.245 hours (~14.7 minutes)**.\n\nSupporting detail:\n- 16 cases fall in the window; owner-assignment links (from `CaseHistory__c.Field__c = 'Owner Assignment'`, `NewValue__c` = agent) give 16 distinct agents, of which only `005Wt000003NDqDIAW` handled >1 case (3 cases: `500Wt00000DDzUPIA1`, `500Wt00000DDzivIAD`, `500Wt00000DDzZHIA1`).\n- Handle time computed only for its non-transferred (`Owner Assignment` count = 1) closed case `500Wt00000DDzUPIA1`: 2023-05-10 14:45:00 → 14:59:42 = 0.245 h. Its other two cases are still `Waiting on Customer` (no `ClosedDate`).\n- All join keys were `#`-stripped on both sides; the result is stable under alternate 4-month boundary choices (2023-05-01 start, 2023-08-31 end)."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "10",
+    "run": "4",
+    "answer": "**005Wt000003NDqDIAW**\n\nReasoning:\n- Window = 2023-05-02 → 2023-09-02 (past four months from today): 16 cases created, 2 of which were transferred (>1 Owner Assignment) and are excluded from handle-time computation.\n- Counting cases handled per agent from all `Owner Assignment` entries on those 16 cases, only one agent handled more than one case: `005Wt000003NDqDIAW` (3 cases).\n- Its non-transferred, closed case `500Wt00000DDzUPIA1` gives a handle time of 0.245 h (14m42s) → average handle time 0.245 hours, the lowest (and only) qualifying agent under the >1-case filter."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "11",
+    "run": "0",
+    "answer": "**`01tWt000006hV8LIAU`** — AI Cirku-Tech.\n\nTrace:\n- Contact `003Wt00000Jqy8SIAR` (Anita Kabir) → Account `001Wt00000PGXrNIAX` (FutureTech Innovations)\n- That account's only order last month (today = ::camber-date-time[2021-07-15], so June 2021): Order `801Wt00000PHRYWIA5`, EffectiveDate `2021-06-15`, Activated\n- Its two line items: **AI Cirku-Tech** (`01tWt000006hV8LIAU`, qty 10@ 476.991) — \"AI-driven circuit design platform\" — and CloudLink Designer (`01tWt000006hTUkIAM`), a cloud design-collaboration tool\n- The AI product in that June transaction is AI Cirku-Tech; allids were `#`-normalized on both sides of every join."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "11",
+    "run": "1",
+    "answer": "**`01tWt000006hV8LIAU`** — the product Id for **AI Cirku-Tech**.\n\nTrace: Contact `003Wt00000Jqy8SIAR` (Anita Kabir) → Account `001Wt00000PGXrNIAX` (FutureTech Innovations) → Order `801Wt00000PHRYWIA5`, EffectiveDate `2021-06-15` (last month relative to 2021-07-15, Activated) → 2 line items: **AI Cirku-Tech** (`01tWt000006hV8LIAU`, qty 10, \"AI-driven circuit design platform\") and CloudLink Designer (a cloud collaboration tool, not an AI processing unit). The account's only other order is dated `2021-11-01`, outside the window."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "11",
+    "run": "2",
+    "answer": "**`01tWt000006hV8LIAU`** — the Product2 Id for **AI Cirku-Tech** (\"AI-driven circuit design platform\"), the only AI product on the contact's last-month purchase.\n\nTrace (all ids `#`-normalized at each hop):\n- Contact `003Wt00000Jqy8SIAR` = Anita Kabir → Account `001Wt00000PGXrNIAX` (FutureTech Innovations)\n- That account's only order effective last month (June 2021) is `801Wt00000PHRYWIA5` (Activated, 2021-06-15); its other order is dated 2021-11-01\n- That order has 2 line items: AI Cirku-Tech (`01tWt000006hV8LIAU`, qty 10) and CloudLink Designer (`01tWt000006hTUkIAM`, qty 20) — only the former is an AI product"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "11",
+    "run": "3",
+    "answer": "**`01tWt000006hV8LIAU`** — the Product2 Id for **AI Cirku-Tech**.\n\nTrace:\n- Contact `003Wt00000Jqy8SIAR` → Anita Kabir, Account `001Wt00000PGXrNIAX` (core_crm).\n- That account has 2 orders; the one effective **2021-06-15** (`801Wt00000PHRYWIA5`, Activated) is the \"last month\" purchase relative to 2021-07-15.\n- Its two line items: **AI Cirku-Tech** (`01tWt000006hV8LIAU`, qty 10 — \"AI-driven circuit design platform\") and CloudLink Designer (`01tWt000006hTUkIAM`, cloud design collaboration). Only the former is the AI processing product.\n- All joins (`Contact.AccountId` → `Order.AccountId` → `OrderItem.OrderId` → `Product2.Id`) were done with leading `#` stripped on both sides."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "11",
+    "run": "4",
+    "answer": "**`01tWt000006hV8LIAU`** — the Product2 Id for **AI Cirku-Tech** (\"AI-driven circuit design platform offering rapid prototyping and innovation support\"), the AI product purchased last month.\n\nTrace (allids `#`-normalized at each hop):\n- Contact `003Wt00000Jqy8SIAR` = Anita Kabir → Account `001Wt00000PGXrNIAX` (FutureTech)\n- That account's orders effective in June 2021 (relative to 2021-07-15): effective date `2021-06-15`, Activated, with two line items — `802Wt0000079AU1IAM` → **AI Cirku-Tech** (`01tWt000006hV8LIAU`) and `802Wt0000079B6hIAE` → CloudLink Designer (`01tWt000006hTUkIAM`, a cloud collaboration tool, not AI)\n- Only AI Cirku-Tech matches the \"AI processing/circuit unit\" description (External_ID__c: `AI-Powered Circuit Design Tools,Customizable Workflow Automation_5`); all other account purchases are dated 2021-11-01."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "12",
+    "run": "0",
+    "answer": "**005Wt000003NDEBIA4**\n\nApplying the Sales Cycle Policy literally (creation date → the corresponding contract's `CompanySignedDate`), only one opportunity has a company-signed \"closing\" date in April 2023:\n\n| Opportunity | Owner (agent) | CreatedDate | CompanySignedDate | Cycle days |\n|---|---|---|---|---|\n| 006Wt000007BI41IAG | 005Wt000003NDEBIA4 | 2022-06-15 | 2023-04-15 | 304 |\n\nSo that owner — `005Wt000003NDEBIA4` (Nadia Al-Balushi) — has the quickest (and only) average turnaround of 304 days for April 2023.\n\nVerification notes: leading `#` stripped on both sides of the Opportunity ↔ Contract join (all 163 contract-linked opportunities matched,0 unparsed dates), and the alternative `Opportunity.CloseDate` window was checked separately — it yields a different set of records/agents and is not the policy-defined closing date."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "12",
+    "run": "1",
+    "answer": "**005Wt000003NDEBIA4**\n\nApplying the Sales Cycle Policy literally (cycle = days from `Opportunity.CreatedDate` to `Contract.CompanySignedDate`, with the April‑2023 window on the closing/company‑signed date), only one opportunity closed in April 2023:\n\n| Opportunity | Owner (agent) | Created | CompanySignedDate | Cycle (days) |\n|---|---|---|---|---|\n| 006Wt000007BI41IAG | 005Wt000003NDEBIA4 | 2022-06-15 | 2023-04-15 | 304 |\n\nThat agent is Nadia Al-Balushi, so by default she holds the quickest (and only) average turnaround of 304 days for April 2023. All joins were `#`-normalized on both sides (163/163 opportunity→contract matches)."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "12",
+    "run": "2",
+    "answer": "**005Wt000003NDEBIA4**\n\nPer the Sales Cycle Policy (opportunity `CreatedDate` → corresponding contract's `CompanySignedDate`), only one opportunity closed (company-signed) in April 2023:\n\n| Opportunity | Owner (agent) | Created | CompanySignedDate | Cycle days |\n|---|---|---|---|---|\n| 006Wt000007BI41IAG | 005Wt000003NDEBIA4 | 2022-06-15| 2023-04-15 | 304 |\n\nThat owner is Nadia Al-Balushi, so she holds the quickest (and only) average turnaround of 304 days for April 2023. Join keys were `#`-normalized on both sides at every hop (Opportunity.ContractID__c → Contract.Id → User.Id); all 163 contract-linked opportunities matched cleanly."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "12",
+    "run": "3",
+    "answer": "I'll analyze the sales cycle using Opportunity.CreatedDate and Contract.CompanySignedDate per the policy definition.**005Wt000003NDEBIA4**\n\nApplying the Sales Cycle Policy literally (`Contract.CompanySignedDate` − `Opportunity.CreatedDate`, with the April-2023 window on the policy's closing date):\n\n- All 163 opportunities with a `ContractID__c` joined cleanly to `Contract` after stripping the leading `#` on both sides (163/163 matched, 0 negative cycles).\n- Exactly one contract in the dataset has a `CompanySignedDate` in April 2023 → opportunity `006Wt000007BI41IAG`, created 2022-06-15, signed 2023-04-15, cycle = 303 days, owner `005Wt000003NDEBIA4` (Adam Brooks in `core_crm.User`).\n\nSo that owner is the only — and therefore the quickest-average — agent under this window. (For reference, the alternative reading \"opportunities *created* in April 2023\" gives 3 records with `005Wt000003NJgAIAW` fastest at 48 days; the policy's wording of \"closing\" points to the CompanySignedDate window used above.)"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "12",
+    "run": "4",
+    "answer": "**005Wt000003NDEBIA4**\n\nPer the Sales Cycle Policy (Opportunity.CreatedDate → Contract.CompanySignedDate), exactly one contract-linked opportunity closed in April 2023:\n\n| Opportunity | Owner (Agent Id) | Created | CompanySignedDate | Cycle (days) |\n|---|---|---|---|---|\n| 006Wt000007BI41IAG | 005Wt000003NDEBIA4 | 2022-06-15 10:20:30 | 2023-04-15 | 303.57 |\n\nSo that owner holds the only — and therefore quickest — average turnaround for April 2023. Keys were normalized by stripping the leading `#` on both `Opportunity.ContractID__c`/`Contract.Id` and `OwnerId` (163/163 opportunities matched a contract, no duplicate contract ids)."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "13",
+    "run": "0",
+    "answer": "**005Wt000003NIXCIA4** — the Order owner (agent Zanele Mofokeng) with the top sales figures for orders in the past five months (2022-06-25 → 2022-11-25), totaling **46,919.15**.\n\nHow it was computed:\n- Sales amount per order = Σ(`OrderItem.Quantity` × `OrderItem.UnitPrice`), aggregated to the order, then grouped by `Order.OwnerId` (allids `#`-normalized before every join).\n- Eligibility window applied via the associated contract's `CompanySignedDate` (orders paired to contracts by account + `EffectiveDate`↔`StartDate`; 16 eligible orders). The single largest order, `801Wt00000PH8yvIAD` (contract `800Wt00000DE2vLIAT`, signed 2022-06-29), drives the top spot.\n- This agent also ranks #1 under the simpler alternative of windowing on `Order.EffectiveDate` (15 orders), so the result is stable across both readings of the window."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "13",
+    "run": "1",
+    "answer": "**005Wt000003NIXCIA4**\n\nThat agent tops sales for orders in the past five months (2022-06-25 → 2022-11-25) with **$46,919.15**, computed as Σ(OrderItem.Quantity × OrderItem.UnitPrice) per order, grouped by `Order.OwnerId`.\n\nVerification details:\n- The result is identical under both eligibility readings: filtering on `Order.EffectiveDate` in the window, and filtering on the linked `Contract.CompanySignedDate` (order↔ contract matched by normalized `AccountId` + `EffectiveDate` = `StartDate`, 163/163 orders matched 1:1).\n- Winning order: `801Wt00000PH8yvIAD` (EffectiveDate 2022-07-01, contract `800Wt00000DE2vLIAT` company-signed 2022-06-29).\n- Runners-up: `005Wt000003NGtcIAG` ($40,914.23, EffectiveDate basis) and `005Wt000003NIaRIAW` ($24,219.03).\n- All join keys had a leading `#` stripped on both sides at every hop."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "13",
+    "run": "2",
+    "answer": "**005Wt000003NIXCIA4**\n\nThat agent (Order.OwnerId) tops sales for orders in the past five months (2022-06-25 → 2022-11-25) with **$46,919.15** from one order.\n\nHow it was computed:\n- Order sales amount = Σ(`OrderItem.Quantity` × `OrderItem.UnitPrice`) per order, aggregated by `Order.OwnerId`.\n- Eligibility window applied via the corresponding contract's `Contract.CompanySignedDate` ∈ [2022-06-25, 2022-11-25]; orders were matched to contracts within the same normalized `AccountId` where `Order.EffectiveDate = Contract.StartDate` (16 qualifying orders, $256,581.07 total).\n- All join keys had the spurious leading `#` stripped on both sides at every hop (Order↔OrderItem, Order↔Contract).\n- Robustness check: ranking by `Order.EffectiveDate` in the same window gives the same top agent (`005Wt000003NIXCIA4`, $46,919.15), and the runner-up (`005Wt000003NHw5IAG`, $26,353.56) is well behind."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "13",
+    "run": "3",
+    "answer": "**005Wt000003NIXCIA4**\n\nThat agent (Order.OwnerId) tops order sales for the past five months (2022-06-25 → 2022-11-25) with **$46,919.15**, computed as Σ(OrderItem.Quantity × OrderItem.UnitPrice) over their orders.\n\nVerification notes:\n- All join keys were normalized by stripping the leading `#` at every hop (Order↔OrderItem, Order↔Contract via Account+date, Contract↔Opportunity.ContractID__c) — 689/689 order items matched their orders, 163/163 contracts matched opportunities.\n- Result is stable under both window interpretations: filtering on `Order.EffectiveDate` and filtering via the corresponding contract's `CompanySignedDate` both rank `005Wt000003NIXCIA4` first at the same $46,919.15, and it holds for start dates 2022-06-25 / 06-26 / 07-01. Runner-up is `005Wt000003NGtcIAG` at $40,914.23."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "13",
+    "run": "4",
+    "answer": "**005Wt000003NIXCIA4**\n\nThat agent (Zanele Mofokeng) leads with **$46,919.15** in order sales, roughly 1.8× the runner-up.\n\nHow it was computed:\n- Joined `Order` → `OrderItem` (leading `#` stripped on both sides) and summed `Quantity * UnitPrice` per line item, per the Sales Amount Policy.\n- Eligibility window: contract `CompanySignedDate` between 2022-06-25 and 2022-11-25 (past five months from 2022-11-25). Orders were tied to their contract via normalized `AccountId` + `EffectiveDate` = `Contract.StartDate` (no direct FK exists; this pairing is 1:1 for all 163 orders, and every account's order count matches its contract count).\n- 16 eligible orders / 61 line items entered the ranking; no duplicate orders were introduced by the join.\n- Robustness:ranking the same metric on `Order.EffectiveDate` instead also puts 005Wt000003NIXCIA4 first at the identical $46,919.15, so the top agent is stable under either date interpretation."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "1",
+    "run": "0",
+    "answer": "I'll load both databases and identify Los Angeles businesses from their own descriptions only.The top 5 businesses located in Los Angeles, California by highest average rating are:\n\n| Rank | Business | Avg. Rating | Reviews |\n|---|---|---|---|\n| 1 | **Widows Peak Salon** | 4.86 | 35 |\n| 2 | **City Textile** | 4.50 | 6 |\n| 3 | **Nobel Textile Co** | 4.29 | 7 |\n| 4 | **San Soo Dang** | 4.28 | 18 |\n| 5 | **Nova Fabrics** | 3.33 | 6 |\n\nMethod: 7 businesses in `business_description` state a Los Angeles, CA address in their own description (location taken only from the business's own record, never inferred from review text). Average ratings computed from the 2,000 reviews in the SQLite `review` table joined on `gmap_id`. The remaining two LA businesses were Ace Jewelry & Loan (3.29) and Beads and More (3.22)."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "1",
+    "run": "1",
+    "answer": "I'll load both databases and identify Los Angeles businesses from their own descriptions, then rank by average review rating.**Top 5 businesses located in Los Angeles, California by highest average rating:**\n\n| # | Business | Average rating | Reviews |\n|---|---|---|---|\n| 1 | Widows Peak Salon | 4.86 | 35 |\n| 2 | City Textile | 4.50 | 6 |\n| 3 | Nobel Textile Co | 4.29 | 7 |\n| 4 | San Soo Dang | 4.28 | 18 |\n| 5 | Nova Fabrics | 3.33 | 6 |\n\nMethod: LA businesses were identified using only each business's own `business_description.description` address text (7 qualified — Los Angeles ZIPs 90005, 90012, 90014, 90021, 90023), then average ratings were computed from the `review` table joined on `gmap_id`. The remaining two LA businesses were Ace Jewelry & Loan (3.29) and Beads and More (3.22)."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "1",
+    "run": "2",
+    "answer": "I'll load both databases and identify Los Angeles businesses from their own descriptions.The top 5 Los Angeles businesses by average rating are:\n\n| # | Business | Avg rating | Reviews |\n|---|---|---|---|\n| 1 | Widows Peak Salon | 4.86 | 35 |\n| 2 | City Textile | 4.50 | 6 |\n| 3 | Nobel Textile Co | 4.29 | 7 |\n| 4 | San Soo Dang | 4.28 | 18 |\n| 5 | Nova Fabrics | 3.33 | 6 |\n\nLocation was determined solely from each business's own `description` in `business_description` (7 businesses state a Los Angeles, CA address), and ratings were averaged from the `review` table joined on `gmap_id`."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "1",
+    "run": "3",
+    "answer": "I'll load both databases and identify Los Angeles businesses from their own descriptions only.The top 5 Los Angeles, California businesses by highest average rating are:\n\n1. **Widows Peak Salon** — 4.86 (35 reviews)\n2. **City Textile** — 4.50 (6 reviews)\n3. **Nobel Textile Co** — 4.29 (7 reviews)\n4. **San Soo Dang** — 4.28 (18 reviews)\n5. **Nova Fabrics** — 3.33 (6 reviews)\n\nOnly 7 businesses in `business_description` have their own description placing them in Los Angeles, CA; the remaining two are Ace Jewelry & Loan (3.29) and Beads and More (3.22). Average ratings were computed from the SQLite `review` table grouped by `gmap_id` and joined to the business metadata."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "1",
+    "run": "4",
+    "answer": "I'll load both databases and identify Los Angeles businesses from their own descriptions, then rank by average review rating.The top 5 Los Angeles, California businesses by highest average rating are:\n\n1. **Widows Peak Salon** — 4.86 (35 reviews)\n2. **City Textile** — 4.50 (6 reviews)\n3. **Nobel Textile Co** — 4.29 (7 reviews)\n4. **San Soo Dang** — 4.28 (18 reviews)\n5. **Nova Fabrics** — 3.33 (6 reviews)\n\nMethod: 7 businesses in `business_description` state a Los Angeles, CA address in their own description (locations determined solely from business descriptions, not review text); average ratings computed from all 2,000 rows in the SQLite `review` table joined on `gmap_id`. The two remaining LA businesses ranked below the top 5 are Ace Jewelry & Loan (3.29) and Beads and More (3.22)."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "2",
+    "run": "0",
+    "answer": "I'll load both databases and search all three sources (business name, description, and review text) for massage-related businesses.Four massage therapy businesses have an average rating of at least 4.0:\n\n| Business | Average rating | Reviews |\n|---|---|---|\n| **Elite Massage** | 5.00 | 1 |\n| **Angel-A Massage** | 4.33 | 6 |\n| **Aurora Massage** | 4.18 | 56 |\n| **J B Oriental Inc** | 4.17 | 6 |\n\nIdentification searched all three sources — business `name`, `business_description.description`, and `review.text` per `gmap_id`. This is what caught `Angel-A Massage` (keyword only in its name) and `J B Oriental Inc` (keyword only in its reviews: \"consistently great massages\", \"a very thorough massage\").\n\nThe remaining massage businesses fell below the 4.0 threshold: Orient Massage (3.93), SUSY massage (3.88), Good Massage (3.88), and Happy Spa & Massage (Formerly Hawaii Massage & Spa) (2.12)."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "2",
+    "run": "1",
+    "answer": "I'll load both databases and search all three sources (business name, description, and review text) for massage-related businesses.Four massage therapy businesses have an average rating of at least 4.0: **Elite Massage — 5.00**, **Angel-A Massage — 4.33**, **Aurora Massage — 4.18**, and **J B Oriental Inc — 4.17**.\n\nDetails (averages computed from the SQLite `review` table, joined to `business_description` on `gmap_id`):\n\n| Business | gmap_id | Avg rating | Reviews used |\n|---|---|---|---|\n| Elite Massage | gmap_25 | 5.00 | 1 |\n| Angel-A Massage | gmap_22 | 4.33 | 6 |\n| Aurora Massage | gmap_20 | 4.18 | 56 |\n| J B Oriental Inc | gmap_32 | 4.17 | 6 |\n\nMassage businesses identified but falling below 4.0: Orient Massage (3.93), SUSY massage (3.88), Good Massage (3.88), Happy Spa & Massage (Formerly Hawaii Massage & Spa) (2.12).\n\nTwo of the qualifying businesses were only findable through a multi-source search: **Angel-A Massage** has the keyword only in its own name (its description says \"wellness retreat... skilled therapists\"), and **J B Oriental Inc** has it only in its review text (\"consistently great massage\", \"a nice massage\") — neither its name nor description mentions massage."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "2",
+    "run": "2",
+    "answer": "Four massage therapy businesses have an average rating of at least 4.0: **Elite Massage — 5.00**, **Angel-A Massage — 4.33**, **Aurora Massage — 4.18**, and **J B Oriental Inc — 4.17**.\n\nDetails:\n\n| Business | gmap_id | Avg rating | Reviews used |\n|---|---|---|---|\n| Elite Massage | gmap_25 | 5.00 | 1 |\n| Angel-A Massage | gmap_22 | 4.33 | 6 |\n| Aurora Massage | gmap_20 | 4.18 | 56 |\n| J B Oriental Inc | gmap_32 | 4.17 | 6 |\n\nMethod notes:\n- Massage businesses were identified by searching all three sources — business `name`, `business_description.description`, and the `review.text` of each `gmap_id`. This caught `Angel-A Massage` (keyword only in its name) and `J B Oriental Inc` (keyword only in its reviews, e.g. \"hoping to get a nice massage\").\n- Massage businesses falling below the 4.0 threshold: Orient Massage (3.93), SUSY massage (3.88), Good Massage (3.88), Happy Spa & Massage (Formerly Hawaii Massage & Spa) (2.12).\n- Keyword hits that are not massage-therapy businesses were excluded after inspecting their own descriptions: Excel Hair & Nails, LuXe Organic Nails Boutique (nail/beauty salons), and Encino Dermatology & Laser: Alex Khadavi MD (dermatology clinic)."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "2",
+    "run": "3",
+    "answer": "I'll load both databases and search for massage-related businesses across all three sources (name, description, review text).Four massage therapy businesses have an average rating of at least 4.0: **Elite Massage — 5.00**, **Angel-A Massage — 4.33**, **Aurora Massage — 4.18**, and **J B Oriental Inc — 4.17**.\n\nDetails (average of `review.rating` per `gmap_id`, joined to `business_description` by `gmap_id`):\n\n| Business | gmap_id | Avg rating | # reviews |\n|---|---|---|---|\n| Elite Massage | gmap_25 | 5.00 | 1 |\n| Angel-A Massage | gmap_22 | 4.33 | 6 |\n| Aurora Massage | gmap_20 | 4.18 | 56 |\n| J B Oriental Inc | gmap_32 | 4.17 | 6 |\n\nMassage businesses identified by searching all three sources — business `name`, `description`, and `review.text`. Notably, `Angel-A Massage` matched only via its own name, and `J B Oriental Inc` only via its review text (\"consistently great massages\", \"a nice massage\"). Below the 4.0 threshold: Orient Massage (3.93), SUSY massage (3.88), Good Massage (3.88), Happy Spa & Massage (Formerly Hawaii Massage & Spa) (2.12). Nail/hair salons and a dermatology clinic whose reviews only mention \"spa\"/\"massage\" incidentally were excluded as not massage-therapy businesses."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "2",
+    "run": "4",
+    "answer": "Four massage therapy businesses have an average rating of at least 4.0: **Elite Massage — 5.00**, **Angel-A Massage — 4.33**, **Aurora Massage — 4.18**, and **J B Oriental Inc — 4.17**.\n\n| Business | Avg rating | Reviews |\n|---|---|---|\n| Elite Massage | 5.00 | 1 |\n| Angel-A Massage | 4.33 | 6 |\n| Aurora Massage | 4.18 | 56 |\n| J B Oriental Inc | 4.17 | 6 |\n\nNotes on how these were identified:\n- Massage providers were found by searching all three sources — business `name`, `business_description.description`, and `review.text` per `gmap_id`. `Angel-A Massage` matched only on its name; `J B Oriental Inc` matched only through its reviews (\"consistently great massages\", \"a very thorough massage\").\n- Businesses below the4.0 threshold: Orient Massage (3.93), SUSY massage (3.88), Good Massage (3.88), Happy Spa & Massage (Formerly Hawaii Massage & Spa) (2.12).\n- Excluded as not massage-therapy businesses despite incidental keyword hits in reviews: Encino Dermatology & Laser: Alex Khadavi MD, Excel Hair & Nails, and LuXe Organic Nails Boutique (nail/hair/derm services where a customer merely mentioned \"spa\" or a hot-stone massage add-on)."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "3",
+    "run": "0",
+    "answer": "I'll load both databases and work through this step by step.The top 5 businesses open after 6:00 PM on at least one weekday, ranked by highest average rating (all five have a perfect **5.0** average; ties broken by review count):\n\n**1. Taba Rug Gallery — average rating 5.0** (18 reviews)\n- Monday: 10AM–7PM\n- Tuesday: 10AM–7PM\n- Wednesday: 10AM–7PM\n- Thursday: 10AM–7PM\n- Friday: 10AM–7PM\n- Saturday: 10AM–7PM\n- Sunday: 11AM–6PM\n\n**2. Beauty Divine Artistry — average rating 5.0** (8 reviews)\n- Monday: 9AM–8PM\n- Tuesday: 9AM–8PM\n- Wednesday: 9AM–8PM\n- Thursday: 9AM–8PM\n- Friday: 9AM–8PM\n- Saturday: 10AM–7PM\n- Sunday: 11AM–6PM\n\n**3. Mariscos el poblano — average rating 5.0** (3 reviews)\n- Monday: 9AM–3:30AM\n- Tuesday: 8AM–3:30PM\n- Wednesday: 8AM–3:30PM\n- Thursday: Open 24 hours\n- Friday: 8AM–3:30PM\n- Saturday: 8AM–3:30PM\n- Sunday: 8AM–3:30PM\n\n**4. White Barn Candle Co — average rating 5.0** (2 reviews)\n- Monday: 10AM–9PM\n- Tuesday: 10AM–9PM\n- Wednesday: 10AM–9PM\n- Thursday: 10AM–9PM\n- Friday: 10AM–9PM\n- Saturday: 10AM–9PM\n- Sunday: 11AM–7PM\n\n**5. TACOS LA CABANA — average rating 5.0** (2 reviews)\n- Monday: 5–11PM\n- Tuesday: Closed\n- Wednesday: Closed\n- Thursday: Closed\n- Friday: 5–11PM\n- Saturday: 5–11PM\n- Sunday: 5–11PM\n\nMethod: parsed the `hours` list from `business_description` (PostgreSQL dump), kept businesses whose Monday–Friday closing time is later than 6:00 PM (including \"Open 24 hours\" and past-midnight closings), then joined on `gmap_id` to the mean of `review.rating` from the SQLite review table. 25 businesses met the weekday-evening criterion."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "3",
+    "run": "1",
+    "answer": "I'll load both databases and work through this.The top 5 are **Taba Rug Gallery**, **Beauty Divine Artistry**, **Mariscos el poblano**, **White Barn Candle Co**, and **TACOS LA CABANA** — each with a perfect average rating of **5.00**, and each open past 6:00 PM on at least one weekday.\n\n**1. Taba Rug Gallery** — average rating 5.00 (18 reviews)\n- Monday: 10AM–7PM\n- Tuesday: 10AM–7PM\n- Wednesday: 10AM–7PM\n- Thursday: 10AM–7PM\n- Friday: 10AM–7PM\n- Saturday: 10AM–7PM\n- Sunday: 11AM–6PM\n\n**2. Beauty Divine Artistry** — average rating 5.00 (8 reviews)\n- Monday: 9AM–8PM\n- Tuesday: 9AM–8PM\n- Wednesday: 9AM–8PM\n- Thursday: 9AM–8PM\n- Friday: 9AM–8PM\n- Saturday: 10AM–7PM\n- Sunday: 11AM–6PM\n\n**3. Mariscos el poblano** — average rating 5.00 (3 reviews)\n- Monday: 9AM–3:30AM\n- Tuesday: 8AM–3:30PM\n- Wednesday: 8AM–3:30PM\n- Thursday: Open 24 hours\n- Friday: 8AM–3:30PM\n- Saturday: 8AM–3:30PM\n- Sunday: 8AM–3:30PM\n\n**4. White Barn Candle Co** — average rating 5.00 (2 reviews)\n- Monday: 10AM–9PM\n- Tuesday: 10AM–9PM\n- Wednesday: 10AM–9PM\n- Thursday: 10AM–9PM\n- Friday: 10AM–9PM\n- Saturday: 10AM–9PM\n- Sunday: 11AM–7PM\n\n**5. TACOS LA CABANA** — average rating 5.00 (2 reviews)\n- Monday: 5–11PM\n- Tuesday: Closed\n- Wednesday: Closed\n- Thursday: Closed\n- Friday: 5–11PM\n- Saturday: 5–11PM\n- Sunday: 5–11PM\n\nMethod: 25 of the 79 businesses have listed hours with a weekday (Mon–Fri) closing time later than 6:00 PM (including \"Open 24 hours\" and past-midnight closings). Average ratings came from the 2,000 SQLite reviews joined on `gmap_id`. Because several qualifying businesses tie at exactly 5.00, the tie was broken by review volume (most reviews first), which makes Taba Rug Gallery the most robustly rated of the group."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "3",
+    "run": "2",
+    "answer": "I'll load both databases and work through this.**Top 5 (all tied at a 5.00 average rating,ordered by review volume):**\n\n**1. Taba Rug Gallery — avg rating 5.00 (18 reviews)**\n- Monday: 10AM–7PM\n- Tuesday: 10AM–7PM\n- Wednesday: 10AM–7PM\n- Thursday: 10AM–7PM\n- Friday: 10AM–7PM\n- Saturday: 10AM–7PM\n- Sunday: 11AM–6PM\n\n**2. Beauty Divine Artistry — avg rating 5.00 (8 reviews)**\n- Monday: 9AM–8PM\n- Tuesday: 9AM–8PM\n- Wednesday: 9AM–8PM\n- Thursday: 9AM–8PM\n- Friday: 9AM–8PM\n- Saturday: 10AM–7PM\n- Sunday: 11AM–6PM\n\n**3. Mariscos el poblano — avg rating 5.00 (3 reviews)**\n- Monday: 9AM–3:30AM\n- Tuesday: 8AM–3:30PM\n- Wednesday: 8AM–3:30PM\n- Thursday: Open 24 hours\n- Friday: 8AM–3:30PM\n- Saturday: 8AM–3:30PM\n- Sunday: 8AM–3:30PM\n\n**4. White Barn Candle Co — avg rating 5.00 (2 reviews)**\n- Monday: 10AM–9PM\n- Tuesday: 10AM–9PM\n- Wednesday: 10AM–9PM\n- Thursday: 10AM–9PM\n- Friday: 10AM–9PM\n- Saturday: 10AM–9PM\n- Sunday: 11AM–7PM\n\n**5. TACOS LA CABANA — avg rating 5.00 (2 reviews)**\n- Monday: 5–11PM\n- Tuesday: Closed\n- Wednesday: Closed\n- Thursday: Closed\n- Friday: 5–11PM\n- Saturday: 5–11PM\n- Sunday: 5–11PM\n\nMethod: 25 of the 79 businesses have a Monday–Friday closing time later than 6:00 PM (including past-midnight and \"Open 24 hours\" cases); average ratings came from the SQLite `review` table joined on `gmap_id`. Several businesses tie at 5.00, so ranking within the tie used review count as the tiebreaker."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "3",
+    "run": "3",
+    "answer": "I'll load both databases and analyze weekday closing hours against average review ratings.**Top 5 businesses open after 6:00 PM on at least one weekday, by highest average rating (all tied at 5.00,ordered by review volume):**\n\n**1. Taba Rug Gallery — average rating 5.00 (18 reviews)**\n- Monday: 10AM–7PM\n- Tuesday: 10AM–7PM\n- Wednesday: 10AM–7PM\n- Thursday: 10AM–7PM\n- Friday: 10AM–7PM\n- Saturday: 10AM–7PM\n- Sunday: 11AM–6PM\n\n**2. Beauty Divine Artistry — average rating 5.00 (8 reviews)**\n- Monday: 9AM–8PM\n- Tuesday: 9AM–8PM\n- Wednesday: 9AM–8PM\n- Thursday: 9AM–8PM\n- Friday: 9AM–8PM\n- Saturday: 10AM–7PM\n- Sunday: 11AM–6PM\n\n**3. Mariscos el poblano — average rating 5.00 (3 reviews)**\n- Monday: 9AM–3:30AM\n- Tuesday: 8AM–3:30PM\n- Wednesday: 8AM–3:30PM\n- Thursday: Open 24 hours\n- Friday: 8AM–3:30PM\n- Saturday: 8AM–3:30PM\n- Sunday: 8AM–3:30PM\n\n**4. White Barn Candle Co — average rating 5.00 (2 reviews)**\n- Monday: 10AM–9PM\n- Tuesday: 10AM–9PM\n- Wednesday: 10AM–9PM\n- Thursday: 10AM–9PM\n- Friday: 10AM–9PM\n- Saturday: 10AM–9PM\n- Sunday: 11AM–7PM\n\n**5. TACOS LA CABANA — average rating 5.00 (2 reviews)**\n- Monday: 5–11PM\n- Tuesday: Closed\n- Wednesday: Closed\n- Thursday: Closed\n- Friday: 5–11PM\n- Saturday: 5–11PM\n- Sunday: 5–11PM\n\nMethod: 25 of the 79 businesses have listed `hours` with a Monday–Friday closing time later than 6:00 PM (including \"Open 24 hours\" and past-midnight closings). Average ratings came from the 2,000 SQLite reviews joined on `gmap_id`; since several businesses share a perfect 5.00 average, ties were broken by number of reviews."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "3",
+    "run": "4",
+    "answer": "I'll load both databases and work through this.**Top 5 (all tied at a 5.0 average rating):**\n\n**1. Taba Rug Gallery** — average rating 5.0 (18 reviews)\n- Monday: 10AM–7PM\n- Tuesday: 10AM–7PM\n- Wednesday: 10AM–7PM\n- Thursday: 10AM–7PM\n- Friday: 10AM–7PM\n- Saturday: 10AM–7PM\n- Sunday: 11AM–6PM\n\n**2. Beauty Divine Artistry** — average rating 5.0 (8 reviews)\n- Monday: 9AM–8PM\n- Tuesday: 9AM–8PM\n- Wednesday: 9AM–8PM\n- Thursday: 9AM–8PM\n- Friday: 9AM–8PM\n- Saturday: 10AM–7PM\n- Sunday: 11AM–6PM\n\n**3. Mariscos el poblano** — average rating 5.0 (3 reviews)\n- Monday: 9AM–3:30AM\n- Tuesday: 8AM–3:30PM\n- Wednesday: 8AM–3:30PM\n- Thursday: Open 24 hours\n- Friday: 8AM–3:30PM\n- Saturday: 8AM–3:30PM\n- Sunday: 8AM–3:30PM\n\n**4. White Barn Candle Co** — average rating 5.0 (2 reviews)\n- Monday: 10AM–9PM\n- Tuesday: 10AM–9PM\n- Wednesday: 10AM–9PM\n- Thursday: 10AM–9PM\n- Friday: 10AM–9PM\n- Saturday: 10AM–9PM\n- Sunday: 11AM–7PM\n\n**5. TACOS LA CABANA** — average rating 5.0 (2 reviews)\n- Monday: 5–11PM\n- Tuesday: Closed\n- Wednesday: Closed\n- Thursday: Closed\n- Friday: 5–11PM\n- Saturday: 5–11PM\n- Sunday: 5–11PM\n\nMethod: 25 of the 79 businesses have a listed weekday (Mon–Fri) closing time later than 6:00 PM (including \"Open 24 hours\"); their ratings were averaged from the 2,000 SQLite reviews joined on `gmap_id`. Since many businesses tie at exactly 5.0, the ordering above breaks the tie by review volume (18, 8, 3, 2, 2)."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "4",
+    "run": "0",
+    "answer": "**Top 3 businesses by number of high-rating (≥4.5, i.e. 5-star) reviews in 2019:**\n\n| Business | High-rating reviews in 2019 |\n|---|---|\n| Encino Dermatology & Laser: Alex Khadavi MD | 19 |\n| The Boochyard @ Local Roots | 17 |\n| Aurora Massage | 14 |\n\nMethod notes: since `review.rating` is an integer1–5, \"4.5 or higher\" resolves to 5-star reviews. All2,000 review timestamps were parsed across the three mixed formats present in the SQLite table (0 unparsed), filtered to calendar year 2019, counted per `gmap_id`, then joined to `business_description` names from the PostgreSQL dump. There is no tie at the 3rd position (4th place is Widows Peak Salon with 13)."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "4",
+    "run": "1",
+    "answer": "Ratings are integers (1–5), so \"4.5 or higher\" resolves to rating = 5. Next: parse the three timestamp formats and filter to 2019.The top 3 businesses by number of reviews rated 4.5 or higher (i.e.5-star, since ratings are integers 1–5) during 2019 are:\n\n1. **Encino Dermatology & Laser: Alex Khadavi MD** — 19 high-rating reviews\n2. **The Boochyard @ Local Roots** — 17 high-rating reviews\n3. **Aurora Massage** — 14 high-rating reviews\n\nMethod: parsed all three timestamp formats in `review.time` (0 unparsed of 2,000 rows), filtered to `rating >= 4.5` with year 2019, counted per `gmap_id`, then joined to `business_description` for names. Next closest was Widows Peak Salon at 13, so the top 3 are unambiguous with no ties."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "4",
+    "run": "2",
+    "answer": "**Encino Dermatology & Laser: Alex Khadavi MD — 19 high-rating reviews; The Boochyard @ Local Roots — 17; Aurora Massage — 14.**\n\nThese are the top 3 businesses by count of 2019 reviews with a rating of 4.5 or higher (i.e., 5-star reviews, since ratings are integers 1–5).\n\n| Business | gmap_id | High-rating reviews (2019) |\n|---|---|---|\n| Encino Dermatology & Laser: Alex Khadavi MD | gmap_35 | 19 |\n| The Boochyard @ Local Roots | gmap_53 | 17 |\n| Aurora Massage | gmap_20 | 14 |\n\nMethod: all 2,000 SQLite reviews had their mixed-format timestamps parsed (0 unparsed), filtered to calendar year 2019 with `rating >= 4.5` (238 reviews), grouped by `gmap_id`, then joined to the PostgreSQL `business_description` names. No ties affect the top 3 (4th place is Widows Peak Salon at 13)."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "4",
+    "run": "3",
+    "answer": "I'll load both databases, normalize the mixed timestamp formats, and count 2019 reviews with rating ≥ 4.5.**Encino Dermatology & Laser: Alex Khadavi MD (19 high-rating reviews), The Boochyard @ Local Roots (17), and Aurora Massage (14)** are the top3 businesses by number of reviews rated 4.5 or higher in 2019.\n\nDetails:\n\n| Rank | Business | gmap_id | High-rating reviews in 2019 |\n|---|---|---|---|\n| 1 | Encino Dermatology & Laser: Alex Khadavi MD | gmap_35 | 19 |\n| 2 | The Boochyard @ Local Roots | gmap_53 | 17 |\n| 3 | Aurora Massage | gmap_20 | 14 |\n\nMethod notes:ratings in `review` are integers 1–5, so \"4.5 or higher\" resolves to rating = 5. The `time` column was parsed across all three observed formats (ISO, `\"September 03, 2020 at 04:15 PM\"`, `\"08 Mar 2020, 00:04\"`) with zero unparsed rows; 314 reviews fall in 2019, of which 238 are rated ≥ 4.5. Counts were grouped by `gmap_id` and joined to `business_description` names in pandas (no cross-database join). Next in line were Widows Peak Salon (13) and a three-way tie at 12, so the top 3 is unambiguous."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "4",
+    "run": "4",
+    "answer": "Ratings are integers only (1–5), so \"4.5 or higher\" resolves to rating = 5. Now parse the three timestamp formats.The top 3 businesses by number of high-rating (≥4.5, i.e. 5-star) reviews in 2019 are:\n\n| Business | High-rating reviews in 2019 |\n|---|---|\n| Encino Dermatology & Laser: Alex Khadavi MD | 19 |\n| The Boochyard @ Local Roots | 17 |\n| Aurora Massage | 14 |\n\nMethod: parsed all three timestamp formats in `review.time` (0 unparsed rows), filtered to 2019 reviews with `rating >= 4.5` (238 reviews total, all 5-star since ratings are integers), counted per `gmap_id`, and joined names from `business_description`. Next closest was Widows Peak Salon with 13."
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "1",
+    "run": "0",
+    "answer": "I'll work through this step by step, starting with the databases.The previous cell picked up the wrong id list; fixing in place with the verified track ids.**$1,059.46 USD.**\n\nApple Music generated **$1,059.46** in Canada from Beyoncé's \"Get Me Bodied\" (990 units across 3 sale records).\n\nHow this was derived:\n- The catalog contains **5 duplicate records** of this song across sources, matched after normalizing title/artist (lowercase, accent-stripped, punctuation-stripped, all whitespace collapsed) — including the `\"GetMe Bodied\"` typo variant:\n\n| track_id | source_id | title | artist |\n|---|---|---|---|\n| 4233 | 1 | Get Me Bodied (Sexxxplicit R&B, Volume 25) | Beyoncé |\n| 5281 | 5 | GetMe Bodied | Beyoncé |\n| 10838 | 2 | Beyoncé - Get Me Bodied | None |\n| 12954 | 3 | Get Me Bodied - Sexxxplicit R&B, Volume 25 | Beyoncé |\n| 15158 | 4 | 022-Get Me Bodied | Beyonce |\n\n- Of those 5 track_ids, only 3 have Apple Music/Canada sales: 4233 ($377.62), 5281 ($458.02), 12954 ($223.82).\n- A fuzzy edit-distance sweep over all 19,375 catalog rows found no additional variants beyond these 5."
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "1",
+    "run": "1",
+    "answer": "I'll query both databases and handle the duplicate-track normalization carefully.**$1,059.46 USD.**\n\nApple Music generated **$1,059.46** in revenue (990 units) in Canada from Beyoncé's \"Get Me Bodied\".\n\nDetails:\n- Found **5 duplicate catalog rows** for the song across sources (track_ids 4233, 5281, 10838, 12954, 15158), including the whitespace typo variant `\"GetMe Bodied\"` and the prefixed variants `\"Beyoncé - Get Me Bodied\"` and `\"022-Get Me Bodied\"`. A fuzzy (edit-distance ≤2) cross-check confirmed no additional variants exist.\n- Of those 5 track_ids, **3 sales rows** matched `store = 'Apple Music'` AND `country = 'Canada'`, summing to 990 units and $1,059.46."
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "1",
+    "run": "2",
+    "answer": "**$1,059.46** in Apple Music revenue from Beyoncé's \"Get Me Bodied\" in Canada (990 units sold).\n\nThis aggregates all 5 duplicate catalog records of the song across sources:\n\n| track_id | title | artist |\n|---|---|---|\n| 4233 | Get Me Bodied (Sexxxplicit R&B, Volume 25) | Beyoncé |\n| 5281 | GetMe Bodied | Beyoncé |\n| 10838 | Beyoncé - Get Me Bodied | *(null)* |\n| 12954 | Get Me Bodied - Sexxxplicit R&B, Volume 25 | Beyoncé |\n| 15158 | 022-Get Me Bodied | Beyonce |\n\nWhitespace-collapsing normalization plus a fuzzy-ratio cross-check confirmed exactly these 5 variants — no additional ones exist in the catalog."
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "1",
+    "run": "3",
+    "answer": "I'll query both databases and handle the known duplicate-track normalization for this song.**$1,059.46 USD.**\n\nApple Music's revenue in Canada for Beyoncé's \"Get Me Bodied\" totals **$1,059.46** across 990 units sold in 3 sale transactions.\n\nThis aggregates all 5 duplicate catalog records for the song (track_ids 4233, 5281, 10838, 12954, 15158), which appear across5 different sources with variant titles:\n- `Get Me Bodied (Sexxxplicit R&B, Volume 25)`\n- `GetMe Bodied` (missing space typo)\n- `Beyoncé - Get Me Bodied`\n- `Get Me Bodied - Sexxxplicit R&B, Volume 25`\n- `022-Get Me Bodied`"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "1",
+    "run": "4",
+    "answer": "I'll query both databases and handle the known duplicate-track quirks for this song.**$1,059.46 USD.**\n\nApple Music generated **$1,059.46** in revenue (990 units) in Canada from Beyoncé's \"Get Me Bodied.\"\n\nHow it was derived:\n- The song exists as **5 duplicate records** across sources, found by normalizing titles (lowercase, accent-stripped, punctuation- and whitespace-collapsed):\n  - `4233` — \"Get Me Bodied (Sexxxplicit R&B, Volume 25)\" / Beyoncé\n  - `5281` — \"GetMe Bodied\" / Beyoncé (missing space typo)\n  - `10838` — \"Beyoncé - Get Me Bodied\" / artist NULL\n  - `12954` — \"Get Me Bodied - Sexxxplicit R&B, Volume 25\" / Beyoncé\n  - `15158` — \"022-Get Me Bodied\" / Beyonce\n- A Levenshtein scan (≤3) over the remaining 19,370 titles found no additional variants.\n- Across all 5 track_ids, 3 sales rows match `store = 'Apple Music'` **and** `country = 'Canada'`, summing to $1,059.46."
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "2",
+    "run": "0",
+    "answer": "**Amazon Music** earned the most revenue — **$1,108.99 USD** — from Brucqe Maginnis' \"Street Hype\" across all countries.\n\nFull breakdown (all 13 sales across the 5 duplicate catalog records of this song):\n\n| Store | Revenue USD | Units |\n|---|---|---|\n| Amazon Music | 1,108.99 | 1,024 |\n| Apple Music | 984.48 | 838 |\n| iTunes | 916.86 | 806 |\n| Google Play | 51.40 | 44 |\n\nThe song appears 5 times in the catalog under different sources/spellings, all of which I merged before aggregating: `Street Hype` / `Brucqe Maginnis` (id 4122), `Bruce Maginnis - Sttreet Hype` (id 7, artist NULL), `Street Hype - Groove City` (4628), `StreetH ype (Groove City)` (13758), and `011-Street Hype` (14080) — all on the album *Groove City* (2005)."
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "2",
+    "run": "1",
+    "answer": "I'll find all duplicate track records for that song and sum revenue by store.**Amazon Music** earned the most revenue — **$1,108.99 USD** — from Bruce/Brucqe Maginnis' \"Street Hype\" across all countries.\n\nFull breakdown across all 5 duplicate catalog records of the song (13 sales transactions, $3,061.73 total):\n\n| Store | Revenue USD | Units | Sales |\n|---|---|---|---|\n| Amazon Music | 1,108.99 | 1,024 | 4 |\n| Apple Music | 984.48 | 838 | 5 |\n| iTunes | 916.86 | 806 | 3 |\n| Google Play | 51.40 | 44 | 1 |\n\nThe song appears as 5 duplicate rows across all 5 sources, with title/artist corruption in each: `'Street Hype'` (artist `'Brucqe Maginnis'`, id 4122), `'Street Hype - Groove City'` (4628), `'StreetHype (Groove City)'` (13758), `'011-Street Hype'` (14080), and `'Bruce Maginnis - Sttreet Hype'` (id 7 — artist field NULL, title typo `Sttreet`, only found via edit-distance matching). Missing any of these would change the ranking."
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "2",
+    "run": "2",
+    "answer": "I'll find all duplicate track records for that song, then aggregate sales by store.**Amazon Music** earned the most revenue from Bruce Maginnis' \"Street Hype\" — **$1,108.99 USD** across all countries.\n\nStore breakdown (all 5 duplicate catalog records combined, 13 sales transactions, $3,061.73 total):\n\n| Store | Revenue USD | Units | Sales |\n|---|---|---|---|\n| Amazon Music | 1,108.99 | 1,024 | 4 |\n| Apple Music | 984.48 | 838 | 5 |\n| iTunes | 916.86 | 806 | 3 |\n| Google Play | 51.40 | 44 | 1 |\n\nThe song appears as 5 duplicate records across sources (track_ids 7, 4122, 4628, 13758, 14080) with variants including `'Street Hype'` / `'Brucqe Maginnis'`, `'Bruce Maginnis - Sttreet Hype'`, `'StreetH ype (Groove City)'`, `'Street Hype - Groove City'`, and `'011-Street Hype'` — all were included in the aggregation."
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "2",
+    "run": "3",
+    "answer": "**Amazon Music** earned the most revenue from Brucqe Maginnis' \"Street Hype\" — **$1,108.99** across all countries.\n\nFull breakdown across all 5 duplicate catalog records of the song (track_ids 7, 4122, 4628, 13758, 14080 — variants `'Street Hype'`, `'Bruce Maginnis - Sttreet Hype'`, `'Street Hype - Groove City'`, `'StreetH ype (Groove City)'`, `'011-Street Hype'`; 13 sale rows total):\n\n| Store | Revenue USD | Units |\n|---|---|---|\n| Amazon Music | 1,108.99 | 1,024 |\n| Apple Music | 984.48 | 838 |\n| iTunes | 916.86 | 806 |\n| Google Play | 51.40 | 44 |"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "2",
+    "run": "4",
+    "answer": "I'll find all duplicate records of that track and aggregate its sales by store.**Amazon Music**, with **$1,108.99** in revenue.\n\nRevenue by store, aggregated across all countries and all 5 duplicate catalog records of the song (track_ids 7, 4122, 4628, 13758, 14080 — total $3,061.73):\n\n| Store | Revenue (USD) | Units | Sales |\n|---|---|---|---|\n| Amazon Music | 1,108.99 | 1,024 | 4 |\n| Apple Music | 984.48 | 838 | 5 |\n| iTunes | 916.86 | 806 | 3 |\n| Google Play | 51.40 | 44 | 1 |\n\nThe five duplicate records had these title/artist variants: `Bruce Maginnis - Sttreet Hype`, `Street Hype` (artist spelled `Brucqe Maginnis`), `Street Hype - Groove City`, `StreetH ype (Groove City)`, and `011-Street Hype` — all on the album *Groove City* (2005)."
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "3",
+    "run": "0",
+    "answer": "I'll explore both databases and aggregate revenue across duplicate track records.Normalization now correctly unifies all 5 known duplicates. Now grouping by (title, artist) with fuzzy merge.**\"Zo gaat het leven aan je voor\" by Syb van der Ploeg generated the highest total revenue: $9,013.69 USD.**\n\nSupporting detail:\n\n| track_id | source_id | title as stored | revenue_usd |\n|---|---|---|---|\n| 3024 | 1 | Zo gaat het leven aan je voor (Hillich fjoer \\| Heilig vuur) | 1754.68 |\n| 3435 | 5 | Zo gaat het leven aan je voor | 2024.37 |\n| 12620 | 3 | Zo gaat het leven aan je voor - Hillich fjoer \\| Heilig vuur | 2377.59 |\n| 12854 | 4 | 006-Zo gaat het leven aan je voor | 1379.67 |\n| 13225 | 2 | Syb van der Ploeg - Zo gaat het leven aan je voor | 1477.38 |\n\n- All **5** duplicate source rows were found (one per `source_id` 1–5), so the group is complete; verified directly in DuckDB: 22 sale transactions, 7,792 units, $9,013.69.\n- Runners-up after de-duplication: \"Chile\" — Neil Biggin ($7,744.25) and \"Emerge (Dexter remix)\" — Fischerspooner ($7,515.88).\n- Higher-looking title-only groups were rejected as false merges: `apache` ($9,277.62) splits into two different songs (The Shadows' \"Apache (intro)\" $6,551.90 vs. Agents & Vesa Haaja's \"Apache (instrumental)\" $2,725.72), and `failure` ($9,002.41) splits between Bushfire and Fall of Envy. Placeholder titles (`[unknown]`, `n/a`, `Intro`, `Outro`, `unk.`) are collisions across many unrelated artists, not songs."
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "3",
+    "run": "1",
+    "answer": "**\"Zo gaat het leven aan je voor\" by Syb van der Ploeg — $9,013.69 in total revenue.**\n\nDetails after deduplicating the catalog's cross-source duplicates:\n\n| # | Song | Artist | Total revenue (USD) | Source rows |\n|---|---|---|---|---|\n| 1 | Zo gaat het leven aan je voor | Syb van der Ploeg | **9,013.69** | 5 |\n| 2 | Chile | Neil Biggin | 7,744.25 | 5 |\n| 3 | Emerge (Dexter remix) | Fischerspooner | 7,515.88 | 6 |\n| 4 | Ne veruj | Vrisak generacije | 7,299.91 | 5 |\n| 5 | Vagga | Ske | 7,214.20 | 5 |\n\nThe winning song appears as 5 separate `track_id`s — one per `source_id` (1–5) — under the title variants `\"Zo gaat het leven aan je voor (Hillich fjoer | Heilig vuur)\"`, `\"Zo gaat het leven aan je voor\"`, `\"Zo gaat het leven aan je voor - Hillich fjoer | Heilig vuur\"`, `\"006-Zo gaat het leven aan je voor\"`, and `\"Syb van der Ploeg - Zo gaat het leven aan je voor\"` (the last with a NULL artist). Summing revenue across all five gives 9,013.69 USD on 7,792 units. No single `track_id` alone would win, which is why duplicate collapsing (case, accents, punctuation, whitespace, `\"Artist - \"` and `\"NNN-\"` prefixes, album qualifiers) was required."
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "3",
+    "run": "2",
+    "answer": "I'll analyze the catalog and sales data, accounting for cross-source duplicate track records.The initial grouping collapsed distinct songs (title-only key merged every \"Mozart - …\" row and generic titles like \"Intro\"). Rebuilding the key to resolve artist from `\"Artist - Title\"` prefixes and group by (artist, title).**\"Zo gaat het leven aan je voor\" by Syb van der Ploeg** generated the highest total revenue: **$9,013.69 USD** across all stores and countries (7,792 units).\n\nHow it was determined:\n- Aggregated `sales.revenue_usd` per `track_id` in DuckDB, then joined to the SQLite `tracks` catalog in pandas (no cross-DB join).\n- Collapsed cross-source duplicates by normalizing title + artist: accent stripping, lowercasing, removal of all punctuation/whitespace, stripping `NNN-` numeric prefixes, `Artist - ` prefixes, and compilation qualifiers appearing either as `(...)` or as a` - ...` suffix; artist names were fuzzy-clustered per title, and rows with NULL/`[unknown]` artist were attached when unambiguous.\n- The winning group contains all **5** source rows for that song, including the variant with a NULL artist:\n  - `Zo gaat het leven aan je voor (Hillich fjoer | Heilig vuur)`\n  - `Zo gaat het leven aan je voor`\n  - `Zo gaat het leven aan je voor - Hillich fjoer | Heilig vuur`\n  - `006-Zo gaat het leven aan je voor`\n  - `Syb van der Ploeg - Zo gaat het leven aan je voor`\n\nRunner-up: \"Chile\" by Neil Biggin at $7,744.25 — a clear ~$1,270 margin, so the result is not tie-sensitive. Note that larger raw sums appear if one groups only by artist-prefix artifacts (e.g. all `Wolfgang Amadeus Mozart - …` rows total $23,308.91), but those are many distinct compositions, not a single song."
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "3",
+    "run": "3",
+    "answer": "I'll analyze both databases, normalizing track titles/artists to collapse duplicate records across sources before aggregating revenue.The global substring stripping was too aggressive (it ate \"getme\"). Fixing with safer segment-level matching.**\"Zo gaat het leven aan je voor\" by Syb van der Ploeg** generated the highest total revenue: **$9,013.69 USD** across all stores and countries.\n\nDetails:\n- Revenue is summed across **5 duplicate catalog rows** for this same song (one per source: track_ids 3024, 3435, 12620, 12854, 13225), whose title variants are `\"Zo gaat het leven aan je voor (Hillich fjoer | Heilig vuur)\"`, `\"Zo gaat het leven aan je voor\"`, `\"Zo gaat het leven aan je voor - Hillich fjoer | Heilig vuur\"`, `\"006-Zo gaat het leven aan je voor\"`, and `\"Syb van der Ploeg - Zo gaat het leven aan je voor\"` (the last has a NULL artist, with the artist embedded in the title).\n- 22 sale transactions, 7,792 units sold.\n- Runner-up: `\"Chile\"` by Neil Biggin at $7,744.25.\n\nDuplicates were matched by normalizing title and artist (lowercase, accent-stripped, punctuation- and whitespace-collapsed), stripping leading track-number prefixes, parenthetical/segment album qualifiers, and artist prefixes, then clustering remaining variants with an edit-distance tolerance. Placeholder titles (`[untitled]`, `n.a.`, `unk.`) were excluded as non-songs."
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "3",
+    "run": "4",
+    "answer": "I'll work through this by loading both databases, normalizing track identities to collapse cross-source duplicates, then aggregating revenue.Grouping by title alone conflates generic titles and mis-stripped artist prefixes. Fixing the normalization to use a global artist vocabulary and to key on (title, artist).**\"Emerge\" by Fischerspooner** generated the highest total revenue: **$7,515.88 USD** across all stores and countries.\n\n**How the duplicates roll up** (6 catalog rows for the same song, spread across 5 sources):\n\n| track_id | title | artist | revenue |\n|---|---|---|---|\n| 4895 | Fischerspooner - Emerge (Dexter remix) | None | 1,610.46 |\n| 6988 | Emerge (Dexter remix) (#1) | Fischerspooner | 1,762.80 |\n| 7575 | Emerge (Dave Clarke remix) | Fischerspooner | 850.86 |\n| 10166 | Emerge (Dexter remix) - #1 | Fischerspooner | 850.61 |\n| 10606 | Emerge (Dexter remix) | Fischerspooner | 672.12 |\n| 17167 | 027-Emerge (Dexter remix) | Fischerspooner | 1,769.03 |\n\nMethod: aggregated `revenue_usd` per `track_id` in DuckDB, joined to the SQLite catalog in pandas, then clustered duplicate rows using normalization (deaccenting, lowercasing, dropping parentheticals and `NNN-` prefixes, stripping `\"Artist - \"` prefixes, removing all punctuation **and all internal whitespace**) plus edit-distance-tolerant union-find matching with artist compatibility (artist inferred from the title when the field was NULL).\n\nRobustness note: if you treat the Dave Clarke remix (track 7575) as a separate recording, the Dexter-remix-only total is **$6,665.02** — still ahead of the runner-up, \"Zo gaat het leven aan je voor\" by Syb van der Ploeg at **$6,636.10**. So Fischerspooner's \"Emerge\" is the top song either way."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "1",
+    "run": "0",
+    "answer": "I'll explore both databases and compute intraday volatility for Asian indices since 2020.**399001.SZ (Shenzhen Stock Exchange index)** has the highest average intraday volatility in Asia since 2020, at **1.83%** of the opening price per day.\n\nAverage daily intraday range `(High − Low) / Open`, computed over rows dated 2020-01-01 onward (data ends mid-2021), across the six Asian indices in `index_trade`:\n\n| Index | Exchange | Avg intraday range (%) | Days |\n|---|---|---|---|\n| 399001.SZ | Shenzhen Stock Exchange | 1.834 | 342 |\n| NSEI | National Stock Exchange of India | 1.707 | 349 |\n| HSI | Hong Kong Stock Exchange | 1.493 | 348 |\n| 000001.SS | Shanghai Stock Exchange | 1.378 | 340 |\n| N225 | Tokyo Stock Exchange | 1.343 | 344 |\n| TWII | Taiwan Stock Exchange | 1.323 | 339 |\n\nThe ranking is unchanged if normalizing by `Close` instead of `Open`. Note: by raw point range HSI is largest (391.9 pts), but that reflects index level, not relative volatility."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "1",
+    "run": "1",
+    "answer": "**399001.SZ (Shenzhen Stock Exchange component index) — highest average intraday volatility among Asian indices since 2020, at ~1.83% of closing price per day.**\n\nRanking of Asia-region indices (avg daily (High−Low)/Close × 100, dates ≥ 2020-01-01, data ends mid-2021):\n\n| Index | Exchange | Avg intraday range (% of Close) | Trading days |\n|---|---|---|---|\n| 399001.SZ | Shenzhen Stock Exchange | 1.834 | 342 |\n| NSEI | National Stock Exchange of India | 1.707 | 349 |\n| HSI | Hong Kong Stock Exchange | 1.496 | 348 |\n| 000001.SS | Shanghai Stock Exchange | 1.377 | 340 |\n| N225 | Tokyo Stock Exchange | 1.344 | 344 |\n| TWII | Taiwan Stock Exchange | 1.326 | 339 |\n\nNotes: the three mixed `Date` text formats were all parsed (0 unparsed rows); volatility measured as the daily high–low range normalized by close (the open-normalized variant gives the same ranking). Absolute point range would instead rank HSI first, but that is not currency/level-comparable across indices."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "1",
+    "run": "2",
+    "answer": "**399001.SZ** (the Shenzhen Stock Exchange component index) has the highest average intraday volatility among Asian indices since 2020, at **1.83%** of the opening price per day.\n\nRanking of Asia-region indices, average daily `(High − Low) / Open × 100` over all trading days from 2020-01-01 onward (data ends mid-2021):\n\n| Index | Exchange | Avg intraday % | Days |\n|---|---|---|---|\n| 399001.SZ | Shenzhen Stock Exchange | 1.8341 | 342 |\n| NSEI | National Stock Exchange of India | 1.7072 | 349 |\n| HSI | Hong Kong Stock Exchange | 1.4932 | 348 |\n| 000001.SS | Shanghai Stock Exchange | 1.3781 | 340 |\n| N225 | Tokyo Stock Exchange | 1.3427 | 344 |\n| TWII | Taiwan Stock Exchange | 1.3225 | 339 |\n\nNotes: all three date text formats in `index_trade` were parsed (0 unparsed rows) before filtering to≥ 2020-01-01. Asia membership was assigned by mapping each index symbol to its exchange in `index_info` (Shenzhen, NSE India, Hong Kong, Shanghai, Tokyo, Taiwan); the remaining 7 indices belong to US, Canadian, European, or South African exchanges."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "1",
+    "run": "3",
+    "answer": "**399001.SZ (the Shenzhen Stock Exchange index) has the highest average intraday volatility in Asia since 2020**, averaging a daily High–Low range of **1.83% of the opening price**.\n\nRanking of Asian indices (2020-01-01 onward, 339–349 trading days each):\n\n| Index | Exchange | Avg intraday range (% of Open) |\n|---|---|---|\n| 399001.SZ | Shenzhen | 1.83% |\n| NSEI | National Stock Exchange of India | 1.71% |\n| HSI | Hong Kong | 1.49% |\n| 000001.SS | Shanghai | 1.38% |\n| N225 | Tokyo | 1.34% |\n| TWII | Taiwan | 1.32% |\n\nNotes: intraday volatility = (High − Low) / Open per day, averaged per index; the ranking is identical if normalized by Low or Close instead. All three mixed date formats in `index_trade` were parsed (0 unparsed rows); data coverage ends around 2021-06."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "1",
+    "run": "4",
+    "answer": "I'll start by inspecting both databases.**399001.SZ (Shenzhen Stock Exchange, China)** has the highest average intraday volatility among Asian indices since 2020, at **1.83%** average daily `(High − Low) / Close`.\n\nRanking of Asian-region indices, Jan 2020 → Jun 2021 (the dataset's full post-2020 coverage):\n\n| Index | Exchange | Avg intraday range | Days |\n|---|---|---|---|\n| 399001.SZ | Shenzhen Stock Exchange | 1.83% | 342 |\n| NSEI | National Stock Exchange of India | 1.71% | 349 |\n| HSI | Hong Kong Stock Exchange | 1.50% | 348 |\n| 000001.SS | Shanghai Stock Exchange | 1.38% | 340 |\n| N225 | Tokyo Stock Exchange | 1.34% | 344 |\n| TWII | Taiwan Stock Exchange | 1.33% | 339 |\n\nNotes: dates were normalized from the three mixed text formats in `index_trade` (0 rows unparsed). Volatility is measured as a percentage of closing price so it is comparable across currencies — by raw point range instead, HSI would lead (391.89 points) purely because of its higher price level."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "2",
+    "run": "0",
+    "answer": "**IXIC (NASDAQ) was the only North American index with more up days than down days in 2018** — 131 up vs 120 down (up day = Close > Open).\n\nThe three North American indices in the data (NYA – New York Stock Exchange, IXIC – NASDAQ, GSPTSE – Toronto Stock Exchange), each with 251 trading days in 2018:\n\n| Index | Exchange | Up (Close > Open) | Down (Close < Open) |\n|---|---|---|---|\n| IXIC | NASDAQ | **131** | 120 |\n| NYA | New York Stock Exchange | 125 | 126 |\n| GSPTSE | Toronto Stock Exchange | 115 | 135 |\n\nNote on definition: if \"up day\" is instead measured as Close above the *previous* day's Close, all three flip to net-positive (IXIC 133/116, NYA 133/117, GSPTSE 129/121). The intraday Open→Close definition is used above since both fields exist on each row.\n\nAll three mixed date formats in `index_trade` were normalized before filtering to 2018 (0 unparsed rows)."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "2",
+    "run": "1",
+    "answer": "**IXIC (NASDAQ)** — it's the only North American index with more up days than down days in 2018.\n\nNorth American indices in the data (via `index_info` → exchange/currency mapping): `NYA` (New York Stock Exchange, USD), `IXIC` (NASDAQ, USD), `GSPTSE` (Toronto Stock Exchange, CAD).\n\n2018 daily counts (251 trading days each), up day = Close > Open:\n\n| Index | Exchange | Up days | Down days |\n|---|---|---|---|\n| IXIC | NASDAQ | **131** | 120 |\n| NYA | New York Stock Exchange | 125 | 126 |\n| GSPTSE | Toronto Stock Exchange | 115 | 135 |\n\nNote on definition: if \"up day\" is instead measured as Close > previous day's Close, all three qualify (IXIC 134/116, NYA 134/117, GSPTSE 130/121). Dates required normalizing three mixed text formats before filtering to 2018."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "2",
+    "run": "2",
+    "answer": "I'll explore both databases, normalize the mixed date formats, and identify North American indices.**IXIC (NASDAQ) — it is the only North American index with more up days than down days in 2018 under the intraday (Close > Open) definition: 131 up vs 120 down.**\n\n2018 counts for the three North American indices (251 trading days each):\n\n| Index | Exchange | Up (Close > Open) | Down (Close < Open) | More up? |\n|---|---|---|---|---|\n| IXIC | NASDAQ | 131 | 120 | ✅ |\n| NYA | New York Stock Exchange | 125 | 126 | ❌ |\n| GSPTSE | Toronto Stock Exchange | 115 | 135 | ❌ |\n\nNote on definition: if \"up day\" instead means close higher than the *previous* day's close, all three qualify (IXIC 134/116, NYA 134/117, GSPTSE 130/121). The intraday Open→Close comparison is the definition fully supported by each row's own fields, and under it only IXIC qualifies."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "2",
+    "run": "3",
+    "answer": "All three North American indices — **IXIC (NASDAQ), NYA (New York Stock Exchange), and GSPTSE (Toronto Stock Exchange)** — had more up days than down days in 2018.\n\n2018 counts (up day = close above prior trading day's close):\n\n| Index | Exchange | Trading days | Up | Down |\n|---|---|---|---|---|\n| IXIC | NASDAQ | 251 | 134 | 116 |\n| NYA | New York Stock Exchange | 251 | 134 | 117 |\n| GSPTSE | Toronto Stock Exchange | 251 | 130 | 121 |\n\nNorth American indices were identified via the SQLite `index_info` exchanges (NASDAQ/NYSE = USD, Toronto = CAD). Dates were parsed from the three mixed text formats in `index_trade` with zero unparsed rows. Note: using an intraday definition instead (close > open) would flip GSPTSE and NYA to net-negative, so the result above uses the standard day-over-day close convention."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "2",
+    "run": "4",
+    "answer": "**IXIC (NASDAQ)** — it is the only North American index with more up days than down days in 2018 on an intraday basis (Close > Open: 131 up vs 120 down).\n\nDetails for the three North American indices (NYA = New York Stock Exchange, IXIC = NASDAQ, GSPTSE = Toronto Stock Exchange), 251 trading days each in 2018:\n\n| Index | Up (Close>Open) | Down (Close<Open) | Up (vs prior Close) | Down (vs prior Close) |\n|---|---|---|---|---|\n| IXIC | 131 | 120 | 134 | 116 |\n| NYA | 125 | 126 | 134 | 117 |\n| GSPTSE | 115 | 135 | 130 | 121 |\n\nNote: if \"up day\" is instead defined as Close above the *previous* day's Close, all three (IXIC, NYA, GSPTSE) had more up days than down days."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "3",
+    "run": "0",
+    "answer": "**Top 5: IXIC (NASDAQ, United States) +382.4%, GDAXI (Frankfurt Stock Exchange, Germany) +134.9%, NSEI (National Stock Exchange of India, India) +134.9%, 399001.SZ (Shenzhen Stock Exchange, China) +134.0%, and TWII (Taiwan Stock Exchange, Taiwan) +129.7%.**\n\n| Rank | Index | Exchange / Country | Currency | Months invested | Invested (USD) | Final value (USD) | Total return |\n|---|---|---|---|---|---|---|---|\n| 1 | IXIC | NASDAQ — United States | USD | 257 | 25,700 | 123,972.32 | +382.38% |\n| 2 | GDAXI | Frankfurt Stock Exchange — Germany | EUR | 257 | 25,700 | 60,376.63 | +134.93% |\n| 3 | NSEI | National Stock Exchange of India — India | INR | 165 | 16,500 | 38,752.83 | +134.87% |\n| 4 | 399001.SZ | Shenzhen Stock Exchange — China | CNY | 258 | 25,800 | 60,382.82 | +134.04% |\n| 5 | TWII | Taiwan Stock Exchange — Taiwan | TWD | 257 | 25,700 | 59,018.81 | +129.65% |\n\nMethod: simulated a $100 purchase at each month's last available `CloseUSD` from January 2000 onward (USD basis, so results are FX-comparable), then valued the accumulated units at each index's final observed close (May–June 2021). Return = final value / total invested − 1.\n\nNotes on the data:\n- The `Date` column mixes three text formats; all 104,224 rows parsed cleanly after normalizing.\n- NSEI starts 2007-09 and J203.JO starts 2012-02, so those two have shorter contribution windows than the rest — NSEI's #3ranking comes from only 165 monthly buys, making it the strongest performer per month invested after NASDAQ.\n- Country attribution comes from the exchange names in `index_info` (the SQLite table has no symbol column, so indices were matched to exchanges by symbol semantics); `N100` (Euronext) is pan-European rather than single-country."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "3",
+    "run": "1",
+    "answer": "The top 5 are **IXIC (NASDAQ, United States) +387.8%**, **399001.SZ (Shenzhen Stock Exchange, China) +137.5%**, **GDAXI (Frankfurt Stock Exchange, Germany) +131.9%**, **TWII (Taiwan Stock Exchange, Taiwan) +131.9%**, and **NSEI (National Stock Exchange of India, India) +121.5%**.\n\n| Rank | Index | Exchange | Country | Months invested | Total return |\n|---|---|---|---|---|---|\n| 1 | IXIC | NASDAQ | United States | 257 (2000-01 → 2021-05) | +387.8% |\n| 2 | 399001.SZ | Shenzhen Stock Exchange | China | 258 (2000-01 → 2021-06) | +137.5% |\n| 3 | GDAXI | Frankfurt Stock Exchange | Germany | 257 (2000-01 → 2021-05) | +131.9% |\n| 4 | TWII | Taiwan Stock Exchange | Taiwan | 257 (2000-01 → 2021-05) | +131.9% |\n| 5 | NSEI | National Stock Exchange of India | India | 165 (2007-09 → 2021-05) | +121.5% |\n\nMethod: dollar-cost averaging — a fixed $100 invested at the first available trading close of every month from January 2000 through the end of the data (May/June 2021), with return = final holding value ÷ total contributed − 1. All 104,224 rows parsed cleanly across the three date formats; `CloseUSD` and `Close` give identical percentage returns since the conversion factor is constant per index.\n\nCaveats worth noting: NSEI history only begins 2007-09 in this data (and J203.JO in 2012-02), so those indices had fewer, later contributions. GDAXI and TWII tie at 131.9% — TWII is marginally ahead on final value ($59,596.37 vs $59,596.35)."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "3",
+    "run": "2",
+    "answer": "The top 5 are **IXIC (NASDAQ — United States)**, **399001.SZ (Shenzhen Stock Exchange — China)**, **GDAXI (Frankfurt Stock Exchange — Germany)**, **TWII (Taiwan Stock Exchange — Taiwan)**, and **NSEI (National Stock Exchange of India — India)**.\n\nMethod: monthly dollar-cost averaging from January 2000 onward, buying at the first trading day's `CloseUSD` of each month (USD-normalized so cross-currency indices are comparable), valued at the last available month.\n\n| Rank | Index | Exchange | Country | Currency | DCA return |\n|---|---|---|---|---|---|\n| 1 | IXIC | NASDAQ | United States | USD | +387.8% |\n| 2 | 399001.SZ | Shenzhen Stock Exchange | China | CNY | +137.5% |\n| 3 | GDAXI | Frankfurt Stock Exchange | Germany | EUR | +131.9% |\n| 4 | TWII | Taiwan Stock Exchange | Taiwan | TWD | +131.9% |\n| 5 | NSEI | National Stock Exchange of India | India | INR | +121.5% |\n\nNotes on the data:\n- Coverage ends 2021-05/2021-06 in this dataset, so \"since 2000\" means Jan 2000 → mid-2021.\n- NSEI only starts 2007-09 and J203.JO 2012-02, so their contribution windows are shorter than the others'.\n- GDAXI and TWII are effectively tied at 131.9% (GDAXI 131.94% vs TWII 131.87% before rounding).\n- Country labels come from the exchange names in `index_info`; N100 (Euronext) is pan-European rather than a single country."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "3",
+    "run": "3",
+    "answer": "I'll work through this step by step — parsing the mixed date formats first, then simulating monthly DCA investments per index.**Top 5 indices by overall return from monthly investing since 2000: IXIC (NASDAQ — United States, +382.7%), NSEI (National Stock Exchange of India — India, +135.8%), 399001.SZ (Shenzhen Stock Exchange — China, +134.8%), GDAXI (Frankfurt Stock Exchange — Germany, +134.7%), and TWII (Taiwan Stock Exchange — Taiwan, +129.8%).**\n\n| Rank | Index | Exchange / Country | Months invested | Final value per 1/month | Total return |\n|---|---|---|---|---|---|\n| 1 | IXIC | NASDAQ — United States | 257 | 1240.52 | **+382.7%** |\n| 2 | NSEI | National Stock Exchange of India — India | 165 | 389.14 | +135.8% |\n| 3 | 399001.SZ | Shenzhen Stock Exchange — China | 258 | 605.65 | +134.8% |\n| 4 | GDAXI | Frankfurt Stock Exchange — Germany | 257 | 603.19 | +134.7% |\n| 5 | TWII | Taiwan Stock Exchange — Taiwan | 257 | 590.64 | +129.8% |\n\nMethod: all three date formats in `index_trade` were normalized (0 unparsed rows), one unit was invested at the first trading day of every month from 2000-01 through the last available date (2021-05/06), and return = final portfolio value ÷ total invested − 1, using each index's native-currency `Close`.\n\nCaveat: NSEI's history in this dataset only begins 2007-09-17 (165 monthly buys) and J203.JO begins 2012, so those two had shorter accumulation windows than the other 11 indices — NSEI's rank 2 reflects a 14-year rather than 21-year run. NASDAQ (IXIC) leads by a wide margin regardless."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "3",
+    "run": "4",
+    "answer": "I'll start by exploring both databases and checking the date formats.The top5 indices are **IXIC (NASDAQ, United States)**, **NSEI (National Stock Exchange of India, India)**, **399001.SZ (Shenzhen Stock Exchange, China)**, **GDAXI (Frankfurt Stock Exchange, Germany)**, and **TWII (Taiwan Stock Exchange, Taiwan)**.\n\n| Rank | Index | Exchange | Country | Currency | Months invested | Overall return |\n|---|---|---|---|---|---|---|\n| 1 | IXIC | NASDAQ | United States | USD | 257 | **+382.69%** |\n| 2 | NSEI | National Stock Exchange of India | India | INR | 165 | **+135.84%** |\n| 3 | 399001.SZ | Shenzhen Stock Exchange | China | CNY | 258 | **+134.75%** |\n| 4 | GDAXI | Frankfurt Stock Exchange | Germany | EUR | 257 | **+134.70%** |\n| 5 | TWII | Taiwan Stock Exchange | Taiwan | TWD | 257 | **+129.82%** |\n\nMethod: equal USD amount invested at the first available trading day of every month from 2000-01 onward, priced on `CloseUSD` so all indices are compared in a common currency; overall return = final portfolio value ÷ total invested − 1, valued at each index's last available date (May–June 2021).\n\nCaveats worth noting: NSEI's history in this data only starts 2007-09-17 (165 monthly buys, not 257), so its return covers a shorter, more favorable window — over a full 2000-start window it would not necessarily rank second. J203.JO likewise only starts 2012. Excluding short-history indices, the ranking becomes IXIC → 399001.SZ → GDAXI → TWII → N225 (Tokyo Stock Exchange, Japan, +116.91%)."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "1",
+    "run": "0",
+    "answer": "I'll look up the ticker for The RealReal, Inc. in the stockinfo metadata, then query its 2020 price history.**$18.44** (2020-01-03) was the maximum adjusted closing price in 2020 for The RealReal, Inc. (ticker `REAL`).\n\nNotes:\n- Matched via `stockinfo`: `Symbol = REAL`, description \"The RealReal, Inc. is a leader in the luxury consignment market...\".\n- The `REAL` price table covers only 63 trading days in 2020 (`2020-01-02` → `2020-04-01`), so this is the max over the available 2020 data.\n- Exact stored value: `18.440001`; `Adj Close` equals `Close` for that day."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "1",
+    "run": "1",
+    "answer": "I'll look up The RealReal's ticker in the SQLite metadata, then query its 2020 price history in DuckDB.**$18.44** (18.440001), reached on 2020-01-03.\n\n- Ticker: `REAL` — matched via `Company Description` beginning \"The RealReal, Inc. is a leader in the luxury consignment market...\"\n- The `REAL` table's 2020 coverage is 63 trading days, 2020-01-02 through 2020-04-01, so this is the max over that available window.\n- `Close` and `Adj Close` are identical on that date."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "1",
+    "run": "2",
+    "answer": "**$18.44** — the maximum adjusted closing price in 2020 for The RealReal, Inc. (ticker `REAL`), reached on::camber-date-time[2020-01-03].\n\n- Ticker resolved from `stockinfo`: `REAL` — \"The RealReal, Inc. is a leader in the luxury consignment market...\"\n- Exact value: 18.440001 (Close and Adj Close identical); next highest 2020 values were 18.17 (Jan 9) and 18.16 (Jan 13).\n- Note: this table's 2020 coverage ends in early April, so the max reflects the data present in the dataset."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "1",
+    "run": "3",
+    "answer": "**$18.44** — the maximum adjusted closing price in 2020 for The RealReal, Inc. (ticker `REAL`), reached on ::camber-date-time[2020-01-03T00:00:00Z].\n\n- Matched via `stockinfo` → `Symbol = REAL`, Company Description: \"The RealReal, Inc. is an online marketplace...\"\n- The 2020 data in this dataset covers only Jan 2 – Apr 1, 2020 (63 trading days), so the max reflects that window."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "1",
+    "run": "4",
+    "answer": "I'll locate the ticker from the listing metadata, then query its 2020 price history.**$18.44** (adjusted close on 2020-01-03).\n\n- Ticker resolved from `stockinfo`: `REAL` — \"The RealReal, Inc. is a leader in the luxury consignment market...\"\n- The `REAL` table's 2020 coverage is 63 trading days, 2020-01-02 through 2020-04-01, so this is the max over that available window.\n- Runner-ups: $18.17 (2020-01-09), $18.16 (2020-01-13)."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "2",
+    "run": "0",
+    "answer": "I'll query the SQLite metadata for NYSE Arca ETFs, then scan their price tables in DuckDB for 2015.**31ETFs** listed on NYSE Arca (exchange code `P`) reached an adjusted closing price above $200 at some point during 2015:\n\n| # | Symbol | Max Adj Close 2015 | Fund |\n|---|---|---|---|\n| 1 | UVXY | 81,500.00 | ProShares Trust Ultra VIX Short Term Futures ETF |\n| 2 | GUSH | 78,699.22 | Direxion Daily S&P Oil & Gas Exp. & Prod. Bull 2X Shares |\n| 3 | COM | 40,487.99 | Direxion Auspice Broad Commodity Strategy ETF |\n| 4 | RTL | 13,306.76 | Pacer Benchmark Retail Real Estate SCTR ETF |\n| 5 | JDST | 12,988.41 | Direxion Daily Junior Gold Miners Index Bear 2X Shares |\n| 6 | HYUP | 4,329.75 | Xtrackers High Beta High Yield Bond ETF |\n| 7 | SOXS | 3,886.62 | Direxion Daily Semiconductor Bear 3x Shares |\n| 8 | VPC | 2,250.14 | Virtus Private Credit Strategy ETF |\n| 9 | DUST | 1,923.28 | Direxion Daily Gold Miners Index Bear 2X Shares |\n| 10 | LBJ | 998.11 | Direxion Daily Latin America 3x Bull Shares |\n| 11 | PTIN | 843.53 | Pacer Trendpilot International ETF |\n| 12 | GFIN | 686.76 | Goldman Sachs Motif Finance Reimagined ETF |\n| 13 | ERX | 645.16 | Direxion Energy Bull 2X Shares |\n| 14 | LABD | 624.08 | Direxion Daily S&P Biotech Bear 3X Shares |\n| 15 | VIXY | 491.00 | ProShares Trust VIX Short-Term Futures ETF |\n| 16 | BZQ | 462.78 | ProShares UltraShort MSCI Brazil Capped |\n| 17 | JNUG | 451.07 | Direxion Daily Junior Gold Miners Index Bull 2X Shares |\n| 18 | SDOW | 415.17 | UltraPro Short Dow30 |\n| 19 | BOIL | 382.20 | ProShares Ultra Bloomberg Natural Gas |\n| 20 | YANG | 347.35 | Direxion Daily FTSE China Bear 3x Shares |\n| 21 | EDZ | 302.01 | Direxion Emerging Markets Bear 3X Shares |\n| 22 | FAZ | 288.54 | Direxion Financial Bear 3X Shares |\n| 23 | XES | 278.55 | SPDR Series Trust SPDR S&P Oil & Gas Equipment & Services ETF |\n| 24 | TZA | 272.63 | Direxion Small Cap Bear 3X Shares |\n| 25 | SSG | 263.87 | ProShares UltraShort Semiconductors |\n| 26 | MDY | 263.77 | SPDR MidCap Trust Series I |\n| 27 | TECS | 253.30 | Direxion Technology Bear 3X Shares |\n| 28 | LABU | 230.28 | Direxion Daily S&P Biotech Bull 3X Shares |\n| 29 | XOP | 208.74 | SPDR S&P Oil & Gas Exploration & Production |\n| 30 | FXP | 206.00 | ProShares Ultrashort FTSE China 50 |\n| 31 | JPN | 201.52 | Xtrackers Japan JPX-Nikkei 400 Equity ETF |\n\nMethod: filtered `stockinfo` (SQLite) to `ETF='Y'` and `Listing Exchange='P'` → 1,435 tickers, all of which had a matching DuckDB price table; 1,001 had2015 trading data, and 31 of those exceeded $200 on `Adj Close`. The list is dominated by leveraged/inverse products whose pre-reverse-split unadjusted history produces the very large adjusted values at the top.\n\nFull results saved to `./outputs/nyse_arca_etfs_above_200_2015.csv`."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "2",
+    "run": "1",
+    "answer": "I'll query the SQLite metadata for NYSE Arca ETFs, then scan their price tables in DuckDB for 2015.**31 NYSE Arca-listed ETFs** reached an adjusted closing price above $200 during 2015:\n\n| # | Symbol | Max Adj Close 2015 |\n|---|---|---|\n| 1 | UVXY | 81,500.00 |\n| 2 | GUSH | 78,699.22 |\n| 3 | COM | 40,487.99 |\n| 4 | RTL | 13,306.76 |\n| 5 | JDST | 12,988.41 |\n| 6 | HYUP | 4,329.75 |\n| 7 | SOXS | 3,886.62 |\n| 8 | VPC | 2,250.14 |\n| 9 | DUST | 1,923.28 |\n| 10 | LBJ | 998.11 |\n| 11 | PTIN | 843.53 |\n| 12 | GFIN | 686.76 |\n| 13 | ERX | 645.16 |\n| 14 | LABD | 624.08 |\n| 15 | VIXY | 491.00 |\n| 16 | BZQ | 462.78 |\n| 17 | JNUG | 451.07 |\n| 18 | SDOW | 415.17 |\n| 19 | BOIL | 382.20 |\n| 20 | YANG | 347.35 |\n| 21 | EDZ | 302.01 |\n| 22 | FAZ | 288.54 |\n| 23 | XES | 278.55 |\n| 24 | TZA | 272.63 |\n| 25 | SSG | 263.87 |\n| 26 | MDY | 263.77 |\n| 27 | TECS | 253.30 |\n| 28 | LABU | 230.28 |\n| 29 | XOP | 208.74 |\n| 30 | FXP | 206.00 |\n| 31 | JPN | 201.52 |\n\nMethod: filtered `stockinfo` to `ETF = 'Y'` and `Listing Exchange = 'P'` (NYSE Arca) → 1,435 ETFs, all of which have a per-ticker price table in the DuckDB file. Took `MAX(\"Adj Close\")` over dates `2015-01-01`–`2015-12-31` for each and kept those above $200. The extremely high values (UVXY, GUSH, JDST, etc.) are split-adjusted prices for leveraged/inverse funds that have undergone repeated reverse splits."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "2",
+    "run": "2",
+    "answer": "I'll query the SQLite metadata for NYSE Arca ETFs, then scan their price tables in DuckDB for 2015.**31 ETFs** listed on NYSE Arca (Listing Exchange = `P`, ETF = `Y`) reached an adjusted closing price above $200 at some point during 2015:\n\n| Symbol | 2015 max Adj Close | Fund |\n|---|---|---|\n| UVXY | 81,500.00 | ProShares Trust Ultra VIX Short Term Futures ETF |\n| GUSH | 78,699.22 | Direxion Daily S&P Oil & Gas Exp. & Prod. Bull 2X Shares |\n| COM | 40,487.99 | Direxion Auspice Broad Commodity Strategy ETF |\n| RTL | 13,306.76 | Pacer Benchmark Retail Real Estate SCTR ETF |\n| JDST | 12,988.41 | Direxion Daily Junior Gold Miners Index Bear 2X Shares |\n| HYUP | 4,329.75 | Xtrackers High Beta High Yield Bond ETF |\n| SOXS | 3,886.62 | Direxion Daily Semiconductor Bear 3x Shares |\n| VPC | 2,250.14 | Virtus Private Credit Strategy ETF |\n| DUST | 1,923.28 | Direxion Daily Gold Miners Index Bear 2X Shares |\n| LBJ | 998.11 | Direxion Daily Latin America 3x Bull Shares |\n| PTIN | 843.53 | Pacer Trendpilot International ETF |\n| GFIN | 686.76 | Goldman Sachs Motif Finance Reimagined ETF |\n| ERX | 645.16 | Direxion Energy Bull 2X Shares |\n| LABD | 624.08 | Direxion Daily S&P Biotech Bear 3X Shares |\n| VIXY | 491.00 | ProShares Trust VIX Short-Term Futures ETF |\n| BZQ | 462.78 | ProShares UltraShort MSCI Brazil Capped |\n| JNUG | 451.07 | Direxion Daily Junior Gold Miners Index Bull 2X Shares |\n| SDOW | 415.17 | UltraPro Short Dow30 |\n| BOIL | 382.20 | ProShares Ultra Bloomberg Natural Gas |\n| YANG | 347.35 | Direxion Daily FTSE China Bear 3x Shares |\n| EDZ | 302.01 | Direxion Emerging Markets Bear 3X Shares |\n| FAZ | 288.54 | Direxion Financial Bear 3X Shares |\n| XES | 278.55 | SPDR S&P Oil & Gas Equipment & Services ETF |\n| TZA | 272.63 | Direxion Small Cap Bear 3X Shares |\n| SSG | 263.87 | ProShares UltraShort Semiconductors |\n| MDY | 263.77 | SPDR MidCap Trust Series I |\n| TECS | 253.30 | Direxion Technology Bear 3X Shares |\n| LABU | 230.28 | Direxion Daily S&P Biotech Bull 3X Shares |\n| XOP | 208.74 | SPDR S&P Oil & Gas Exploration & Production |\n| FXP | 206.00 | ProShares Ultrashort FTSE China 50 |\n| JPN | 201.52 | Xtrackers Japan JPX-Nikkei 400 Equity ETF |\n\nNotes: all 1,435Arca-listed ETFs in `stockinfo` had a matching price table in DuckDB, and the very high values reflect split-adjusted (reverse-split) prices in the `Adj Close` column for leveraged/volatility products. Full results saved to `./outputs/arca_etfs_above_200_2015.csv`."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "2",
+    "run": "3",
+    "answer": "I'll query the SQLite metadata for NYSE Arca ETFs, then scan their DuckDB price tables for 2015.**31 NYSE Arca-listed ETFs reached an adjusted closing price above $200 at some point during 2015.**\n\n| # | Symbol | Max 2015 Adj Close | Fund |\n|---|---|---|---|\n| 1 | UVXY | 81,500.00 | ProShares Trust Ultra VIX Short Term Futures ETF |\n| 2 | GUSH | 78,699.22 | Direxion Daily S&P Oil & Gas Exp. & Prod. Bull 2X Shares |\n| 3 | COM | 40,487.99 | Direxion Auspice Broad Commodity Strategy ETF |\n| 4 | RTL | 13,306.76 | Pacer Benchmark Retail Real Estate SCTR ETF |\n| 5 | JDST | 12,988.41 | Direxion Daily Junior Gold Miners Index Bear 2X Shares |\n| 6 | HYUP | 4,329.75 | Xtrackers High Beta High Yield Bond ETF |\n| 7 | SOXS | 3,886.62 | Direxion Daily Semiconductor Bear 3x Shares |\n| 8 | VPC | 2,250.14 | Virtus Private Credit Strategy ETF |\n| 9 | DUST | 1,923.28 | Direxion Daily Gold Miners Index Bear 2X Shares |\n| 10 | LBJ | 998.11 | Direxion Daily Latin America 3x Bull Shares |\n| 11 | PTIN | 843.53 | Pacer Trendpilot International ETF |\n| 12 | GFIN | 686.76 | Goldman Sachs Motif Finance Reimagined ETF |\n| 13 | ERX | 645.16 | Direxion Energy Bull 2X Shares |\n| 14 | LABD | 624.08 | Direxion Daily S&P Biotech Bear 3X Shares |\n| 15 | VIXY | 491.00 | ProShares Trust VIX Short-Term Futures ETF |\n| 16 | BZQ | 462.78 | ProShares UltraShort MSCI Brazil Capped |\n| 17 | JNUG | 451.07 | Direxion Daily Junior Gold Miners Index Bull 2X Shares |\n| 18 | SDOW | 415.17 | UltraPro Short Dow30 |\n| 19 | BOIL | 382.20 | ProShares Ultra Bloomberg Natural Gas |\n| 20 | YANG | 347.35 | Direxion Daily FTSE China Bear 3x Shares |\n| 21 | EDZ | 302.01 | Direxion Emerging Markets Bear 3X Shares |\n| 22 | FAZ | 288.54 | Direxion Financial Bear 3X Shares |\n| 23 | XES | 278.55 | SPDR Series Trust SPDR S&P Oil & Gas Equipment & Services ETF |\n| 24 | TZA | 272.63 | Direxion Small Cap Bear 3X Shares |\n| 25 | SSG | 263.87 | ProShares UltraShort Semiconductors |\n| 26 | MDY | 263.77 | SPDR MidCap Trust Series I |\n| 27 | TECS | 253.30 | Direxion Technology Bear 3X Shares |\n| 28 | LABU | 230.28 | Direxion Daily S&P Biotech Bull 3X Shares |\n| 29 | XOP | 208.74 | SPDR S&P Oil & Gas Exploration & Production |\n| 30 | FXP | 206.00 | ProShares Ultrashort FTSE China 50 |\n| 31 | JPN | 201.52 | Xtrackers Japan JPX-Nikkei 400 Equity ETF |\n\nMethod: filtered `stockinfo` for `ETF='Y'` and `Listing Exchange='P'` (NYSE Arca) → 1,435 symbols, all of which had a matching per-ticker OHLCV table in DuckDB; took `MAX(\"Adj Close\")` over dates in 2015 for each. The extremely high values at the top are split-adjustment artifacts in the `Adj Close` series for heavily reverse-split leveraged/volatility products."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "2",
+    "run": "4",
+    "answer": "I'll query the SQLite metadata for NYSE Arca ETFs, then scan their DuckDB price tables for 2015.**31 NYSE Arca–listed ETFs** reached an adjusted closing price above $200 at some point during 2015:\n\n| # | Symbol | Max Adj Close 2015 | Fund name (from data) |\n|---|---|---|---|\n| 1 | UVXY | 81,500.00 | ProShares Trust Ultra VIX Short Term Futures ETF |\n| 2 | GUSH | 78,699.22 | Direxion Daily S&P Oil & Gas Exp. & Prod. Bull 2X Shares |\n| 3 | COM | 40,487.99 | Direxion Auspice Broad Commodity Strategy ETF |\n| 4 | RTL | 13,306.76 | Pacer Benchmark Retail Real Estate SCTR ETF |\n| 5 | JDST | 12,988.41 | Direxion Daily Junior Gold Miners Index Bear 2X Shares |\n| 6 | HYUP | 4,329.75 | Xtrackers High Beta High Yield Bond ETF |\n| 7 | SOXS | 3,886.62 | Direxion Daily Semiconductor Bear 3x Shares |\n| 8 | VPC | 2,250.14 | Virtus Private Credit Strategy ETF |\n| 9 | DUST | 1,923.28 | Direxion Daily Gold Miners Index Bear 2X Shares |\n| 10 | LBJ | 998.11 | Direxion Daily Latin America 3x Bull Shares |\n| 11 | PTIN | 843.53 | Pacer Trendpilot International ETF |\n| 12 | GFIN | 686.76 | Goldman Sachs Motif Finance Reimagined ETF |\n| 13 | ERX | 645.16 | Direxion Energy Bull 2X Shares |\n| 14 | LABD | 624.08 | Direxion Daily S&P Biotech Bear 3X Shares |\n| 15 | VIXY | 491.00 | ProShares Trust VIX Short-Term Futures ETF |\n| 16 | BZQ | 462.78 | ProShares UltraShort MSCI Brazil Capped |\n| 17 | JNUG | 451.07 | Direxion Daily Junior Gold Miners Index Bull 2X Shares |\n| 18 | SDOW | 415.17 | UltraPro Short Dow30 |\n| 19 | BOIL | 382.20 | ProShares Ultra Bloomberg Natural Gas |\n| 20 | YANG | 347.35 | Direxion Daily FTSE China Bear 3x Shares |\n| 21 | EDZ | 302.01 | Direxion Emerging Markets Bear 3X Shares |\n| 22 | FAZ | 288.54 | Direxion Financial Bear 3X Shares |\n| 23 | XES | 278.55 | SPDR Series Trust SPDR S&P Oil & Gas Equipment & Services ETF |\n| 24 | TZA | 272.63 | Direxion Small Cap Bear 3X Shares |\n| 25 | SSG | 263.87 | ProShares UltraShort Semiconductors |\n| 26 | MDY | 263.77 | SPDR MidCap Trust Series I |\n| 27 | TECS | 253.30 | Direxion Technology Bear 3X Shares |\n| 28 | LABU | 230.28 | Direxion Daily S&P Biotech Bull 3X Shares |\n| 29 | XOP | 208.74 | SPDR S&P Oil & Gas Exploration & Production |\n| 30 | FXP | 206.00 | ProShares Ultrashort FTSE China 50 |\n| 31 | JPN | 201.52 | Xtrackers Japan JPX-Nikkei 400 Equity ETF |\n\nMethod: filtered `stockinfo` (SQLite) to `Listing Exchange = 'P'` (NYSE Arca) and `ETF = 'Y'` → 1,435 tickers, all of which had matching per-ticker tables in the DuckDB price database. For each, took `MAX(\"Adj Close\")` over dates `2015-01-01`–`2015-12-31` and kept those > $200.\n\nNote: the extreme values at the top (UVXY, GUSH, COM, etc.) are split-adjusted historical prices for leveraged/volatility products that later did large reverse splits — they are what the `Adj Close` column actually contains, not errors in the screen."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "3",
+    "run": "0",
+    "answer": "**15 NASDAQ-listed financially troubled companies (Financial Status `D` = deficient or `H` = deficient & delinquent) have 2008 trading volume:**\n\n| Company Name | Symbol | Status | Avg Daily Volume 2008 |\n|---|---|---|---|\n| Frontier Communications Corporation | FTR | D | 254,397.63 |\n| Correvio Pharma Corp. | CORV | D | 145,247.83 |\n| CBAK Energy Technology, Inc. | CBAT | D | 86,223.32 |\n| Sypris Solutions, Inc. | SYPR | D | 36,836.36 |\n| Apex Global Brands Inc. | APEX | D | 23,781.42 |\n| DASAN Zhone Solutions, Inc. | DZSI | D | 15,578.66 |\n| BIO-key International, Inc. | BKYI | D | 10,988.14 |\n| Pacific Ethanol, Inc. | PEIX | D | 10,706.72 |\n| China Ceramics Co., Ltd. | CCCL | D | 4,366.80 |\n| Synthesis Energy Systems, Inc. | SES | H | 2,390.51 |\n| Sunesis Pharmaceuticals, Inc. | SNSS | D | 781.82 |\n| CounterPath Corporation | CPAH | D | 375.49 |\n| Ocean Power Technologies, Inc. | OPTT | D | 254.15 |\n| Ideanomics, Inc. | IDEX | D | 10.28 |\n| Future FinTech Group Inc. | FTFT | D | 9.85 |\n\nNotes: 25 securities in `stockinfo` are NASDAQ-listed with a troubled flag (24 `D`, 1 `H`), but only these 15 have any 2008 rows in their per-ticker OHLCV table. All had 253 trading days of non-null volume in 2008 except FTFT (168 days)."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "3",
+    "run": "1",
+    "answer": "**15 financially troubled NASDAQ-listed companies have 2008 trading volume, with these average daily volumes (2008):**\n\n| Symbol | Company Name | Status | Avg daily volume 2008 |\n|---|---|---|---|\n| FTR | Frontier Communications Corporation | D | 254,397.63 |\n| CORV | Correvio Pharma Corp. | D | 145,247.83 |\n| CBAT | CBAK Energy Technology, Inc. | D | 86,223.32 |\n| SYPR | Sypris Solutions, Inc. | D | 36,836.36 |\n| APEX | Apex Global Brands Inc. | D | 23,781.42 |\n| DZSI | DASAN Zhone Solutions, Inc. | D | 15,578.66 |\n| BKYI | BIO-key International, Inc. | D | 10,988.14 |\n| PEIX | Pacific Ethanol, Inc. | D | 10,706.72 |\n| CCCL | China Ceramics Co., Ltd. | D | 4,366.80 |\n| SES | Synthesis Energy Systems, Inc. | H | 2,390.51 |\n| SNSS | Sunesis Pharmaceuticals, Inc. | D | 781.82 |\n| CPAH | CounterPath Corporation | D | 375.49 |\n| OPTT | Ocean Power Technologies, Inc. | D | 254.15 |\n| IDEX | Ideanomics, Inc. | D | 10.28 |\n| FTFT | Future FinTech Group Inc. | D | 9.85 |\n\nDetails:\n- `stockinfo` has 25 securities flagged as financially troubled (24 `D` = delinquent, 1 `H` = deficient+delinquent); all 25 are NASDAQ-listed (Listing Exchange `Q`).\n- Averages are computed over eachticker's non-null `Volume` rows with `Date` in 2008— 253 trading days for all except FTFT (168 days, partial-year listing).\n- The remaining 10 troubled tickers have no 2008 rows at all in their price tables: AGMH, AMTX, BIOC, FAMI, ISDS, MCEP, NXTD, RBZ, SPI, VTIQW."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "3",
+    "run": "2",
+    "answer": "I'll start by connecting to both databases and inspecting the relevant metadata.15 NASDAQ-listed financially troubled companies (Financial Status `D` = delinquent or `H` = deficient+delinquent) have 2008 trading volume, with these average daily volumes in 2008:\n\n| Symbol | Company | Avg daily volume 2008 |\n|---|---|---|\n| FTR | Frontier Communications Corporation | 254,397.63 |\n| CORV | Correvio Pharma Corp | 145,247.83 |\n| CBAT | CBAK Energy Technology, Inc | 86,223.32 |\n| SYPR | Sypris Solutions, Inc | 36,836.36 |\n| APEX | Apex Global Brands Inc | 23,781.42 |\n| DZSI | DASAN Zhone Solutions, Inc | 15,578.66 |\n| BKYI | BIO-key International, Inc | 10,988.14 |\n| PEIX | Pacific Ethanol, Inc | 10,706.72 |\n| CCCL | China Ceramics Co., Ltd | 4,366.80 |\n| SES | Synthesis Energy Systems, Inc | 2,390.51 |\n| SNSS | Sunesis Pharmaceuticals, Inc | 781.82 |\n| CPAH | CounterPath Corporation | 375.49 |\n| OPTT | Ocean Power Technologies, Inc | 254.15 |\n| IDEX | Ideanomics, Inc | 10.28 |\n| FTFT | Future FinTech Group Inc | 9.85 |\n\nNotes:\n- Filter: `Financial Status ∈ {D, H}` and NASDAQ market tier (`Market Category ∈ {G, Q, S}`) — 25 such securities exist (24 `D`, 1 `H`), all on Listing Exchange `Q`.\n- 10 of them have no 2008 rows in their DuckDB price tables and are therefore excluded: AGMH, AMTX, BIOC, FAMI, ISDS, MCEP, NXTD, RBZ, SPI, VTIQW.\n- All 15 reported tickers had 253 trading days in 2008 except FTFT (168 days)."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "3",
+    "run": "3",
+    "answer": "I'll start by inspecting both databases.**15 NASDAQ-listed financially troubled companies (Financial Status = D or H) have 2008 trading volume; their 2008 average daily volumes are:**\n\n| Symbol | Company | Avg daily volume 2008 | Trading days |\n|---|---|---|---|\n| FTR | Frontier Communications Corporation | 254,397.63 | 253 |\n| CORV | Correvio Pharma Corp. | 145,247.83 | 253 |\n| CBAT | CBAK Energy Technology, Inc. | 86,223.32 | 253 |\n| SYPR | Sypris Solutions, Inc. | 36,836.36 | 253 |\n| APEX | Apex Global Brands Inc. | 23,781.42 | 253 |\n| DZSI | DASAN Zhone Solutions, Inc. | 15,578.66 | 253 |\n| BKYI | BIO-key International, Inc. | 10,988.14 | 253 |\n| PEIX | Pacific Ethanol, Inc. | 10,706.72 | 253 |\n| CCCL | China Ceramics Co., Ltd. | 4,366.80 | 253 |\n| SES | Synthesis Energy Systems, Inc. | 2,390.51 | 253 |\n| SNSS | Sunesis Pharmaceuticals, Inc. | 781.82 | 253 |\n| CPAH | CounterPath Corporation | 375.49 | 253 |\n| OPTT | Ocean Power Technologies, Inc. | 254.15 | 253 |\n| IDEX | Ideanomics, Inc. | 10.28 | 253 |\n| FTFT | Future FinTech Group Inc. | 9.85 | 168 |\n\nMethod: `stockinfo` (SQLite) filtered to `Financial Status IN ('D','H')` and NASDAQ-listed (`Market Category` ≠ \"Not applicable or not NASDAQ-listed\"), then each ticker's per-ticker table in the DuckDB price database averaged over non-null `Volume` rows dated in 2008. Flagged tickers with no 2008 rows were excluded; all but FTFT traded the full 253-day year."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "3",
+    "run": "4",
+    "answer": "I'll start by exploring both databases.15 NASDAQ-listed financially troubled companies (`Financial Status` = D or H) have 2008 trading volume data, with these average daily volumes:\n\n| Company | Symbol | Status | 2008 avg daily volume |\n|---|---|---|---|\n| Frontier Communications Corporation | FTR | D (delinquent) | 254,397.63 |\n| Correvio Pharma Corp. | CORV | D | 145,247.83 |\n| CBAK Energy Technology, Inc. | CBAT | D | 86,223.32 |\n| Sypris Solutions, Inc. | SYPR | D | 36,836.36 |\n| Apex Global Brands Inc. | APEX | D | 23,781.42 |\n| DASAN Zhone Solutions, Inc. | DZSI | D | 15,578.66 |\n| BIO-key International, Inc. | BKYI | D | 10,988.14 |\n| Pacific Ethanol, Inc. | PEIX | D | 10,706.72 |\n| China Ceramics Co., Ltd. | CCCL | D | 4,366.80 |\n| Synthesis Energy Systems, Inc. | SES | H (deficient & delinquent) | 2,390.51 |\n| Sunesis Pharmaceuticals, Inc. | SNSS | D | 781.82 |\n| CounterPath Corporation | CPAH | D | 375.49 |\n| Ocean Power Technologies, Inc. | OPTT | D | 254.15 |\n| Ideanomics, Inc. | IDEX | D | 10.28 |\n| Future FinTech Group Inc. | FTFT | D | 9.85 |\n\nNotes: 25 securities in `stockinfo` carry a troubled `Financial Status` (24 `D`, 1 `H`) and all25 are NASDAQ-listed (`Listing Exchange` = `Q`). The remaining 10 have price tables with no 2008 rows, so no2008 average exists for them. Most tickers here have 253 trading days in 2008; FTFT has only 168."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "4",
+    "run": "0",
+    "answer": "The top5 are **MFA Financial, Inc.** (MFO), **Argo Group International Holdings, Ltd.** (ARGD), **HDFC Bank Limited** (HDB), **Albany International Corporation** (AIN), and **DTE Energy Company** (DTQ).\n\nRanked by surplus of up days over down days in 2017 among NYSE-listed (`Listing Exchange = 'N'`), non-ETF securities:\n\n| Rank | Symbol | Company | Up days | Down days | Surplus |\n|---|---|---|---|---|---|\n| 1 | MFO | MFA Financial, Inc. | 139 | 67 | +72 |\n| 2 | ARGD | Argo Group International Holdings, Ltd. | 133 | 82 | +51 |\n| 3 | HDB | HDFC Bank Limited | 146 | 102 | +44 |\n| 4 | AIN | Albany International Corporation | 143 | 101 | +42 |\n| 5 | DTQ | DTE Energy Company | 139 | 98 | +41 |\n\nAll 234 NYSE non-ETF symbols had a matching per-ticker price table, so no tickers were dropped from the comparison."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "4",
+    "run": "1",
+    "answer": "**Top 5 NYSE non-ETF stocks with more up days than down days in 2017:**\n\n1. **MFA Financial, Inc.** (MFO) — 139 up vs67 down (+72)\n2. **Argo Group International Holdings, Ltd.** (ARGD) — 133 up vs 82 down (+51)\n3. **HDFC Bank Limited** (HDB) — 146up vs 102 down (+44)\n4. **Albany International Corporation** (AIN) — 143 up vs 101 down (+42)\n5. **DTE Energy Company** (DTQ) — 139 up vs 98 down (+41)\n\nMethod: filtered `stockinfo` to `Listing Exchange = 'N'` and `ETF = 'N'` (234 symbols), then counted 2017 trading days with `Close > Open` vs `Close < Open` in each ticker's DuckDB table, ranking by the up-minus-down surplus. All 234 NYSE symbols had a matching price table."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "4",
+    "run": "2",
+    "answer": "I'll explore the databases and compute this.**HDFC Bank Limited, Getty Realty Corporation, Albany International Corporation, Mettler-Toledo International, Inc., and Ameriprise Financial, Inc.**\n\nRanked by number of up days in 2017 (all NYSE-listed, `ETF = 'N'`, and all with up days > down days):\n\n| Rank | Symbol | Company name | Up days | Down days |\n|---|---|---|---|---|\n| 1 | HDB | HDFC Bank Limited | 146 | 102 |\n| 2 | GTY | Getty Realty Corporation | 143 | 104 |\n| 2 | AIN | Albany International Corporation | 143 | 101 |\n| 2 | MTD | Mettler-Toledo International, Inc. | 143 | 108 |\n| 5 | AMP | Ameriprise Financial, Inc. | 141 | 110 |\n\nNotes: 234 NYSE non-ETF symbols had price tables; 131 of them had more up days than down days in 2017. GTY/AIN/MTD are tied at 143 up days, but all three fit within the top 5 either way. (If instead ranked by the up-minus-down *margin*, the top 5 would be MFA Financial, Inc.; Argo Group International Holdings, Ltd.; HDFC Bank Limited; Albany International Corporation; and DTE Energy Company.)"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "4",
+    "run": "3",
+    "answer": "The top 5 are **MFA Financial, Inc.**, **Argo Group International Holdings, Ltd.**, **HDFC Bank Limited**, **Albany International Corporation**, and **DTE Energy Company**.\n\nRanked by 2017 up-day margin (up days minus down days) among NYSE-listed (`Listing Exchange = N`), non-ETF securities:\n\n| Rank | Symbol | Company Name | Up days | Down days | Margin |\n|---|---|---|---|---|---|\n| 1 | MFO | MFA Financial, Inc. | 139 | 67 | +72 |\n| 2 | ARGD | Argo Group International Holdings, Ltd. | 133 | 82 | +51 |\n| 3 | HDB | HDFC Bank Limited | 146 | 102 | +44 |\n| 4 | AIN | Albany International Corporation | 143 | 101 | +42 |\n| 5 | DTQ | DTE Energy Company | 139 | 98 | +41 |\n\nAll 234 NYSE non-ETF symbols in `stockinfo` had a matching price table in the DuckDB database, so no tickers were dropped from the comparison."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "4",
+    "run": "4",
+    "answer": "The top 5 are **MFA Financial, Inc.**, **Argo Group International Holdings, Ltd.**, **HDFC Bank Limited**, **Albany International Corporation**, and **DTE Energy Company**.\n\nRanked by surplus of up days over down days in 2017 (NYSE-listed, `Listing Exchange = N`, `ETF = N`):\n\n| Rank | Symbol | Name | Up | Down | Surplus |\n|---|---|---|---|---|---|\n| 1 | MFO | MFA Financial, Inc. | 139 | 67 | +72 |\n| 2 | ARGD | Argo Group International Holdings, Ltd. | 133 | 82 | +51 |\n| 3 | HDB | HDFC Bank Limited | 146 | 102 | +44 |\n| 4 | AIN | Albany International Corporation | 143 | 101 | +42 |\n| 5 | DTQ | DTE Energy Company | 139 | 98 | +41 |\n\nAll 234 NYSE non-ETF symbols in `stockinfo` had matching per-ticker tables in the DuckDB file, so no ticker was dropped from the comparison."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "5",
+    "run": "0",
+    "answer": "I'll start by loading the stock metadata and identifying NASDAQ Capital Market listings.The top 5 companies are **Synthesis Energy Systems, Inc.**, **TD Holdings, Inc.**, **TMSR Holding Company Limited**, **Verb Technology Company, Inc.**, and **Sunesis Pharmaceuticals, Inc.**\n\n| Rank | Symbol | Company | Days in 2019 with (High−Low)/Low > 20% |\n|---|---|---|---|\n| 1 | SES | Synthesis Energy Systems, Inc. | 51 |\n| 2 | GLG | TD Holdings, Inc. | 42 |\n| 3 | TMSR | TMSR Holding Company Limited | 40 |\n| 4 | VERB | Verb Technology Company, Inc. | 38 |\n| 5 | SNSS | Sunesis Pharmaceuticals, Inc. | 32 |\n\nMethod: filtered `stockinfo` to `Market Category = 'S'` (NASDAQ Capital Market → 86 symbols, all with matching DuckDB price tables), then counted 2019 trading days where `(High - Low) / Low > 0.20` per ticker. The next-ranked names (CBAT23, FAMI 23) fall well below #5, so the top 5 is unambiguous."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "5",
+    "run": "1",
+    "answer": "I'll start by exploring both databases.**Synthesis Energy Systems, Inc.; TD Holdings, Inc.; TMSR Holding Company Limited; Verb Technology Company, Inc.; Sunesis Pharmaceuticals, Inc.**\n\n| # | Company | Symbol | Days in 2019 with (High−Low)/Low > 20% |\n|---|---|---|---|\n| 1 | Synthesis Energy Systems, Inc. | SES | 51 |\n| 2 | TD Holdings, Inc. | GLG | 42 |\n| 3 | TMSR Holding Company Limited | TMSR | 40 |\n| 4 | Verb Technology Company, Inc. | VERB | 38 |\n| 5 | Sunesis Pharmaceuticals, Inc. | SNSS | 32 |\n\nMethod: filtered `stockinfo` to Market Category `S` (NASDAQ Capital Market) → 86 tickers, all present in the DuckDB OHLCV database; counted 2019 trading days where intraday range exceeded 20% of the day's low. No tie at the 5th position (next highest were CBAT and FAMI at 23 days)."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "5",
+    "run": "2",
+    "answer": "The top 5 NASDAQ Capital Market companies by number of 2019 days with an intraday range exceeding 20% of the low price are:\n\n1. **Synthesis Energy Systems, Inc.** (SES) — 51 days\n2. **TD Holdings, Inc.** (GLG) — 42 days\n3. **TMSR Holding Company Limited** (TMSR) — 40 days\n4. **Verb Technology Company, Inc.** (VERB) — 38 days\n5. **Sunesis Pharmaceuticals, Inc.** (SNSS) — 32 days\n\nMethod: filtered `stockinfo` to Market Category `S` (NASDAQ Capital Market → 86 securities, all non-ETF), then for each ticker's DuckDB OHLCV table counted 2019 rows where `(High − Low) / Low > 0.20`. No ties at the 5th position (next highest is 23 days)."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "5",
+    "run": "3",
+    "answer": "The top 5 NASDAQ Capital Market companies by number of 2019 days with intraday range exceeding 20% of the low price are:\n\n1. **Synthesis Energy Systems, Inc.** (SES) — 51 days\n2. **TD Holdings, Inc.** (GLG) — 42 days\n3. **TMSR Holding Company Limited** (TMSR) — 40 days\n4. **Verb Technology Company, Inc.** (VERB) — 38 days\n5. **Sunesis Pharmaceuticals, Inc.** (SNSS) — 32 days\n\nMethod: filtered `stockinfo` to Market Category `S` (NASDAQ Capital Market → 86 symbols, all matched to per-ticker DuckDB tables), counted 2019 trading days where `(High - Low) / Low > 0.20`, then joined names from `Company Description`. No ties at the 5th position (next highest was 23 days)."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "5",
+    "run": "4",
+    "answer": "I'll work through this step by step — first exploring the databases.**Synthesis Energy Systems, Inc. (SES, 51 days); TD Holdings, Inc. (GLG, 42 days); TMSR Holding Company Limited (TMSR, 40 days); Verb Technology Company, Inc. (VERB, 38 days); Sunesis Pharmaceuticals, Inc. (SNSS, 32 days).**\n\nThese are the top 5 of the 86 NASDAQ Capital Market–listed securities (Market Category `S`), ranked by the number of 2019 trading days where `(High − Low) / Low > 0.20`. Next closest were CBAK Energy Technology, Inc. and Farmmi, Inc. at 23 days each."
+  },
+  {
+    "dataset": "yelp",
+    "query": "1",
+    "run": "0",
+    "answer": "**3.55** — the average review rating across all businesses located in Indianapolis, IN.\n\n- 8 businesses in `business` have descriptions placing them in Indianapolis, IN.\n- Their `businessid_<n>` keys were normalized to `businessref_<n>` and matched against the DuckDB `review` table, yielding **117 reviews**.\n- Review-level mean = **3.547** (≈3.55). For reference, averaging each business's own mean first gives 3.50."
+  },
+  {
+    "dataset": "yelp",
+    "query": "1",
+    "run": "1",
+    "answer": "I'll load both databases and identify Indianapolis businesses.**3.55** is the average rating of all businesses located in Indianapolis, IN.\n\nDetails:\n- 8 businesses in the `business` collection have descriptions placing them in **Indianapolis, IN**: Architectural Antiques of Indianapolis, Gamestop, Big Lots, Jordans Fish and Chicken, Pat Flynn's Public House, Taste of Europe, Long John Silver's, Fox and Hound English Pub and Grille.\n- Joining on the normalized business key (`businessid_<n>` ↔ `businessref_<n>`) yields **117 reviews**, mean rating **3.55** (review-level average).\n- Averaging each business's own mean rating first (unweighted per-business) gives **3.50**, so the result is stable either way."
+  },
+  {
+    "dataset": "yelp",
+    "query": "1",
+    "run": "2",
+    "answer": "I'll query both databases and join on the normalized business key.**The average rating of businesses located in Indianapolis, Indiana is ≈ 3.55 (3.5470).**\n\nHow this was derived:\n- 8 of the 100 businesses in the mongo `business` collection have `Indianapolis, IN` embedded in their `description` (no separate address field exists).\n- Their `businessid_<n>` keys were normalized to `businessref_<n>` to join against the DuckDB `review` table, yielding **117 reviews**.\n- Pooled mean over those 117 review ratings = **3.5470** → **3.55**.\n\nFor reference, averaging the8 per-business means equally (unweighted) gives **3.4975 ≈ 3.50**, so the pooled figure of 3.55 is the answer if each review counts equally."
+  },
+  {
+    "dataset": "yelp",
+    "query": "1",
+    "run": "3",
+    "answer": "**3.55** — the average rating across all reviews of businesses located in Indianapolis, IN.\n\nDetails:\n- 8 businesses in the `business` collection have descriptions containing \"Indianapolis, IN\".\n- Matching them to `review.business_ref` (normalizing the `businessid_` vs `businessref_` prefix mismatch by numeric suffix) yields 117 reviews.\n- Pooled mean of those 117 ratings = **3.55**. (If instead each business is weighted equally by first averaging within business, the result is 3.50.)"
+  },
+  {
+    "dataset": "yelp",
+    "query": "1",
+    "run": "4",
+    "answer": "**3.55** — the average rating across all reviews of businesses located in Indianapolis, IN.\n\n- 8 businesses in the `business` collection have descriptions placing them in \"Indianapolis, IN\"\n- Those businesses have 117 reviews in the DuckDB `review` table (joined on the numeric suffix, `businessid_<n>` ↔ `businessref_<n>`)\n- Mean of all 117 review ratings = **3.55**; if instead each business is weighted equally (mean of the 8 per-business averages), the result is **3.50**"
+  },
+  {
+    "dataset": "yelp",
+    "query": "2",
+    "run": "0",
+    "answer": "I'll load both databases and join businesses to reviews via the numeric suffix.**Pennsylvania (PA) has the highest number of reviews — 662 reviews — with an average rating of 3.70 stars.**\n\nDetails:\n- State was parsed out of the free-text `business.description` field in the MongoDB `business` collection (no separate address column); the 4 non-U.S. businesses (Edmonton, AB) were excluded.\n- Reviews from the DuckDB `review` table were joined to businesses by normalizing the key mismatch (`businessref_<n>` → `businessid_<n>`); 45 of 2,000 reviews reference business numbers not present in the 100-document business collection and were dropped.\n- Runners-up: FL (406 reviews, 3.03), MO (213, 3.91), IN (176, 3.47).\n- Alternative framing: if \"number of reviews\" is taken from the businesses' own `review_count` field instead of actual review rows, MO leads (2,243 vs PA's 2,022) — but the actual review records in the review table put PA clearly first."
+  },
+  {
+    "dataset": "yelp",
+    "query": "2",
+    "run": "1",
+    "answer": "**Pennsylvania (PA) has the highest number of reviews — 662 reviews — with an average rating of 3.70 stars.**\n\nDetails:\n\n| State | Reviews | Avg rating |\n|---|---|---|\n| **PA** | **662** | **3.70** |\n| FL | 406 | 3.03 |\n| MO | 213 | 3.91 |\n| IN | 176 | 3.47 |\n| ID | 126 | 3.65 |\n| LA | 125 | 3.54 |\n\nMethod: states were parsed out of the free-text `business.description` field in MongoDB (no separate address column), then joined to the 2,000 DuckDB reviews after normalizing the key mismatch (`businessid_<n>` ↔ `businessref_<n>`) — all 2,000 reviews matched a business. 4 businesses were excluded as non-U.S. (Edmonton, AB). The 3.70 figure is the mean of all individual review ratings in PA; averaging per-business mean ratings first instead gives 3.65."
+  },
+  {
+    "dataset": "yelp",
+    "query": "2",
+    "run": "2",
+    "answer": "**Pennsylvania (PA) has the highest number of reviews — 662 reviews — with an average rating of 3.7.**\n\nDetails:\n- State was recovered by parsing the `city, ST` pattern out of the free-text `business.description` field in the MongoDB `business` collection (no separate address/state column exists).\n- Reviews were joined from the DuckDB `review` table by normalizing `businessref_<n>` → `businessid_<n>`; all 2,000 reviews matched a business.\n- PA covers 33 of the 96 U.S. businesses in the dataset. The 3.70 figure is the mean of all 662 individual review ratings; averaging per-business means first instead gives 3.65.\n- 4 businesses (all in Edmonton, AB, Canada) were excluded as non-U.S."
+  },
+  {
+    "dataset": "yelp",
+    "query": "2",
+    "run": "3",
+    "answer": "**Pennsylvania (PA)** has the highest number of reviews — 662 reviews — with an average rating of **3.70** stars.\n\nDetails:\n- PA covers 27 businesses in the dataset, the most of any state.\n- Averaging per-business mean ratings instead gives 3.65, so the answer is ~3.7 either way.\n- Next highest states by review volume: FL (406, avg 3.03) and MO (213, avg 3.91).\n- Method: states were parsed from `business.description` (no address field exists), then joined to DuckDB `review` rows by normalizing the numeric suffix of `businessid_<n>` ↔ `businessref_<n>`. Four businesses in Edmonton, AB (Canada) were excluded as non-U.S."
+  },
+  {
+    "dataset": "yelp",
+    "query": "2",
+    "run": "4",
+    "answer": "**Pennsylvania (PA) has the highest number of reviews — 662 reviews — with an average rating of 3.70 stars.**\n\nDetails:\n- State was parsed out of `business.description` (no separate address field); reviews were joined from DuckDB `review.business_ref` → mongo `business.business_id` via the numeric suffix (all 2,000 reviews matched).\n- Top states by actual review rows: PA 662 (avg 3.70), FL 406 (avg 3.03), MO 213 (avg 3.91), IN 176 (avg 3.47).\n- Averaging per business first instead of per review gives PA 3.65 — same conclusion.\n- Note: 4 businesses are in Edmonton, AB (non-U.S.) and were excluded."
+  },
+  {
+    "dataset": "yelp",
+    "query": "3",
+    "run": "0",
+    "answer": "I'll load both databases and check the 2018 reviews against business parking attributes.**35 businesses.**\n\nOf the 67 businesses that received at least one review dated in 2018, 35 have parking availability — either a `BusinessParking` sub-option set to `True` (garage, street, validated, lot, or valet) or `BikeParking` set to `True`. Attribute values were parsed with `ast.literal_eval` after stripping both `u'...'` and `'...'` wrappers, and all 2000 review dates parsed cleanly across the mixed date formats."
+  },
+  {
+    "dataset": "yelp",
+    "query": "3",
+    "run": "1",
+    "answer": "I'll work through this in steps — first loading both databases.**35 businesses.**\n\nOf the 67 distinct businesses that received at least one review dated in 2018 (211 reviews total), 35 have parking availability in their attributes:\n\n| Amenity | Businesses |\n|---|---|\n| Business parking only (any of garage/street/validated/lot/valet = True) | 8 |\n| Bike parking only | 5 |\n| Both | 22 |\n| **Either (answer)** | **35** |\n\nMethod notes: review dates were year-extracted with a regex to handle the three mixed date formats; `businessref_<n>` was normalized to `businessid_<n>` for the cross-database match (all 67 refs matched); `BusinessParking` was parsed with `ast.literal_eval` after stripping `u'...'` wrappers, and counted as offered when at least one parking type is `True`."
+  },
+  {
+    "dataset": "yelp",
+    "query": "3",
+    "run": "2",
+    "answer": "**35 businesses.**\n\nOf the 67 businesses that received at least one review dated in 2018, 35 have parking availability — either `BusinessParking` with at least one true sub-option (garage, street, lot, valet, validated) or `BikeParking` = True.\n\nMethod notes:\n- Review dates parsed defensively (mixed formats,0 unparsed rows out of 2,000) and filtered to year 2018.\n- `businessref_<n>` normalized to `businessid_<n>` to join across DuckDB → MongoDB.\n- `attributes` values parsed with `ast.literal_eval` after stripping both `u'...'` and `'...'` wrappers, since `BusinessParking` is a stringified Python dict with string-encoded booleans."
+  },
+  {
+    "dataset": "yelp",
+    "query": "3",
+    "run": "3",
+    "answer": "**35 businesses.**\n\nOf the 67 distinct businesses that received reviews during 2018 (211 reviews total), 35 offer either business parking or bike parking:\n\n- 30 have at least one `BusinessParking` sub-option set to `True` (garage, street, validated, lot, or valet)\n- 27 have `BikeParking = True`\n- 22 have both, giving 30 + 27 − 22 = 35 in the union\n\nNotes on handling: review dates were parsed defensively (all 2000 parsed cleanly), business keys were joined on the numeric suffix (`businessref_N` ↔ `businessid_N`), and `attributes.BusinessParking` was parsed with `ast.literal_eval` after stripping both `u'...'` and `'...'` wrappers."
+  },
+  {
+    "dataset": "yelp",
+    "query": "3",
+    "run": "4",
+    "answer": "I'll work through this by loading the reviews from DuckDB, filtering to 2018, then checking parking attributes on the matching businesses in MongoDB.**35 businesses.**\n\nOf the 67 distinct businesses that received at least one review dated in 2018 (211 reviews total), 35 offer either business parking (any `BusinessParking` sub-option = True, e.g. lot/street/valet/garage/validated) or bike parking (`BikeParking` = True).\n\nMethod notes:\n- 2018 reviews identified by extracting the 4-digit year from the mixed-format `review.date` strings.\n- Joined `review.business_ref` (`businessref_<n>`) to mongo `business.business_id` (`businessid_<n>`) on the numeric suffix — all 67 matched.\n- `attributes` values parsed with `ast.literal_eval` after stripping both `u'...'` and `'...'` wrapper styles."
+  },
+  {
+    "dataset": "yelp",
+    "query": "4",
+    "run": "0",
+    "answer": "I'll work through the Mongo business metadata and the DuckDB reviews to answer this.**Restaurants** — 23 credit-card-accepting businesses, with an average rating of **3.60**.\n\nDetails:\n- Credit-card acceptance was taken from `business.attributes.BusinessAcceptsCreditCards == 'True'` (75 of 100 businesses; 2 `False`, 14 missing the key, 9 with null attributes).\n- Categories were parsed out of the free-text `description` field (no dedicated categories column), then counted per category among the credit-card-accepting businesses.\n- Average rating = mean of `review.rating` in DuckDB over the 698 reviews for those 23 businesses, joining `businessref_<n>` ↔ `businessid_<n>` on the numeric suffix.\n\nRunner-ups: Shopping (17 businesses, 3.53) and Food (15, 3.73)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "4",
+    "run": "1",
+    "answer": "I'll load both databases and work through category extraction and the credit-card filter.**Shopping** is the category with the largest number of credit-card-accepting businesses (14), and its average review rating is **3.72**.\n\nDetails:\n- 75 of the 100 businesses have `BusinessAcceptsCreditCards = True` (after stripping the `u'...'`/`'...'` repr wrappers).\n- Categories were parsed from the free-text `description` field (the trailing comma-separated list after phrases like \"services in\"), since there is no separate categories column.\n- Ratings come from DuckDB `review`, joined to Mongo `business` on the numeric suffix (`businessref_<n>` ↔ `businessid_<n>`): 199 reviews across those 14 Shopping businesses, mean rating 3.724.\n- Runners-up: Restaurants (10 businesses, avg 3.55) and Food (8 businesses, avg 3.83)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "4",
+    "run": "2",
+    "answer": "I'll load both databases and work through this step by step.**Restaurants** is the category with the most credit-card-accepting businesses — 27 of them — and their average rating is **3.63** stars.\n\nDetails:\n- 75 of the 100 businesses have `attributes.BusinessAcceptsCreditCards == 'True'` (2 are `'False'`, 23 have no such attribute).\n- Categories were parsed out of the free-text `business.description` field (no separate categories column exists). Among credit-card-accepting businesses: Restaurants 27, Food 20, Shopping 17, Home Services 8, then a cluster at 7 (Beauty & Spas, Automotive, Breakfast & Brunch, American (New), Bars, Nightlife).\n- The rating comes from the DuckDB `review` table, joined on the numeric suffix of `businessid_<n>` ↔ `businessref_<n>`: 778 reviews across all 27 businesses, mean rating 3.63 (if instead averaging each business's own mean rating, it's 3.43)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "4",
+    "run": "3",
+    "answer": "I'll work through the two databases to answer this.**Restaurants — 27 credit-card-accepting businesses, average rating 3.63.**\n\nDetails of how this was derived:\n- `BusinessAcceptsCreditCards == 'True'` in the mongo `business.attributes` holds for 75 of 100 businesses (2 `False`, 14 attribute-present-but-missing-key, 9 null attributes).\n- Categories were parsed out of the free-text `description` field (no categories column exists), building a vocabulary of Title-Case category phrases and then matching case-insensitively so lowercase mentions (\"restaurants\", \"bars\") are also caught.\n- Ratings come from the DuckDB `review` table, joined on the numeric suffix of `businessref_<n>` ↔ `businessid_<n>` (100% match rate).\n\nRunner-ups among credit-card businesses: Food (20 businesses, 3.55), Shopping (17, 3.53). The Restaurants figure rests on 778 reviews."
+  },
+  {
+    "dataset": "yelp",
+    "query": "4",
+    "run": "4",
+    "answer": "I'll load both databases and work through this.**Restaurants**, with 26 credit-card-accepting businesses and an average rating of **3.64** stars.\n\nDetails:\n-75 of the 100 businesses have `BusinessAcceptsCreditCards = True` (2 False, 23 with no attribute data).\n- Categories were parsed out of the free-text `business.description` field (no separate categories column), then joined to DuckDB `review.rating` by normalizing `businessid_<n>` ↔ `businessref_<n>`.\n- The 3.641 average is over all 771 reviews belonging to those 26 restaurants. Runners-up: Shopping (17 businesses, 3.54) and Food (15, 3.73)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "5",
+    "run": "0",
+    "answer": "I'll work through the Mongo business metadata and DuckDB reviews to answer this.**Pennsylvania (PA), with 8 WiFi-offering businesses and an average rating of about 3.48.**\n\nDetails:\n- WiFi businesses were identified from the mongo `business.attributes.WiFi` field, keeping values `free` and `paid` (after stripping the `u'...'` / `'...'` repr wrappers) — 22 of 100 businesses offer WiFi; 13 are `no` and 65 have no WiFi attribute.\n- States were parsed out of the free-text `description` field. Counts: PA 8, FL 5, MO 2, IN 2, then AB/IL/ID/LA/NV with 1 each.\n- Ratings came from the DuckDB `review` table, joined on the numeric suffix (`businessref_<n>` ↔ `businessid_<n>`). Across all 281 reviews of PA's 8 WiFi businesses the mean rating is **3.48**; averaging each business's own mean first gives **3.58**."
+  },
+  {
+    "dataset": "yelp",
+    "query": "5",
+    "run": "1",
+    "answer": "I'll load the business collection from the MongoDB BSON dump and inspect the WiFi attribute and description fields.**Pennsylvania (PA)** has the most WiFi-offering businesses — 8 — with an average rating of **3.48** stars.\n\nDetails:\n- WiFi-offering = `attributes.WiFi` parsed to `free` or `paid` (after stripping `u'...'`/`'...'` wrappers); state parsed from the free-text `description` field.\n- Average rating = mean `review.rating` across the 281 reviews of those 8 PA businesses (joined on the numeric suffix, `businessref_<n>` ↔ `businessid_<n>`).\n- Runners-up: FL (5 businesses, 3.60), then MO and IN (2 each)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "5",
+    "run": "2",
+    "answer": "**Pennsylvania (PA)** has the highest number of WiFi-offering businesses — 8 — and their average review rating is **3.48**.\n\nDetails:\n- WiFi-offering = `attributes.WiFi` parsed to `free` (21) or `paid` (1), after stripping both `u'...'` and `'...'` quoting styles; 22 businesses total, of which 21 are U.S. (1 was in Edmonton, AB and excluded as non-U.S.).\n- States parsed from the free-text `description` field (no dedicated address column).\n- Average rating computed from the DuckDB `review.rating` values joined on the numeric suffix (`businessref_<n>` ↔ `businessid_<n>`): 281 reviews across the 8 PA businesses, mean 3.48.\n\nRunner-up: FL with 5 businesses (avg 3.59)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "5",
+    "run": "3",
+    "answer": "I'll work through this step by step — loading the MongoDB business dump, parsing the WiFi attribute, extracting states from descriptions, then joining ratings from DuckDB.**Pennsylvania (PA)** has the highest number of WiFi-offering businesses — **8** — with an **average rating of 3.48** stars.\n\nDetails:\n- WiFi-offering = `attributes.WiFi` parsed to `free` or `paid` (Python-repr wrappers like `u'free'` stripped); `no` and missing attributes excluded.\n- State recovered from the free-text `business.description` field (no separate address column).\n- Counts by state: PA 8, FL 5, MO 2, IN 2, then LA/IL/NV/ID/AB with 1 each — no tie at the top.\n- The 3.48 average is over all 281 reviews in `user_database.review` matched to those 8 PA businesses (joining on the numeric suffix, since `businessref_<n>` vs `businessid_<n>` prefixes differ). If instead averaged per-business first, the figure is 3.58."
+  },
+  {
+    "dataset": "yelp",
+    "query": "5",
+    "run": "4",
+    "answer": "I'll load both databases and work through this step by step.**Pennsylvania (PA), with 8 WiFi-offering businesses and an average review rating of 3.48.**\n\nDetails:\n- WiFi attribute parsed from `business.attributes` (handling both `u'free'` and `'free'` forms): 21 businesses with `free`, 1 with `paid`, 13 with `no`, 65 missing the attribute.\n- State parsed from the free-text `description` field. PA leads with 8 (all `free`), followed by FL (5), MO (2), IN (2), then IL/ID/LA/NV (1 each). The single `paid` business is in AB (Alberta, not a U.S. state).\n- Ratings from DuckDB `review`, joined on the numeric suffix (`businessref_N` ↔ `businessid_N`): 281 reviews across the 8 PA businesses, pooled mean **3.48** (unweighted average of the 8 per-business means is 3.58)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "6",
+    "run": "0",
+    "answer": "I'll load both databases and work through this. Starting with the DuckDB reviews.**Coffee House Too Cafe** received the highest average rating (4.375) between January 1, 2016 and June 30, 2016 among businesses with at least 5 reviews, and it belongs to the categories **Restaurants, Breakfast & Brunch, American (New), Cafes**.\n\nSupporting detail (all businesses meeting the ≥5-review threshold in that window):\n\n| Business | Reviews (H1 2016) | Avg rating |\n|---|---|---|\n| Coffee House Too Cafe (`businessid_9`) | 16 | 4.375 |\n| Orangetheory Fitness Carrollwood (`businessid_37`) | 7 | 4.000 |\n| Uber (`businessid_8`) | 5 | 3.600 |\n\nMethod notes: 115 reviews fell in the Jan 1 – Jun 30, 2016 window after defensively parsing the three mixed date formats present in `review.date` (all 2000 rows parsed cleanly); `businessref_<n>` was normalized to `businessid_<n>` to join against the MongoDB `business` collection, and the category list was extracted from the free-text `description` field."
+  },
+  {
+    "dataset": "yelp",
+    "query": "6",
+    "run": "1",
+    "answer": "**Coffee House Too Cafe** received the highest average rating (4.375 across 16 reviews) between January 1 and June 30, 2016, and it belongs to the **Restaurants / Breakfast & Brunch / American (New) / Cafes** categories.\n\n| Business | Reviews (H1 2016) | Avg rating | Categories |\n|---|---|---|---|\n| Coffee House Too Cafe (`businessid_9`) | 16 | 4.375 | Restaurants, Breakfast & Brunch, American (New), Cafes |\n| Orangetheory Fitness Carrollwood | 7 | 4.000 | — |\n| Uber | 5 | 3.600 | — |\n\nOnly three businesses met the ≥5-review threshold in that window. All 2,000 review dates parsed cleanly across the three mixed formats present in the data, and the `businessref_9` → `businessid_9` link was resolved by matching numeric suffixes. Categories come from the free-text `description` field (\"...offers a delightful menu featuring Restaurants, Breakfast & Brunch, American (New), Cafes...\"), since there is no separate categories column."
+  },
+  {
+    "dataset": "yelp",
+    "query": "6",
+    "run": "2",
+    "answer": "I'll work through this step by step — loading reviews from DuckDB, parsing the mixed date formats, then joining to the MongoDB business metadata.**Coffee House Too Cafe** — categories: Restaurants, Breakfast & Brunch, American (New), Cafes.\n\nDetails:\n- Highest average rating among businesses with ≥5 reviews dated Jan 1 – Jun 30, 2016 (115 reviews fell in the window; only 3 businesses met the ≥5-review threshold).\n- `business_ref` = `businessref_2` → mongo `businessid_2`, \"Coffee House Too Cafe\", located at 501 Fairmount Ave, Philadelphia, PA.\n- Its category list was parsed from the free-text `description` field, since the business collection has no separate categories column."
+  },
+  {
+    "dataset": "yelp",
+    "query": "6",
+    "run": "3",
+    "answer": "I'll start by loading both databases and inspecting the review date formats.**Coffee House Too Cafe** (`businessid_9`) received the highest average rating between January 1 and June 30, 2016 — **4.375** across 16 reviews — and its categories are **Restaurants, Breakfast & Brunch, American (New), Cafes**.\n\nRunner-ups among businesses with ≥5 reviews in that window:\n\n| Business | Reviews | Avg rating |\n|---|---|---|\n| Coffee House Too Cafe | 16 | 4.375 |\n| Orangetheory Fitness Carrollwood | 7 | 4.000 |\n| Uber | 5 | 3.600 |\n\nNotes: review dates were parsed defensively across the three formats present (`YYYY-MM-DD HH:MM:SS`, `DD Mon YYYY, HH:MM`, `Month DD, YYYY at HH:MM AM/PM`) — all 2,000 rows parsed; 115 reviews fall in the window. `businessref_<n>` was joined to mongo `businessid_<n>` on the numeric suffix, and the category list was extracted from the business `description` text since there is no separate categories field."
+  },
+  {
+    "dataset": "yelp",
+    "query": "6",
+    "run": "4",
+    "answer": "**Coffee House Too Cafe** received the highest average rating (4.375) between January 1 and June 30, 2016, and it belongs to the categories **Restaurants, Breakfast & Brunch, American (New), Cafes**.\n\nDetails:\n\n| Business | Reviews (H1 2016) | Avg rating | Categories |\n|---|---|---|---|\n| Coffee House Too Cafe | 16 | 4.375 | Restaurants, Breakfast & Brunch, American (New), Cafes |\n| Orangetheory Fitness Carrollwood | 7 | 4.000 | Fitness & Instruction, Gyms, Boot Camps, Trainers, Active Life, Interval Training Gyms |\n| Uber | 5 | 3.600 | Hotels & Travel, Taxis, Transportation, Local Services, Automotive |\n\nMethod: 115 reviews fell in the window after defensively parsing the mixed `date` formats; only 3 businesses met the ≥5-review threshold. Business names/categories came from the MongoDB `business.description` field, joined by normalizing the `businessref_<n>` ↔ `businessid_<n>` key mismatch on the numeric suffix."
+  },
+  {
+    "dataset": "yelp",
+    "query": "7",
+    "run": "0",
+    "answer": "I'll load both databases and work through this step by step.**Restaurants (58), Food (38), American (New) (24), Shopping (20), and Breakfast & Brunch (19)** are the top 5 categories by total reviews from users who registered in 2016.\n\nDetails:\n- 168 users registered in 2016; they wrote 150 reviews dated 2016 or later, all matching businesses in the Mongo `business` collection (`businessref_<n>` ↔ `businessid_<n>` numeric-suffix join).\n- Categories were parsed from the free-text `business.description` field (no separate category column); a review counts once toward each category of its business.\n- Next ranks: Automotive and Local Services (17 each), American (Traditional) (16), then Fast Food and Home Services (14 each)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "7",
+    "run": "1",
+    "answer": "I'll work through this step by step — loading both databases, then parsing categories out of the business descriptions.**Restaurants (58), Food (38), American (New) (24), Shopping (20), and Breakfast & Brunch (19)** are the top 5 categories by total reviews from users who registered in 2016.\n\nMethod: 168 users in `user` have `yelping_since` in 2016; their reviews dated 2016 or later total 150 reviews (all `business_ref` values matched a mongo `business_id` after normalizing `businessref_<n>` → `businessid_<n>`). Categories were parsed out of the free-text `business.description` field (no categories column exists), and each review was counted once per category of its business.\n\nNextranks for context: Automotive and Local Services (17 each), American (Traditional) (16)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "7",
+    "run": "2",
+    "answer": "I'll work through this step by step — first loading both databases and inspecting the actual data.**Restaurants (58), Food (38), American (New) (24), Shopping (20), and Breakfast & Brunch (19)** are the top 5 categories by total reviews from users who registered in 2016.\n\n| Rank | Category | Reviews |\n|---|---|---|\n| 1 | Restaurants | 58 |\n| 2 | Food | 38 |\n| 3 | American (New) | 24 |\n| 4 | Shopping | 20 |\n| 5 | Breakfast & Brunch | 19 |\n\nMethod: 168 users have `yelping_since` in 2016 (parsed across all three date formats); their reviews dated 2016 or later total 150. Each review's `business_ref` numeric suffix was normalized to the Mongo `businessid_<n>` key (all 150 matched), and categories were extracted from the free-text `business.description` field using a vocabulary-based longest-match scan that also recovers lowercase/edge-case mentions (e.g. \"sports bars\", \"Car Wash\"). Reviews count once per category, so a review of a restaurant tagged both `Restaurants` and `Food` contributes to both. Next in line: Automotive and Local Services (17 each), so the 5th place gap over 6th is 2 reviews."
+  },
+  {
+    "dataset": "yelp",
+    "query": "7",
+    "run": "3",
+    "answer": "I'll work through this step by step — loading both databases, then parsing categories out of the business descriptions."
+  },
+  {
+    "dataset": "yelp",
+    "query": "7",
+    "run": "4",
+    "answer": "I'll work through this step by step — first connecting to both databases.The category parser is dropping `(New)`/`(Traditional)` qualifiers and lowercase category mentions — rebuilding it with a two-pass vocabulary approach.**Restaurants, Food, American (New), Shopping, and Breakfast & Brunch** are the top 5 categories.\n\n| Rank | Category | Total reviews |\n|---|---|---|\n| 1 | Restaurants | 58 |\n| 2 | Food | 38 |\n| 3 | American (New) | 24 |\n| 4 | Shopping | 20 |\n| 5 | Breakfast & Brunch | 19 |\n\nHow this was computed: 168 users in `user` have `yelping_since` in 2016 (parsed across the three mixed date formats present). Those users wrote 150 reviews dated 2016-01-01 or later, all of which matched a business after normalizing the `businessref_<n>` ↔ `businessid_<n>` key mismatch. Categories were parsed out of the free-text `business.description` field (there is no categories column), including the lowercase prose mentions (e.g. \"perfect for nightlife, bars, restaurants\") and the quoted `'Restaurants, Chinese'` variant. A review counts once per distinct category on the business it reviews.\n\nNote: if the two `American` variants are treated as one combined \"American\" category it would rank 3rd with 27 reviews, still leaving the top-5 set the same except for that merge; `Automotive` and `Local Services` sit just behind at 17 each."
+  }
+]


### PR DESCRIPTION
## Camber — Leaderboard Submission

**Agent name:** Camber
**Team:** Camber https://www.cambercloud.com/
**Backbone LLM:** Claude Opus 5 via Amazon Bedrock (`bedrock:claude-opus-5`), reasoning effort `high`, single model, no fallback
**Hints:** Yes 
**Trials:** 5 per query, all 54 queries, all 12 datasets (270 records)
**Pass@1 (mean over datasets of each dataset's average per-query pass rate):** **0.8790**

### Architecture

Each dataset is served by its own Camber Cloud notebook agent (`@camber-dev.<dataset>`), invoked once per trial as an independent conversation (`camber chat --agent ... --message <query> --model bedrock:claude-opus-5 --effort high`, no `--conversation-id`, so every run is a clean context). The agent drives a Jupyter kernel via `generate_code`/`append_code_cell` tool calls, reading only that dataset's sanctioned stores, and returns its final answer as the chat result.

### Results

| Dataset | Pass@1 |
| --- | --- |
| bookreview | 1.0000 |
| crmarenapro | 1.0000 |
| music_brainz_20k | 1.0000 |
| stockindex | 1.0000 |
| stockmarket | 1.0000 |
| PATENTS | 1.0000 |
| PANCANCER_ATLAS | 0.9333 |
| googlelocal | 0.9500 |
| yelp | 0.9143 |
| GITHUB_REPOS | 0.7500 |
| agnews | 0.5000 |
| DEPS_DEV_V1 | 0.5000 |

**Pass@1: 0.8790**

### Integrity

- Scored with the unmodified per-query `validate.py` validators from this repo, 270/270 trials, no missing runs.
- Mechanical leakage sweep over every trial's full execution trace (`tool_call_parts`: all `generate_code`/`append_code_cell` bodies and outputs) for:
  - Web-fetch patterns (`requests`, `urllib`/`urlopen`, `wget`/`curl`, `load_dataset`, `hf_hub`/`snapshot_download`, `raw.githubusercontent`, `gdown`, `kaggle`, `git clone`) — **zero hits**.
  - Off-limits local files (`ground_truth.csv`/`.txt`, `validate.py`, other datasets' directories, other submissions'/benchmark's result files) — **zero hits**.
  - Cross-dataset store access (each dataset's agent only ever touches its own `data-agent-bench/<dataset>/` path) — **zero mismatches**.
- Answers in `submission.json` verified to match the corresponding `answer` field in `traces.jsonl` for all 270 records.

### Files

- Submission JSON: `submissions/camber_opus5_n5.json`
- Execution traces (full tool-call trajectories, one record per trial): [traces.jsonl.zip](https://github.com/user-attachments/files/31515915/traces.jsonl.zip)


