### PR TITLE
Add Phoenix-CLI to leaderboard (isolated rerun; hints, no tuned prompt)

### DIFF
--- a/leaderboard_submissions/phoenix_cli.json
+++ b/leaderboard_submissions/phoenix_cli.json
@@ -1,0 +1,1622 @@
+[
+ {
+  "dataset": "DEPS_DEV_V1",
+  "query": "1",
+  "run": "0",
+  "answer": "@dmrvos/infrajs>0.0.5>typescript (2.6.2, 94931 stars); @dmrvos/infrajs>0.0.6>typescript (2.6.2, 94931 stars); @docly/web (0.2.3, 89398 stars); @dylanvann/svelte (3.25.4, 73499 stars); @dumc11/tailwindcss (0.4.0, 73464 stars)"
+ },
+ {
+  "dataset": "DEPS_DEV_V1",
+  "query": "1",
+  "run": "1",
+  "answer": "@dmrvos/infrajs>0.0.5>typescript (2.6.2, 94,931 stars); @dmrvos/infrajs>0.0.6>typescript (2.6.2, 94,931 stars); @docly/web (0.2.3, 89,398 stars); @dylanvann/svelte (3.25.4, 73,499 stars); @dumc11/tailwindcss (0.4.0, 73,464 stars)"
+ },
+ {
+  "dataset": "DEPS_DEV_V1",
+  "query": "1",
+  "run": "2",
+  "answer": "@dylanvann/svelte 3.25.4 (73,499 stars); @dumc11/tailwindcss 0.4.0 (73,464 stars); @dreampie/semantic-ui 2.2.11 (51,069 stars); @dongls/pdfjs-dist 3.2.72 (44,231 stars); @dman777/shadow-dom-quill-temp 1.0.0 (42,407 stars)"
+ },
+ {
+  "dataset": "DEPS_DEV_V1",
+  "query": "1",
+  "run": "3",
+  "answer": "@dylanvann/svelte 3.25.4 (73,499 stars); @dumc11/tailwindcss 0.4.0 (73,464 stars); @dreampie/semantic-ui 2.2.11 (51,069 stars); @dongls/pdfjs-dist 3.2.72 (44,231 stars); @dman777/shadow-dom-quill-temp 1.0.0 (42,407 stars)"
+ },
+ {
+  "dataset": "DEPS_DEV_V1",
+  "query": "1",
+  "run": "4",
+  "answer": "@dmrvos/infrajs>0.0.5>typescript v2.6.2 (microsoft/typescript, 94,931 stars); @dmrvos/infrajs>0.0.6>typescript v2.6.2 (microsoft/typescript, 94,931 stars); @dylanvann/svelte v3.25.4 (sveltejs/svelte, 73,499 stars); @dumc11/tailwindcss v0.4.0 (tailwindcss/tailwindcss, 73,464 stars); @dollarshaveclub/cli>1.0.0>lodash v4.17.4 (lodash/lodash, 57,779 stars \u2014 tied with 94 other lodash-sourced packages)"
+ },
+ {
+  "dataset": "DEPS_DEV_V1",
+  "query": "2",
+  "run": "0",
+  "answer": "mui-org/material-ui (30,522 forks), moment/moment (7,201 forks), semantic-org/semantic-ui (4,955 forks), react-native-elements/react-native-elements (4,623 forks), sveltejs/svelte (4,091 forks)"
+ },
+ {
+  "dataset": "DEPS_DEV_V1",
+  "query": "2",
+  "run": "1",
+  "answer": "mui-org/material-ui (30,522 forks), moment/moment (7,201 forks), semantic-org/semantic-ui (4,955 forks), react-native-elements/react-native-elements (4,623 forks), sveltejs/svelte (4,091 forks)"
+ },
+ {
+  "dataset": "DEPS_DEV_V1",
+  "query": "2",
+  "run": "2",
+  "answer": "mui-org/material-ui (30,522 forks), moment/moment (7,201 forks), semantic-org/semantic-ui (4,955 forks), react-native-elements/react-native-elements (4,623 forks), sveltejs/svelte (4,091 forks)"
+ },
+ {
+  "dataset": "DEPS_DEV_V1",
+  "query": "2",
+  "run": "3",
+  "answer": "mui-org/material-ui (30,522 forks), moment/moment (7,201 forks), semantic-org/semantic-ui (4,955 forks), react-native-elements/react-native-elements (4,623 forks), sveltejs/svelte (4,091 forks)"
+ },
+ {
+  "dataset": "DEPS_DEV_V1",
+  "query": "2",
+  "run": "4",
+  "answer": "mui-org/material-ui (30,522 forks), moment/moment (7,201 forks), semantic-org/semantic-ui (4,955 forks), react-native-elements/react-native-elements (4,623 forks), sveltejs/svelte (4,091 forks)"
+ },
+ {
+  "dataset": "GITHUB_REPOS",
+  "query": "1",
+  "run": "0",
+  "answer": "1/3 \u2248 0.3333 (33.33%) \u2014 1 of 3 README.md files in non-Python repositories contains copyright information"
+ },
+ {
+  "dataset": "GITHUB_REPOS",
+  "query": "1",
+  "run": "1",
+  "answer": "About 14.85% (15 of 101 non-Python repositories' README.md files contain copyright information)"
+ },
+ {
+  "dataset": "GITHUB_REPOS",
+  "query": "1",
+  "run": "2",
+  "answer": "\u224817.8% (18 of 101 non-Python repositories' README.md files contain copyright information)"
+ },
+ {
+  "dataset": "GITHUB_REPOS",
+  "query": "1",
+  "run": "3",
+  "answer": "14.85% (15 of 101 README.md files from non-Python repositories)"
+ },
+ {
+  "dataset": "GITHUB_REPOS",
+  "query": "1",
+  "run": "4",
+  "answer": "\u224814.85% (15 of 101 non-Python repositories' README.md files contain copyright information)"
+ },
+ {
+  "dataset": "GITHUB_REPOS",
+  "query": "2",
+  "run": "0",
+  "answer": "uacaps/PageMenu"
+ },
+ {
+  "dataset": "GITHUB_REPOS",
+  "query": "2",
+  "run": "1",
+  "answer": "uacaps/PageMenu"
+ },
+ {
+  "dataset": "GITHUB_REPOS",
+  "query": "2",
+  "run": "2",
+  "answer": "uacaps/PageMenu"
+ },
+ {
+  "dataset": "GITHUB_REPOS",
+  "query": "2",
+  "run": "3",
+  "answer": "uacaps/PageMenu"
+ },
+ {
+  "dataset": "GITHUB_REPOS",
+  "query": "2",
+  "run": "4",
+  "answer": "SwiftAndroid/swift"
+ },
+ {
+  "dataset": "GITHUB_REPOS",
+  "query": "3",
+  "run": "0",
+  "answer": "1077"
+ },
+ {
+  "dataset": "GITHUB_REPOS",
+  "query": "3",
+  "run": "1",
+  "answer": "1077"
+ },
+ {
+  "dataset": "GITHUB_REPOS",
+  "query": "3",
+  "run": "2",
+  "answer": "1077"
+ },
+ {
+  "dataset": "GITHUB_REPOS",
+  "query": "3",
+  "run": "3",
+  "answer": "1077"
+ },
+ {
+  "dataset": "GITHUB_REPOS",
+  "query": "3",
+  "run": "4",
+  "answer": "1077"
+ },
+ {
+  "dataset": "GITHUB_REPOS",
+  "query": "4",
+  "run": "0",
+  "answer": "apple/swift, twbs/bootstrap, Microsoft/vscode, facebook/react, tensorflow/tensorflow"
+ },
+ {
+  "dataset": "GITHUB_REPOS",
+  "query": "4",
+  "run": "1",
+  "answer": "apple/swift, twbs/bootstrap, Microsoft/vscode, facebook/react, tensorflow/tensorflow"
+ },
+ {
+  "dataset": "GITHUB_REPOS",
+  "query": "4",
+  "run": "2",
+  "answer": "apple/swift, twbs/bootstrap, Microsoft/vscode, facebook/react, tensorflow/tensorflow"
+ },
+ {
+  "dataset": "GITHUB_REPOS",
+  "query": "4",
+  "run": "3",
+  "answer": "apple/swift, twbs/bootstrap, Microsoft/vscode, facebook/react, tensorflow/tensorflow"
+ },
+ {
+  "dataset": "GITHUB_REPOS",
+  "query": "4",
+  "run": "4",
+  "answer": "apple/swift, twbs/bootstrap, Microsoft/vscode, facebook/react, tensorflow/tensorflow"
+ },
+ {
+  "dataset": "PANCANCER_ATLAS",
+  "query": "1",
+  "run": "0",
+  "answer": "Astrocytoma: 2.5713, Oligoastrocytoma: 2.7136, Oligodendroglioma: 2.6825"
+ },
+ {
+  "dataset": "PANCANCER_ATLAS",
+  "query": "1",
+  "run": "1",
+  "answer": "Astrocytoma: 2.5713, Oligoastrocytoma: 2.7136, Oligodendroglioma: 2.6825"
+ },
+ {
+  "dataset": "PANCANCER_ATLAS",
+  "query": "1",
+  "run": "2",
+  "answer": "Astrocytoma: 2.5713, Oligodendroglioma: 2.6825, Oligoastrocytoma: 2.7136"
+ },
+ {
+  "dataset": "PANCANCER_ATLAS",
+  "query": "1",
+  "run": "3",
+  "answer": "Astrocytoma: 2.5713, Oligoastrocytoma: 2.7136, Oligodendroglioma: 2.6825"
+ },
+ {
+  "dataset": "PANCANCER_ATLAS",
+  "query": "1",
+  "run": "4",
+  "answer": "Astrocytoma: 2.5713, Oligoastrocytoma: 2.7136, Oligodendroglioma: 2.6825"
+ },
+ {
+  "dataset": "PANCANCER_ATLAS",
+  "query": "2",
+  "run": "0",
+  "answer": "Infiltrating Lobular Carcinoma (50.56%), Mixed Histology (please specify) (16.67%), Other  specify (8.33%)"
+ },
+ {
+  "dataset": "PANCANCER_ATLAS",
+  "query": "2",
+  "run": "1",
+  "answer": "Infiltrating Lobular Carcinoma (50.56%), Mixed Histology (please specify) (16.67%), Other, specify (8.33%)"
+ },
+ {
+  "dataset": "PANCANCER_ATLAS",
+  "query": "2",
+  "run": "2",
+  "answer": "Infiltrating Lobular Carcinoma (50.56%), Mixed Histology (please specify) (16.67%), Other, specify (8.33%)"
+ },
+ {
+  "dataset": "PANCANCER_ATLAS",
+  "query": "2",
+  "run": "3",
+  "answer": "Infiltrating Lobular Carcinoma (50.56%), Mixed Histology (please specify) (16.67%), Other specify (8.33%)"
+ },
+ {
+  "dataset": "PANCANCER_ATLAS",
+  "query": "2",
+  "run": "4",
+  "answer": "Infiltrating Lobular Carcinoma (50.56%), Mixed Histology (please specify) (16.67%), Other, specify (8.33%)"
+ },
+ {
+  "dataset": "PANCANCER_ATLAS",
+  "query": "3",
+  "run": "0",
+  "answer": "305.12"
+ },
+ {
+  "dataset": "PANCANCER_ATLAS",
+  "query": "3",
+  "run": "1",
+  "answer": "305.12"
+ },
+ {
+  "dataset": "PANCANCER_ATLAS",
+  "query": "3",
+  "run": "2",
+  "answer": "305.12 (chi-square statistic, df = 4)"
+ },
+ {
+  "dataset": "PANCANCER_ATLAS",
+  "query": "3",
+  "run": "3",
+  "answer": "305.12"
+ },
+ {
+  "dataset": "PANCANCER_ATLAS",
+  "query": "3",
+  "run": "4",
+  "answer": "305.12"
+ },
+ {
+  "dataset": "PATENTS",
+  "query": "1",
+  "run": "0",
+  "answer": "A22B, A23J, A23P, A24D, A24F, A41G, A47F, A61G, A61H, A61P, A62D, A63H, B04B, B07B, B08B, B09C, B21J, B22F, B24B, B25B, B25D, B27C, B27M, B60D, B60L, B60P, B61H, B63C, B63G, B65G, B66F, C01D, C01G, C21B, C21C, C22C, D21B, E01H, E02B, E02D, E03B, E04B, E04G, E21D, E21F, F02K, F04F, F16M, F25J, F26B, G01H, G01L, G01S, G05D, G06N, G06Q, G06T, G06V, G08G, G09F, G10L, G16B, G16C, G16H, G21F, H01M, H02B, H02G, H02J, H03H, H04K, H05F"
+ },
+ {
+  "dataset": "PATENTS",
+  "query": "1",
+  "run": "1",
+  "answer": "A22B, A23J, A23P, A24D, A24F, A41G, A47F, A61G, A61H, A61P, A62D, A63H, B04B, B07B, B08B, B09C, B21J, B22F, B24B, B25B, B25D, B27C, B27M, B60D, B60L, B60P, B61H, B63C, B63G, B65G, B66F, C01D, C01G, C21B, C21C, C22C, D21B, E01H, E02B, E02D, E03B, E04B, E04G, E21D, E21F, F02K, F04F, F16M, F25J, F26B, G01H, G01L, G01S, G05D, G06N, G06Q, G06T, G06V, G08G, G09F, G10L, G16B, G16C, G16H, G21F, H01M, H02B, H02G, H02J, H03H, H04K, H05F"
+ },
+ {
+  "dataset": "PATENTS",
+  "query": "1",
+  "run": "2",
+  "answer": "A22B, A23J, A23P, A24D, A24F, A41G, A47F, A61G, A61H, A61P, A62D, A63H, B04B, B07B, B08B, B09C, B21J, B22F, B24B, B25B, B25D, B27C, B27M, B60D, B60L, B60P, B61H, B63C, B63G, B65G, B66F, C01D, C01G, C21B, C21C, C22C, D21B, E01H, E02B, E02D, E03B, E04B, E04G, E21D, E21F, F02K, F04F, F16M, F25J, F26B, G01H, G01L, G01S, G05D, G06N, G06Q, G06T, G06V, G08G, G09F, G10L, G16B, G16C, G16H, G21F, H01M, H02B, H02G, H02J, H03H, H04K, H05F"
+ },
+ {
+  "dataset": "PATENTS",
+  "query": "1",
+  "run": "3",
+  "answer": "A22B, A23J, A23P, A24D, A24F, A41G, A47F, A61G, A61H, A61P, A62D, A63H, B04B, B07B, B08B, B09C, B21J, B22F, B24B, B25B, B25D, B27C, B27M, B60D, B60L, B60P, B61H, B63C, B63G, B65G, B66F, C01D, C01G, C21B, C21C, C22C, D21B, E01H, E02B, E02D, E03B, E04B, E04G, E21D, E21F, F02K, F04F, F16M, F25J, F26B, G01H, G01L, G01S, G05D, G06N, G06Q, G06T, G06V, G08G, G09F, G10L, G16B, G16C, G16H, G21F, H01M, H02B, H02G, H02J, H03H, H04K, H05F"
+ },
+ {
+  "dataset": "PATENTS",
+  "query": "1",
+  "run": "4",
+  "answer": "A22B, A23J, A23P, A24D, A24F, A41G, A47F, A61G, A61H, A61P, A62D, A63H, B04B, B07B, B08B, B09C, B21J, B22F, B24B, B25B, B25D, B27C, B27M, B60D, B60L, B60P, B61H, B63C, B63G, B65G, B66F, C01D, C01G, C21B, C21C, C22C, D21B, E01H, E02B, E02D, E03B, E04B, E04G, E21D, E21F, F02K, F04F, F16M, F25J, F26B, G01H, G01L, G01S, G05D, G06N, G06Q, G06T, G06V, G08G, G09F, G10L, G16B, G16C, G16H, G21F, H01M, H02B, H02G, H02J, H03H, H04K, H05F"
+ },
+ {
+  "dataset": "PATENTS",
+  "query": "2",
+  "run": "0",
+  "answer": "A61 \u2014 MEDICAL OR VETERINARY SCIENCE; HYGIENE \u2014 best year 2016; H04 \u2014 ELECTRIC COMMUNICATION TECHNIQUE \u2014 best year 2015 (both with the highest EMA of 2.0)"
+ },
+ {
+  "dataset": "PATENTS",
+  "query": "2",
+  "run": "1",
+  "answer": "A61 \u2014 MEDICAL OR VETERINARY SCIENCE; HYGIENE \u2014 best year 2016 (EMA 2.0); H04 \u2014 ELECTRIC COMMUNICATION TECHNIQUE \u2014 best year 2015 (EMA 2.0)"
+ },
+ {
+  "dataset": "PATENTS",
+  "query": "2",
+  "run": "2",
+  "answer": "A47 \u2014 \"FURNITURE; DOMESTIC ARTICLES OR APPLIANCES; COFFEE MILLS; SPICE MILLS; SUCTION CLEANERS IN GENERAL\" \u2014 best year 2016 (EMA 2.0); G01 \u2014 \"MEASURING; TESTING\" \u2014 best year 2014 (EMA 2.0); G06 \u2014 \"COMPUTING; CALCULATING OR COUNTING\" \u2014 best year 2016 (EMA 2.0)"
+ },
+ {
+  "dataset": "PATENTS",
+  "query": "2",
+  "run": "3",
+  "answer": "A61 \u2014 MEDICAL OR VETERINARY SCIENCE; HYGIENE \u2014 best year 2016 (EMA 2.0); H04 \u2014 ELECTRIC COMMUNICATION TECHNIQUE \u2014 best year 2015 (EMA 2.0)"
+ },
+ {
+  "dataset": "PATENTS",
+  "query": "2",
+  "run": "4",
+  "answer": "A61 \u2014 MEDICAL OR VETERINARY SCIENCE; HYGIENE \u2014 best year 2016 (EMA 2.0); H04 \u2014 ELECTRIC COMMUNICATION TECHNIQUE \u2014 best year 2015 (EMA 2.0)"
+ },
+ {
+  "dataset": "PATENTS",
+  "query": "3",
+  "run": "0",
+  "answer": "BLOOM ENERGY CORP \u2014 H01M: PROCESSES OR MEANS, e.g. BATTERIES, FOR THE DIRECT CONVERSION OF CHEMICAL ENERGY INTO ELECTRICAL ENERGY; CRYSTAL IS INC \u2014 C30B: SINGLE-CRYSTAL GROWTH; UNIDIRECTIONAL SOLIDIFICATION OF EUTECTIC MATERIAL OR UNIDIRECTIONAL DEMIXING OF EUTECTOID MATERIAL; REFINING BY ZONE-MELTING OF MATERIAL; PRODUCTION OF A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; SINGLE CRYSTALS OR HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; AFTER-TREATMENT OF SINGLE CRYSTALS OR A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; APPARATUS THEREFOR; SCHOWALTER LEO J \u2014 H01L: SEMICONDUCTOR DEVICES NOT COVERED BY CLASS H10"
+ },
+ {
+  "dataset": "PATENTS",
+  "query": "3",
+  "run": "1",
+  "answer": "BLOOM ENERGY CORP \u2014 H01M: \"PROCESSES OR MEANS, e.g. BATTERIES, FOR THE DIRECT CONVERSION OF CHEMICAL ENERGY INTO ELECTRICAL ENERGY\"; CRYSTAL IS INC \u2014 C30B: \"SINGLE-CRYSTAL GROWTH; UNIDIRECTIONAL SOLIDIFICATION OF EUTECTIC MATERIAL OR UNIDIRECTIONAL DEMIXING OF EUTECTOID MATERIAL; REFINING BY ZONE-MELTING OF MATERIAL; PRODUCTION OF A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; SINGLE CRYSTALS OR HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; AFTER-TREATMENT OF SINGLE CRYSTALS OR A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; APPARATUS THEREFOR\"; SCHOWALTER LEO J \u2014 H01L: \"SEMICONDUCTOR DEVICES NOT COVERED BY CLASS H10\""
+ },
+ {
+  "dataset": "PATENTS",
+  "query": "3",
+  "run": "2",
+  "answer": "BLOOM ENERGY CORP \u2014 H01M: \"PROCESSES OR MEANS, e.g. BATTERIES, FOR THE DIRECT CONVERSION OF CHEMICAL ENERGY INTO ELECTRICAL ENERGY\"; CRYSTAL IS INC \u2014 C30B: \"SINGLE-CRYSTAL GROWTH; UNIDIRECTIONAL SOLIDIFICATION OF EUTECTIC MATERIAL OR UNIDIRECTIONAL DEMIXING OF EUTECTOID MATERIAL; REFINING BY ZONE-MELTING OF MATERIAL; PRODUCTION OF A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; SINGLE CRYSTALS OR HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; AFTER-TREATMENT OF SINGLE CRYSTALS OR A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; APPARATUS THEREFOR\"; SCHOWALTER LEO J \u2014 H01L: \"SEMICONDUCTOR DEVICES NOT COVERED BY CLASS H10\""
+ },
+ {
+  "dataset": "PATENTS",
+  "query": "3",
+  "run": "3",
+  "answer": "BLOOM ENERGY CORP \u2014 H01M: PROCESSES OR MEANS, e.g. BATTERIES, FOR THE DIRECT CONVERSION OF CHEMICAL ENERGY INTO ELECTRICAL ENERGY; CRYSTAL IS INC \u2014 C30B: SINGLE-CRYSTAL GROWTH; UNIDIRECTIONAL SOLIDIFICATION OF EUTECTIC MATERIAL OR UNIDIRECTIONAL DEMIXING OF EUTECTOID MATERIAL; REFINING BY ZONE-MELTING OF MATERIAL; PRODUCTION OF A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; SINGLE CRYSTALS OR HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; AFTER-TREATMENT OF SINGLE CRYSTALS OR A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; APPARATUS THEREFOR; SCHOWALTER LEO J \u2014 H01L: SEMICONDUCTOR DEVICES NOT COVERED BY CLASS H10"
+ },
+ {
+  "dataset": "PATENTS",
+  "query": "3",
+  "run": "4",
+  "answer": "BLOOM ENERGY CORP \u2014 H01M: PROCESSES OR MEANS, e.g. BATTERIES, FOR THE DIRECT CONVERSION OF CHEMICAL ENERGY INTO ELECTRICAL ENERGY; CRYSTAL IS INC \u2014 C30B: SINGLE-CRYSTAL GROWTH; UNIDIRECTIONAL SOLIDIFICATION OF EUTECTIC MATERIAL OR UNIDIRECTIONAL DEMIXING OF EUTECTOID MATERIAL; REFINING BY ZONE-MELTING OF MATERIAL; PRODUCTION OF A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; SINGLE CRYSTALS OR HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; AFTER-TREATMENT OF SINGLE CRYSTALS OR A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; APPARATUS THEREFOR; SCHOWALTER LEO J \u2014 H01L: SEMICONDUCTOR DEVICES NOT COVERED BY CLASS H10"
+ },
+ {
+  "dataset": "agnews",
+  "query": "1",
+  "run": "0",
+  "answer": "The Rundown"
+ },
+ {
+  "dataset": "agnews",
+  "query": "1",
+  "run": "1",
+  "answer": "The Rundown"
+ },
+ {
+  "dataset": "agnews",
+  "query": "1",
+  "run": "2",
+  "answer": "The Rundown"
+ },
+ {
+  "dataset": "agnews",
+  "query": "1",
+  "run": "3",
+  "answer": "The Rundown"
+ },
+ {
+  "dataset": "agnews",
+  "query": "1",
+  "run": "4",
+  "answer": "The Rundown"
+ },
+ {
+  "dataset": "agnews",
+  "query": "2",
+  "run": "0",
+  "answer": "26/111 \u2248 0.234 (23.4%)"
+ },
+ {
+  "dataset": "agnews",
+  "query": "2",
+  "run": "1",
+  "answer": "25/111 \u2248 0.225 (22.5%)"
+ },
+ {
+  "dataset": "agnews",
+  "query": "2",
+  "run": "2",
+  "answer": "24/111 \u2248 0.216 (21.6% \u2014 24 of Amy Jones's 111 articles are Science/Technology)"
+ },
+ {
+  "dataset": "agnews",
+  "query": "2",
+  "run": "3",
+  "answer": "25/111 \u2248 0.225 (22.5%)"
+ },
+ {
+  "dataset": "agnews",
+  "query": "2",
+  "run": "4",
+  "answer": "26/111 \u2248 0.234 (23.4%)"
+ },
+ {
+  "dataset": "agnews",
+  "query": "3",
+  "run": "0",
+  "answer": "\u2248 340 business articles per year (about 3,755 total across 2010\u20132020)"
+ },
+ {
+  "dataset": "agnews",
+  "query": "3",
+  "run": "1",
+  "answer": "\u2248337.5 business articles per year (3,713 total over 2010\u20132020)"
+ },
+ {
+  "dataset": "agnews",
+  "query": "3",
+  "run": "2",
+  "answer": "\u2248338 business articles per year (about 3,720 Business articles in Europe over 2010\u20132020)"
+ },
+ {
+  "dataset": "agnews",
+  "query": "3",
+  "run": "3",
+  "answer": "337"
+ },
+ {
+  "dataset": "agnews",
+  "query": "3",
+  "run": "4",
+  "answer": "approximately 321 business articles per year (3,528 Business articles in Europe over 2010\u20132020 \u00f7 11 years = 320.7)"
+ },
+ {
+  "dataset": "agnews",
+  "query": "4",
+  "run": "0",
+  "answer": "North America"
+ },
+ {
+  "dataset": "agnews",
+  "query": "4",
+  "run": "1",
+  "answer": "Pass A (ornith-9b) is running over all 6,696 articles from 2015. I'll report once it checkpoints."
+ },
+ {
+  "dataset": "agnews",
+  "query": "4",
+  "run": "2",
+  "answer": "North America"
+ },
+ {
+  "dataset": "agnews",
+  "query": "4",
+  "run": "3",
+  "answer": "North America"
+ },
+ {
+  "dataset": "agnews",
+  "query": "4",
+  "run": "4",
+  "answer": "Pass 1 is running in the background. Waiting for it to complete."
+ },
+ {
+  "dataset": "bookreview",
+  "query": "1",
+  "run": "0",
+  "answer": "2020s"
+ },
+ {
+  "dataset": "bookreview",
+  "query": "1",
+  "run": "1",
+  "answer": "2020s"
+ },
+ {
+  "dataset": "bookreview",
+  "query": "1",
+  "run": "2",
+  "answer": "2020s"
+ },
+ {
+  "dataset": "bookreview",
+  "query": "1",
+  "run": "3",
+  "answer": "2020s"
+ },
+ {
+  "dataset": "bookreview",
+  "query": "1",
+  "run": "4",
+  "answer": "2020s"
+ },
+ {
+  "dataset": "bookreview",
+  "query": "2",
+  "run": "0",
+  "answer": "Reunion: The Children of Lauderdale Park; The Prophet: With Original 1923 Illustrations by the Author; The Melancholy Strumpet Master; Child Of The King A Journey of Hope Book 1: Earthly Story With A Heavenly Message; Fire Cracker; Local Honey; Hollywood Confessions: Hollywood Headlines Book #3 (Hollywood Headlines Mysteries); Knowing When To Die: Uncollected Stories; Childe Harold of Dysna; Forged in Blood (Freehold); Exits, Desires, & Slow Fires; Kennebago Moments; The Sludge; Liza of Lambeth; Something That Feels Like Truth (Switchgrass Books)"
+ },
+ {
+  "dataset": "bookreview",
+  "query": "2",
+  "run": "1",
+  "answer": "Reunion: The Children of Lauderdale Park; The Prophet: With Original 1923 Illustrations by the Author; The Melancholy Strumpet Master; Child Of The King A Journey of Hope Book 1: Earthly Story With A Heavenly Message; Fire Cracker; Local Honey; Hollywood Confessions: Hollywood Headlines Book #3 (Hollywood Headlines Mysteries); Knowing When To Die: Uncollected Stories; Childe Harold of Dysna; Forged in Blood (Freehold); Exits, Desires, & Slow Fires; Kennebago Moments; The Sludge; Liza of Lambeth; Something That Feels Like Truth (Switchgrass Books)"
+ },
+ {
+  "dataset": "bookreview",
+  "query": "2",
+  "run": "2",
+  "answer": "15 books \u2014 Reunion: The Children of Lauderdale Park; The Prophet: With Original 1923 Illustrations by the Author; The Melancholy Strumpet Master; Child Of The King A Journey of Hope Book 1: Earthly Story With A Heavenly Message; Fire Cracker; Local Honey; Hollywood Confessions: Hollywood Headlines Book #3 (Hollywood Headlines Mysteries); Knowing When To Die: Uncollected Stories; Childe Harold of Dysna; Forged in Blood (Freehold); Exits, Desires, & Slow Fires; Kennebago Moments; The Sludge; Liza of Lambeth; Something That Feels Like Truth (Switchgrass Books)"
+ },
+ {
+  "dataset": "bookreview",
+  "query": "2",
+  "run": "3",
+  "answer": "15 books \u2014 Reunion: The Children of Lauderdale Park; The Prophet: With Original 1923 Illustrations by the Author; The Melancholy Strumpet Master; Child Of The King A Journey of Hope Book 1: Earthly Story With A Heavenly Message; Fire Cracker; Local Honey; Hollywood Confessions: Hollywood Headlines Book #3 (Hollywood Headlines Mysteries); Knowing When To Die: Uncollected Stories; Childe Harold of Dysna; Forged in Blood (Freehold); Exits, Desires, & Slow Fires; Kennebago Moments; The Sludge; Liza of Lambeth; Something That Feels Like Truth (Switchgrass Books)"
+ },
+ {
+  "dataset": "bookreview",
+  "query": "2",
+  "run": "4",
+  "answer": "Reunion: The Children of Lauderdale Park; The Prophet: With Original 1923 Illustrations by the Author; The Melancholy Strumpet Master; Child Of The King A Journey of Hope Book 1: Earthly Story With A Heavenly Message; Fire Cracker; Local Honey; Hollywood Confessions: Hollywood Headlines Book #3 (Hollywood Headlines Mysteries); Knowing When To Die: Uncollected Stories; Childe Harold of Dysna; Forged in Blood (Freehold); Exits, Desires, & Slow Fires; Kennebago Moments; The Sludge; Liza of Lambeth; Something That Feels Like Truth (Switchgrass Books)"
+ },
+ {
+  "dataset": "bookreview",
+  "query": "3",
+  "run": "0",
+  "answer": "Monstrous Stories #4: The Day the Mice Stood Still (5.0); The Old Man and the Pirate Princess (5.0); Egypt (Enchantment of the World) (5.0); Favorite Thorton W. Burgess Stories: 6 Books (5.0); Behind the Wheel (Choose Your Own Adventure #35)(Paperback/Revised) (5.0); Cheer Up, Ben Franklin! (Young Historians) (5.0); The Library Book (5.0); Benny Goes To The Moon: The great new book from Top Children's entertainer Gerry Ogilvie (1) (5.0); LunaLu the Llamacorn (5.0); Around the World Mazes (5.0); Pok\u00e9mon: Sun & Moon, Vol. 8 (8) (5.0); Trouble in the CTC!: The Terra Prime Adventures Book 2 (4.9); Clark the Shark: Tooth Trouble, No. 1 (4.75); Cleo Porter and the Body Electric (4.71)"
+ },
+ {
+  "dataset": "bookreview",
+  "query": "3",
+  "run": "1",
+  "answer": "Monstrous Stories #4: The Day the Mice Stood Still (5.0); The Old Man and the Pirate Princess (5.0); Egypt (Enchantment of the World) (5.0); Favorite Thorton W. Burgess Stories: 6 Books (5.0); Behind the Wheel (Choose Your Own Adventure #35) (5.0); Cheer Up, Ben Franklin! (Young Historians) (5.0); The Library Book (5.0); Benny Goes To The Moon (5.0); LunaLu the Llamacorn (5.0); Around the World Mazes (5.0); Pok\u00e9mon: Sun & Moon, Vol. 8 (5.0); Trouble in the CTC!: The Terra Prime Adventures Book 2 (4.9); Clark the Shark: Tooth Trouble, No. 1 (4.75); Cleo Porter and the Body Electric (4.71)"
+ },
+ {
+  "dataset": "bookreview",
+  "query": "3",
+  "run": "2",
+  "answer": "Monstrous Stories #4: The Day the Mice Stood Still (5.0); The Old Man and the Pirate Princess (5.0); Egypt (Enchantment of the World) (5.0); Favorite Thorton W. Burgess Stories: 6 Books (5.0); Behind the Wheel (Choose Your Own Adventure #35) (5.0); Cheer Up, Ben Franklin! (Young Historians) (5.0); The Library Book (5.0); Benny Goes To The Moon (5.0); LunaLu the Llamacorn (5.0); Around the World Mazes (5.0); Pok\u00e9mon: Sun & Moon, Vol. 8 (5.0); Trouble in the CTC!: The Terra Prime Adventures Book 2 (4.9); Clark the Shark: Tooth Trouble, No. 1 (4.75); Cleo Porter and the Body Electric (4.71)"
+ },
+ {
+  "dataset": "bookreview",
+  "query": "3",
+  "run": "3",
+  "answer": "Monstrous Stories #4: The Day the Mice Stood Still (5.0); The Old Man and the Pirate Princess (5.0); Egypt (Enchantment of the World) (5.0); Favorite Thorton W. Burgess Stories: 6 Books (5.0); Behind the Wheel (Choose Your Own Adventure #35)(Paperback/Revised) (5.0); Cheer Up, Ben Franklin! (Young Historians) (5.0); The Library Book (5.0); Benny Goes To The Moon: The great new book from Top Children's entertainer Gerry Ogilvie (1) (5.0); LunaLu the Llamacorn (5.0); Around the World Mazes (5.0); Pok\u00e9mon: Sun & Moon, Vol. 8 (8) (5.0); Trouble in the CTC!: The Terra Prime Adventures Book 2 (4.9); Clark the Shark: Tooth Trouble, No. 1 (4.75); Cleo Porter and the Body Electric (4.71)"
+ },
+ {
+  "dataset": "bookreview",
+  "query": "3",
+  "run": "4",
+  "answer": "Monstrous Stories #4: The Day the Mice Stood Still (5.0); The Old Man and the Pirate Princess (5.0); Egypt (Enchantment of the World) (5.0); Favorite Thorton W. Burgess Stories: 6 Books (5.0); Behind the Wheel (Choose Your Own Adventure #35)(Paperback/Revised) (5.0); Cheer Up, Ben Franklin! (Young Historians) (5.0); The Library Book (5.0); Benny Goes To The Moon: The great new book from Top Children's entertainer Gerry Ogilvie (1) (5.0); LunaLu the Llamacorn (5.0); Around the World Mazes (5.0); Pok\u00e9mon: Sun & Moon, Vol. 8 (8) (5.0); Trouble in the CTC!: The Terra Prime Adventures Book 2 (4.9); Clark the Shark: Tooth Trouble, No. 1 (4.75); Cleo Porter and the Body Electric (4.71)"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "1",
+  "run": "0",
+  "answer": "Authority, Timeline"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "1",
+  "run": "1",
+  "answer": "Authority, Timeline"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "1",
+  "run": "2",
+  "answer": "Authority, Timeline"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "1",
+  "run": "3",
+  "answer": "Budget, Authority, Timeline"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "1",
+  "run": "4",
+  "answer": "Budget, Authority"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "10",
+  "run": "0",
+  "answer": "005Wt000003NDqDIAW"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "10",
+  "run": "1",
+  "answer": "005Wt000003NDqDIAW"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "10",
+  "run": "2",
+  "answer": "005Wt000003NDqDIAW"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "10",
+  "run": "3",
+  "answer": "005Wt000003NDqDIAW"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "10",
+  "run": "4",
+  "answer": "005Wt000003NDqDIAW"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "11",
+  "run": "0",
+  "answer": "01tWt000006hV8LIAU"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "11",
+  "run": "1",
+  "answer": "01tWt000006hV8LIAU"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "11",
+  "run": "2",
+  "answer": "01tWt000006hV8LIAU"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "11",
+  "run": "3",
+  "answer": "01tWt000006hV8LIAU"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "11",
+  "run": "4",
+  "answer": "01tWt000006hV8LIAU"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "12",
+  "run": "0",
+  "answer": "005Wt000003NJgAIAW"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "12",
+  "run": "1",
+  "answer": "005Wt000003NJgAIAW"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "12",
+  "run": "2",
+  "answer": "005Wt000003NJgAIAW"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "12",
+  "run": "3",
+  "answer": "005Wt000003NJgAIAW"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "12",
+  "run": "4",
+  "answer": "005Wt000003NJgAIAW"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "13",
+  "run": "0",
+  "answer": "005Wt000003NIXCIA4"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "13",
+  "run": "1",
+  "answer": "005Wt000003NEa3IAG"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "13",
+  "run": "2",
+  "answer": "005Wt000003NIXCIA4"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "13",
+  "run": "3",
+  "answer": "005Wt000003NEa3IAG"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "13",
+  "run": "4",
+  "answer": "005Wt000003NEa3IAG"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "2",
+  "run": "0",
+  "answer": "ka0Wt000000Eq0MIAS"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "2",
+  "run": "1",
+  "answer": "ka0Wt000000Eq0MIAS"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "2",
+  "run": "2",
+  "answer": "ka0Wt000000Eq0MIAS"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "2",
+  "run": "3",
+  "answer": "ka0Wt000000Eq0MIAS"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "2",
+  "run": "4",
+  "answer": "ka0Wt000000Eq0MIAS"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "3",
+  "run": "0",
+  "answer": "Negotiation"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "3",
+  "run": "1",
+  "answer": "Negotiation"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "3",
+  "run": "2",
+  "answer": "Negotiation"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "3",
+  "run": "3",
+  "answer": "Negotiation"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "3",
+  "run": "4",
+  "answer": "Negotiation"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "4",
+  "run": "0",
+  "answer": "November"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "4",
+  "run": "1",
+  "answer": "November"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "4",
+  "run": "2",
+  "answer": "November"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "4",
+  "run": "3",
+  "answer": "November"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "4",
+  "run": "4",
+  "answer": "November"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "5",
+  "run": "0",
+  "answer": "a03Wt00000JqnHwIAJ"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "5",
+  "run": "1",
+  "answer": "a03Wt00000JqnHwIAJ"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "5",
+  "run": "2",
+  "answer": "a03Wt00000JqnHwIAJ"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "5",
+  "run": "3",
+  "answer": "a03Wt00000JqnHwIAJ"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "5",
+  "run": "4",
+  "answer": "a03Wt00000JqnHwIAJ"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "6",
+  "run": "0",
+  "answer": "ka0Wt000000EnwvIAC"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "6",
+  "run": "1",
+  "answer": "ka0Wt000000EnwvIAC"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "6",
+  "run": "2",
+  "answer": "ka0Wt000000EnwvIAC"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "6",
+  "run": "3",
+  "answer": "ka0Wt000000EnwvIAC"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "6",
+  "run": "4",
+  "answer": "ka0Wt000000EnwvIAC"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "7",
+  "run": "0",
+  "answer": "ka0Wt000000EpSUIA0"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "7",
+  "run": "1",
+  "answer": "ka0Wt000000EpSUIA0"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "7",
+  "run": "2",
+  "answer": "ka0Wt000000EoD3IAK"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "7",
+  "run": "3",
+  "answer": "ka0Wt000000EpSUIA0"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "7",
+  "run": "4",
+  "answer": "ka0Wt000000EoD3IAK"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "8",
+  "run": "0",
+  "answer": "005Wt000003NIliIAG"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "8",
+  "run": "1",
+  "answer": "005Wt000003NIliIAG"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "8",
+  "run": "2",
+  "answer": "005Wt000003NIliIAG"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "8",
+  "run": "3",
+  "answer": "005Wt000003NIliIAG"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "8",
+  "run": "4",
+  "answer": "005Wt000003NIliIAG"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "9",
+  "run": "0",
+  "answer": "MI"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "9",
+  "run": "1",
+  "answer": "MI"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "9",
+  "run": "2",
+  "answer": "MI"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "9",
+  "run": "3",
+  "answer": "MI"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "9",
+  "run": "4",
+  "answer": "MI"
+ },
+ {
+  "dataset": "googlelocal",
+  "query": "1",
+  "run": "0",
+  "answer": "Widows Peak Salon (4.86), City Textile (4.50), Nobel Textile Co (4.29), San Soo Dang (4.28), Nova Fabrics (3.33)"
+ },
+ {
+  "dataset": "googlelocal",
+  "query": "1",
+  "run": "1",
+  "answer": "Widows Peak Salon (4.86), City Textile (4.50), Nobel Textile Co (4.29), San Soo Dang (4.28), Nova Fabrics (3.33)"
+ },
+ {
+  "dataset": "googlelocal",
+  "query": "1",
+  "run": "2",
+  "answer": "Widows Peak Salon (4.86), City Textile (4.50), Nobel Textile Co (4.29), San Soo Dang (4.28), Nova Fabrics (3.33)"
+ },
+ {
+  "dataset": "googlelocal",
+  "query": "1",
+  "run": "3",
+  "answer": "1. Widows Peak Salon (4.86), 2. City Textile (4.50), 3. Nobel Textile Co (4.29), 4. San Soo Dang (4.28), 5. Nova Fabrics (3.33)"
+ },
+ {
+  "dataset": "googlelocal",
+  "query": "1",
+  "run": "4",
+  "answer": "1. Widows Peak Salon (4.86), 2. City Textile (4.50), 3. Nobel Textile Co (4.29), 4. San Soo Dang (4.28), 5. Nova Fabrics (3.33)"
+ },
+ {
+  "dataset": "googlelocal",
+  "query": "2",
+  "run": "0",
+  "answer": "Elite Massage \u2014 5.00; Angel-A Massage \u2014 4.33; Aurora Massage \u2014 4.18; J B Oriental Inc \u2014 4.17"
+ },
+ {
+  "dataset": "googlelocal",
+  "query": "2",
+  "run": "1",
+  "answer": "Elite Massage \u2014 5.00; Angel-A Massage \u2014 4.33; Aurora Massage \u2014 4.18; J B Oriental Inc \u2014 4.17"
+ },
+ {
+  "dataset": "googlelocal",
+  "query": "2",
+  "run": "2",
+  "answer": "Elite Massage \u2014 5.00; Angel-A Massage \u2014 4.33; Aurora Massage \u2014 4.18; J B Oriental Inc \u2014 4.17"
+ },
+ {
+  "dataset": "googlelocal",
+  "query": "2",
+  "run": "3",
+  "answer": "Elite Massage \u2014 5.00; Angel-A Massage \u2014 4.33; Aurora Massage \u2014 4.18; J B Oriental Inc \u2014 4.17"
+ },
+ {
+  "dataset": "googlelocal",
+  "query": "2",
+  "run": "4",
+  "answer": "Elite Massage \u2014 5.00; Angel-A Massage \u2014 4.33; Aurora Massage \u2014 4.18; J B Oriental Inc \u2014 4.17"
+ },
+ {
+  "dataset": "googlelocal",
+  "query": "3",
+  "run": "0",
+  "answer": "Taba Rug Gallery (Mon\u2013Fri 10AM\u20137PM, 5.0); Beauty Divine Artistry (Mon\u2013Fri 9AM\u20138PM, 5.0); Mariscos el poblano (Mon 9AM\u20133:30AM, Thu open 24 hours, Tue/Wed/Fri 8AM\u20133:30PM, 5.0); TACOS LA CABANA (Mon & Fri 5\u201311PM, Tue\u2013Thu closed, 5.0); White Barn Candle Co (Mon\u2013Fri 10AM\u20139PM, 5.0)"
+ },
+ {
+  "dataset": "googlelocal",
+  "query": "3",
+  "run": "1",
+  "answer": "Taba Rug Gallery (Mon\u2013Fri 10AM\u20137PM), avg rating 5.0; Beauty Divine Artistry (Mon\u2013Fri 9AM\u20138PM), avg rating 5.0; Mariscos el poblano (Thu open 24 hours, Mon 9AM\u20133:30AM, Tue/Wed/Fri 8AM\u20133:30PM), avg rating 5.0; White Barn Candle Co (Mon\u2013Fri 10AM\u20139PM), avg rating 5.0; TACOS LA CABANA (Mon and Fri 5\u201311PM), avg rating 5.0"
+ },
+ {
+  "dataset": "googlelocal",
+  "query": "3",
+  "run": "2",
+  "answer": "1) Taba Rug Gallery \u2014 Mon\u2013Sat 10AM\u20137PM, Sun 11AM\u20136PM \u2014 5.0; 2) Beauty Divine Artistry \u2014 Mon\u2013Fri 9AM\u20138PM, Sat 10AM\u20137PM, Sun 11AM\u20136PM \u2014 5.0; 3) Mariscos el poblano \u2014 Thu Open 24 hours, Mon 9AM\u20133:30AM, Tue/Wed/Fri\u2013Sun 8AM\u20133:30PM \u2014 5.0; 4) TACOS LA CABANA \u2014 Fri\u2013Mon 5\u201311PM, Tue\u2013Thu Closed \u2014 5.0; 5) White Barn Candle Co \u2014 Mon\u2013Sat 10AM\u20139PM, Sun 11AM\u20137PM \u2014 5.0"
+ },
+ {
+  "dataset": "googlelocal",
+  "query": "3",
+  "run": "3",
+  "answer": "1. Taba Rug Gallery \u2014 Mon\u2013Sat 10AM\u20137PM, Sun 11AM\u20136PM \u2014 5.00; 2. Beauty Divine Artistry \u2014 Mon\u2013Fri 9AM\u20138PM, Sat 10AM\u20137PM, Sun 11AM\u20136PM \u2014 5.00; 3. Mariscos el poblano \u2014 Mon 9AM\u20133:30AM, Tue/Wed 8AM\u20133:30PM, Thu Open 24 hours, Fri\u2013Sun 8AM\u20133:30PM \u2014 5.00; 4. White Barn Candle Co \u2014 Mon\u2013Sat 10AM\u20139PM, Sun 11AM\u20137PM \u2014 5.00; 5. TACOS LA CABANA \u2014 Mon 5\u201311PM, Tue\u2013Thu Closed, Fri\u2013Sun 5\u201311PM \u2014 5.00"
+ },
+ {
+  "dataset": "googlelocal",
+  "query": "3",
+  "run": "4",
+  "answer": "Taba Rug Gallery (Mon\u2013Sat 10AM\u20137PM, Sun 11AM\u20136PM; avg 5.0), Beauty Divine Artistry (Mon\u2013Fri 9AM\u20138PM, Sat 10AM\u20137PM, Sun 11AM\u20136PM; avg 5.0), Mariscos el poblano (Mon 9AM\u20133:30AM, Tue\u2013Wed 8AM\u20133:30PM, Thu Open 24 hours, Fri\u2013Sun 8AM\u20133:30PM; avg 5.0), TACOS LA CABANA (Mon 5\u201311PM, Tue\u2013Thu Closed, Fri\u2013Sun 5\u201311PM; avg 5.0), White Barn Candle Co (Mon\u2013Sat 10AM\u20139PM, Sun 11AM\u20137PM; avg 5.0)"
+ },
+ {
+  "dataset": "googlelocal",
+  "query": "4",
+  "run": "0",
+  "answer": "Encino Dermatology & Laser: Alex Khadavi MD (19), The Boochyard @ Local Roots (17), Aurora Massage (14)"
+ },
+ {
+  "dataset": "googlelocal",
+  "query": "4",
+  "run": "1",
+  "answer": "Encino Dermatology & Laser: Alex Khadavi MD \u2014 19; The Boochyard @ Local Roots \u2014 17; Aurora Massage \u2014 14"
+ },
+ {
+  "dataset": "googlelocal",
+  "query": "4",
+  "run": "2",
+  "answer": "Encino Dermatology & Laser: Alex Khadavi MD (19), The Boochyard @ Local Roots (17), Aurora Massage (14)"
+ },
+ {
+  "dataset": "googlelocal",
+  "query": "4",
+  "run": "3",
+  "answer": "Encino Dermatology & Laser: Alex Khadavi MD (19), The Boochyard @ Local Roots (17), Aurora Massage (14)"
+ },
+ {
+  "dataset": "googlelocal",
+  "query": "4",
+  "run": "4",
+  "answer": "Encino Dermatology & Laser: Alex Khadavi MD \u2014 19; The Boochyard @ Local Roots \u2014 17; Aurora Massage \u2014 14"
+ },
+ {
+  "dataset": "music_brainz_20k",
+  "query": "1",
+  "run": "0",
+  "answer": "$1059.46 USD"
+ },
+ {
+  "dataset": "music_brainz_20k",
+  "query": "1",
+  "run": "1",
+  "answer": "$1059.46"
+ },
+ {
+  "dataset": "music_brainz_20k",
+  "query": "1",
+  "run": "2",
+  "answer": "1059.46 USD"
+ },
+ {
+  "dataset": "music_brainz_20k",
+  "query": "1",
+  "run": "3",
+  "answer": "$1059.46"
+ },
+ {
+  "dataset": "music_brainz_20k",
+  "query": "1",
+  "run": "4",
+  "answer": "$1059.46 USD"
+ },
+ {
+  "dataset": "music_brainz_20k",
+  "query": "2",
+  "run": "0",
+  "answer": "Amazon Music ($1,108.99 USD)"
+ },
+ {
+  "dataset": "music_brainz_20k",
+  "query": "2",
+  "run": "1",
+  "answer": "Amazon Music (1108.99 USD)"
+ },
+ {
+  "dataset": "music_brainz_20k",
+  "query": "2",
+  "run": "2",
+  "answer": "Amazon Music ($1,108.99 USD)"
+ },
+ {
+  "dataset": "music_brainz_20k",
+  "query": "2",
+  "run": "3",
+  "answer": "Amazon Music (1108.99 USD)"
+ },
+ {
+  "dataset": "music_brainz_20k",
+  "query": "2",
+  "run": "4",
+  "answer": "Amazon Music (1108.99 USD)"
+ },
+ {
+  "dataset": "music_brainz_20k",
+  "query": "3",
+  "run": "0",
+  "answer": "\"Zo gaat het leven aan je voor\" by Syb van der Ploeg \u2014 $9,013.69 USD"
+ },
+ {
+  "dataset": "music_brainz_20k",
+  "query": "3",
+  "run": "1",
+  "answer": "Zo gaat het leven aan je voor \u2014 Syb van der Ploeg (total revenue $9,013.69 USD)"
+ },
+ {
+  "dataset": "music_brainz_20k",
+  "query": "3",
+  "run": "2",
+  "answer": "\"Zo gaat het leven aan je voor\" by Syb van der Ploeg (album: Hillich fjoer | Heilig vuur), with $9,013.69 USD in total revenue"
+ },
+ {
+  "dataset": "music_brainz_20k",
+  "query": "3",
+  "run": "3",
+  "answer": "\"Zo gaat het leven aan je voor\" by Syb van der Ploeg \u2014 $9,013.69 USD total revenue"
+ },
+ {
+  "dataset": "music_brainz_20k",
+  "query": "3",
+  "run": "4",
+  "answer": "\"Zo gaat het leven aan je voor\" by Syb van der Ploeg \u2014 9013.69 USD"
+ },
+ {
+  "dataset": "stockindex",
+  "query": "1",
+  "run": "0",
+  "answer": "399001.SZ (Shenzhen Component Index, Shenzhen Stock Exchange) \u2014 average intraday volatility \u2248 0.01834 (1.83%)"
+ },
+ {
+  "dataset": "stockindex",
+  "query": "1",
+  "run": "1",
+  "answer": "399001.SZ"
+ },
+ {
+  "dataset": "stockindex",
+  "query": "1",
+  "run": "2",
+  "answer": "399001.SZ (Shenzhen Stock Exchange) \u2014 average intraday volatility \u2248 0.0183 (1.83%)"
+ },
+ {
+  "dataset": "stockindex",
+  "query": "1",
+  "run": "3",
+  "answer": "Shenzhen Stock Exchange \u2014 the Shenzhen Component Index (399001.SZ), with an average intraday volatility of approximately 1.83% ((High \u2212 Low) / Open) since 2020"
+ },
+ {
+  "dataset": "stockindex",
+  "query": "1",
+  "run": "4",
+  "answer": "399001.SZ \u2014 the Shenzhen Component Index (Shenzhen Stock Exchange), with an average intraday volatility of about 1.83% ((High\u2212Low)/Open, 342 trading days since 2020-01-01)"
+ },
+ {
+  "dataset": "stockindex",
+  "query": "2",
+  "run": "0",
+  "answer": "IXIC (NASDAQ Composite) \u2014 131 up days vs 120 down days in 2018; it was the only North American index with more up days than down days (NYA: 125 up / 126 down; GSPTSE: 115 up / 135 down)"
+ },
+ {
+  "dataset": "stockindex",
+  "query": "2",
+  "run": "1",
+  "answer": "IXIC (NASDAQ Composite) \u2014 131 up days vs 120 down days in 2018"
+ },
+ {
+  "dataset": "stockindex",
+  "query": "2",
+  "run": "2",
+  "answer": "IXIC (NASDAQ Composite) \u2014 131 up days vs 120 down days in 2018 (the only North American index with more up than down days; NYA 125 up/126 down, GSPTSE 115 up/135 down)"
+ },
+ {
+  "dataset": "stockindex",
+  "query": "2",
+  "run": "3",
+  "answer": "NASDAQ (IXIC) \u2014 131 up days vs 120 down days in 2018"
+ },
+ {
+  "dataset": "stockindex",
+  "query": "2",
+  "run": "4",
+  "answer": "IXIC (NASDAQ Composite) \u2014 131 up days vs 120 down days in 2018; NYA (125 up / 126 down) and GSPTSE (115 up / 135 down) did not."
+ },
+ {
+  "dataset": "stockindex",
+  "query": "3",
+  "run": "0",
+  "answer": "IXIC (NASDAQ Composite) \u2014 United States, +382.7%; 399001.SZ (Shenzhen Component) \u2014 China, +137.5%; NSEI (Nifty 50) \u2014 India, +135.8%; GDAXI (DAX) \u2014 Germany, +134.7%; TWII (TAIEX) \u2014 Taiwan, +129.8%"
+ },
+ {
+  "dataset": "stockindex",
+  "query": "3",
+  "run": "1",
+  "answer": "IXIC (NASDAQ Composite, United States, +382.7%); NSEI (NIFTY 50, India, +135.8%); 399001.SZ (Shenzhen Component, China, +134.8%); GDAXI (DAX, Germany, +134.7%); TWII (TAIEX, Taiwan, +129.8%)"
+ },
+ {
+  "dataset": "stockindex",
+  "query": "3",
+  "run": "2",
+  "answer": "NASDAQ Composite (IXIC) \u2014 United States, +382.7%; Nifty 50 (NSEI) \u2014 India, +135.8%; Shenzhen Component (399001.SZ) \u2014 China, +134.8%; DAX (GDAXI) \u2014 Germany, +134.7%; TAIEX (TWII) \u2014 Taiwan, +129.8%"
+ },
+ {
+  "dataset": "stockindex",
+  "query": "3",
+  "run": "3",
+  "answer": "IXIC (NASDAQ, United States) +382.69%; NSEI (National Stock Exchange of India, India) +135.84%; 399001.SZ (Shenzhen Stock Exchange, China) +134.75%; GDAXI (Frankfurt Stock Exchange, Germany) +134.70%; TWII (Taiwan Stock Exchange, Taiwan) +129.82%"
+ },
+ {
+  "dataset": "stockindex",
+  "query": "3",
+  "run": "4",
+  "answer": "IXIC (NASDAQ Composite, United States, +382.7%); NSEI (NIFTY 50, India, +135.8%); 399001.SZ (Shenzhen Component, China, +134.8%); GDAXI (DAX, Germany, +134.7%); TWII (Taiwan Weighted Index, Taiwan, +129.8%)"
+ },
+ {
+  "dataset": "stockmarket",
+  "query": "1",
+  "run": "0",
+  "answer": "$18.44"
+ },
+ {
+  "dataset": "stockmarket",
+  "query": "1",
+  "run": "1",
+  "answer": "18.44 USD (18.440000534057617, on 2020-01-03)"
+ },
+ {
+  "dataset": "stockmarket",
+  "query": "1",
+  "run": "2",
+  "answer": "$18.44 (18.440000534057617, on 2020-01-03, ticker REAL)"
+ },
+ {
+  "dataset": "stockmarket",
+  "query": "1",
+  "run": "3",
+  "answer": "$18.44"
+ },
+ {
+  "dataset": "stockmarket",
+  "query": "1",
+  "run": "4",
+  "answer": "$18.44"
+ },
+ {
+  "dataset": "stockmarket",
+  "query": "2",
+  "run": "0",
+  "answer": "31 ETFs \u2014 UVXY, GUSH, COM, RTL, JDST, HYUP, SOXS, VPC, DUST, LBJ, PTIN, GFIN, ERX, LABD, VIXY, BZQ, JNUG, SDOW, BOIL, YANG, EDZ, FAZ, XES, TZA, SSG, MDY, TECS, LABU, XOP, FXP, JPN"
+ },
+ {
+  "dataset": "stockmarket",
+  "query": "2",
+  "run": "1",
+  "answer": "31 ETFs \u2014 BOIL, BZQ, COM, DUST, EDZ, ERX, FAZ, FXP, GFIN, GUSH, HYUP, JDST, JNUG, JPN, LABD, LABU, LBJ, MDY, PTIN, RTL, SDOW, SOXS, SSG, TECS, TZA, UVXY, VIXY, VPC, XES, XOP, YANG"
+ },
+ {
+  "dataset": "stockmarket",
+  "query": "2",
+  "run": "2",
+  "answer": "31 ETFs \u2014 BOIL, BZQ, COM, DUST, EDZ, ERX, FAZ, FXP, GFIN, GUSH, HYUP, JDST, JNUG, JPN, LABD, LABU, LBJ, MDY, PTIN, RTL, SDOW, SOXS, SSG, TECS, TZA, UVXY, VIXY, VPC, XES, XOP, YANG"
+ },
+ {
+  "dataset": "stockmarket",
+  "query": "2",
+  "run": "3",
+  "answer": "31 ETFs \u2014 BOIL, BZQ, COM, DUST, EDZ, ERX, FAZ, FXP, GFIN, GUSH, HYUP, JDST, JNUG, JPN, LABD, LABU, LBJ, MDY, PTIN, RTL, SDOW, SOXS, SSG, TECS, TZA, UVXY, VIXY, VPC, XES, XOP, YANG"
+ },
+ {
+  "dataset": "stockmarket",
+  "query": "2",
+  "run": "4",
+  "answer": "31 ETFs \u2014 UVXY, GUSH, COM, RTL, JDST, HYUP, SOXS, VPC, DUST, LBJ, PTIN, GFIN, ERX, LABD, VIXY, BZQ, JNUG, SDOW, BOIL, YANG, EDZ, FAZ, XES, TZA, SSG, MDY, TECS, LABU, XOP, FXP, JPN"
+ },
+ {
+  "dataset": "stockmarket",
+  "query": "3",
+  "run": "0",
+  "answer": "Frontier Communications Corporation (FTR) 254,397.63; Correvio Pharma Corp. (CORV) 145,247.83; CBAK Energy Technology, Inc. (CBAT) 86,223.32; Sypris Solutions, Inc. (SYPR) 36,836.36; Apex Global Brands Inc. (APEX) 23,781.42; DASAN Zhone Solutions, Inc. (DZSI) 15,578.66; BIO-key International, Inc. (BKYI) 10,988.14; Pacific Ethanol, Inc. (PEIX) 10,706.72; China Ceramics Co., Ltd. (CCCL) 4,366.80; Synthesis Energy Systems, Inc. (SES) 2,390.51; Sunesis Pharmaceuticals, Inc. (SNSS) 781.82; CounterPath Corporation (CPAH) 375.49; Ocean Power Technologies, Inc. (OPTT) 254.15; Ideanomics, Inc. (IDEX) 10.28; Future FinTech Group Inc. (FTFT) 9.85 \u2014 average daily shares traded in 2008"
+ },
+ {
+  "dataset": "stockmarket",
+  "query": "3",
+  "run": "1",
+  "answer": "Frontier Communications Corporation (FTR) 254,397.63; Correvio Pharma Corp. (CORV) 145,247.83; CBAK Energy Technology, Inc. (CBAT) 86,223.32; Sypris Solutions, Inc. (SYPR) 36,836.36; Apex Global Brands Inc. (APEX) 23,781.42; DASAN Zhone Solutions, Inc. (DZSI) 15,578.66; BIO-key International, Inc. (BKYI) 10,988.14; Pacific Ethanol, Inc. (PEIX) 10,706.72; China Ceramics Co., Ltd. (CCCL) 4,366.80; Synthesis Energy Systems, Inc. (SES) 2,390.51; Sunesis Pharmaceuticals, Inc. (SNSS) 781.82; CounterPath Corporation (CPAH) 375.49; Ocean Power Technologies, Inc. (OPTT) 254.15; Ideanomics, Inc. (IDEX) 10.28; Future FinTech Group Inc. (FTFT) 9.85"
+ },
+ {
+  "dataset": "stockmarket",
+  "query": "3",
+  "run": "2",
+  "answer": "Frontier Communications Corporation (FTR) 254397.63; Correvio Pharma Corp. (CORV) 145247.83; CBAK Energy Technology, Inc. (CBAT) 86223.32; Sypris Solutions, Inc. (SYPR) 36836.36; Apex Global Brands Inc. (APEX) 23781.42; DASAN Zhone Solutions, Inc. (DZSI) 15578.66; BIO-key International, Inc. (BKYI) 10988.14; Pacific Ethanol, Inc. (PEIX) 10706.72; China Ceramics Co., Ltd. (CCCL) 4366.80; Synthesis Energy Systems, Inc. (SES) 2390.51; Sunesis Pharmaceuticals, Inc. (SNSS) 781.82; CounterPath Corporation (CPAH) 375.49; Ocean Power Technologies, Inc. (OPTT) 254.15; Ideanomics, Inc. (IDEX) 10.28; Future FinTech Group Inc. (FTFT) 9.85"
+ },
+ {
+  "dataset": "stockmarket",
+  "query": "3",
+  "run": "3",
+  "answer": "Frontier Communications Corporation 254397.63; Correvio Pharma Corp. 145247.83; CBAK Energy Technology, Inc. 86223.32; Sypris Solutions, Inc. 36836.36; Apex Global Brands Inc. 23781.42; DASAN Zhone Solutions, Inc. 15578.66; BIO-key International, Inc. 10988.14; Pacific Ethanol, Inc. 10706.72; China Ceramics Co., Ltd. 4366.80; Synthesis Energy Systems, Inc. 2390.51; Sunesis Pharmaceuticals, Inc. 781.82; CounterPath Corporation 375.49; Ocean Power Technologies, Inc. 254.15; Ideanomics, Inc. 10.28; Future FinTech Group Inc. 9.85 (shares/day)"
+ },
+ {
+  "dataset": "stockmarket",
+  "query": "3",
+  "run": "4",
+  "answer": "Frontier Communications Corporation: 254,397.63; Correvio Pharma Corp.: 145,247.83; CBAK Energy Technology, Inc.: 86,223.32; Sypris Solutions, Inc.: 36,836.36; Apex Global Brands Inc.: 23,781.42; DASAN Zhone Solutions, Inc.: 15,578.66; BIO-key International, Inc.: 10,988.14; Pacific Ethanol, Inc.: 10,706.72; China Ceramics Co., Ltd.: 4,366.80; Synthesis Energy Systems, Inc.: 2,390.51; Sunesis Pharmaceuticals, Inc.: 781.82; CounterPath Corporation: 375.49; Ocean Power Technologies, Inc.: 254.15; Ideanomics, Inc.: 10.28; Future FinTech Group Inc.: 9.85"
+ },
+ {
+  "dataset": "stockmarket",
+  "query": "4",
+  "run": "0",
+  "answer": "MFA Financial, Inc.; Argo Group International Holdings, Ltd.; HDFC Bank Limited; Albany International Corporation; DTE Energy Company"
+ },
+ {
+  "dataset": "stockmarket",
+  "query": "4",
+  "run": "1",
+  "answer": "MFA Financial, Inc.; Argo Group International Holdings, Ltd.; HDFC Bank Limited; Albany International Corporation; DTE Energy Company"
+ },
+ {
+  "dataset": "stockmarket",
+  "query": "4",
+  "run": "2",
+  "answer": "MFA Financial, Inc.; Argo Group International Holdings, Ltd.; HDFC Bank Limited; Albany International Corporation; DTE Energy Company"
+ },
+ {
+  "dataset": "stockmarket",
+  "query": "4",
+  "run": "3",
+  "answer": "MFA Financial, Inc.; Argo Group International Holdings, Ltd.; HDFC Bank Limited; Albany International Corporation; DTE Energy Company"
+ },
+ {
+  "dataset": "stockmarket",
+  "query": "4",
+  "run": "4",
+  "answer": "MFA Financial, Inc.; Argo Group International Holdings, Ltd.; HDFC Bank Limited; Albany International Corporation; DTE Energy Company"
+ },
+ {
+  "dataset": "stockmarket",
+  "query": "5",
+  "run": "0",
+  "answer": "Synthesis Energy Systems, Inc. (SES, 51 days); TD Holdings, Inc. (GLG, 42 days); TMSR Holding Company Limited (TMSR, 40 days); Verb Technology Company, Inc. (VERB, 38 days); Sunesis Pharmaceuticals, Inc. (SNSS, 32 days)"
+ },
+ {
+  "dataset": "stockmarket",
+  "query": "5",
+  "run": "1",
+  "answer": "Synthesis Energy Systems, Inc. (SES, 51 days); TD Holdings, Inc. (GLG, 42 days); TMSR Holding Company Limited (TMSR, 40 days); Verb Technology Company, Inc. (VERB, 38 days); Sunesis Pharmaceuticals, Inc. (SNSS, 32 days)"
+ },
+ {
+  "dataset": "stockmarket",
+  "query": "5",
+  "run": "2",
+  "answer": "Synthesis Energy Systems, Inc. (SES, 51 days); TD Holdings, Inc. (GLG, 42 days); TMSR Holding Company Limited (TMSR, 40 days); Verb Technology Company, Inc. (VERB, 38 days); Sunesis Pharmaceuticals, Inc. (SNSS, 32 days)"
+ },
+ {
+  "dataset": "stockmarket",
+  "query": "5",
+  "run": "3",
+  "answer": "Synthesis Energy Systems, Inc. (SES, 51 days); TD Holdings, Inc. (GLG, 42 days); TMSR Holding Company Limited (TMSR, 40 days); Verb Technology Company, Inc. (VERB, 38 days); Sunesis Pharmaceuticals, Inc. (SNSS, 32 days)"
+ },
+ {
+  "dataset": "stockmarket",
+  "query": "5",
+  "run": "4",
+  "answer": "Synthesis Energy Systems, Inc. (SES, 51 days); TD Holdings, Inc. (GLG, 42 days); TMSR Holding Company Limited (TMSR, 40 days); Verb Technology Company, Inc. (VERB, 38 days); Sunesis Pharmaceuticals, Inc. (SNSS, 32 days)"
+ },
+ {
+  "dataset": "yelp",
+  "query": "1",
+  "run": "0",
+  "answer": "3.55"
+ },
+ {
+  "dataset": "yelp",
+  "query": "1",
+  "run": "1",
+  "answer": "3.55"
+ },
+ {
+  "dataset": "yelp",
+  "query": "1",
+  "run": "2",
+  "answer": "3.50 stars"
+ },
+ {
+  "dataset": "yelp",
+  "query": "1",
+  "run": "3",
+  "answer": "3.55"
+ },
+ {
+  "dataset": "yelp",
+  "query": "1",
+  "run": "4",
+  "answer": "3.50"
+ },
+ {
+  "dataset": "yelp",
+  "query": "2",
+  "run": "0",
+  "answer": "Pennsylvania (PA), with 662 reviews and an average rating of 3.70"
+ },
+ {
+  "dataset": "yelp",
+  "query": "2",
+  "run": "1",
+  "answer": "Pennsylvania (PA) \u2014 662 reviews, average rating 3.70"
+ },
+ {
+  "dataset": "yelp",
+  "query": "2",
+  "run": "2",
+  "answer": "Pennsylvania (PA), with 662 reviews and an average rating of 3.70"
+ },
+ {
+  "dataset": "yelp",
+  "query": "2",
+  "run": "3",
+  "answer": "Pennsylvania (PA), with 662 reviews and an average rating of 3.70"
+ },
+ {
+  "dataset": "yelp",
+  "query": "2",
+  "run": "4",
+  "answer": "Pennsylvania (PA) \u2014 662 reviews, average rating 3.70"
+ },
+ {
+  "dataset": "yelp",
+  "query": "3",
+  "run": "0",
+  "answer": "35"
+ },
+ {
+  "dataset": "yelp",
+  "query": "3",
+  "run": "1",
+  "answer": "35"
+ },
+ {
+  "dataset": "yelp",
+  "query": "3",
+  "run": "2",
+  "answer": "35"
+ },
+ {
+  "dataset": "yelp",
+  "query": "3",
+  "run": "3",
+  "answer": "35"
+ },
+ {
+  "dataset": "yelp",
+  "query": "3",
+  "run": "4",
+  "answer": "35"
+ },
+ {
+  "dataset": "yelp",
+  "query": "4",
+  "run": "0",
+  "answer": "Restaurants, with 27 credit-card-accepting businesses and an average rating of 3.63"
+ },
+ {
+  "dataset": "yelp",
+  "query": "4",
+  "run": "1",
+  "answer": "Restaurants (27 businesses accepting credit cards), average rating 3.63"
+ },
+ {
+  "dataset": "yelp",
+  "query": "4",
+  "run": "2",
+  "answer": "Restaurants (27 businesses accepting credit cards), average rating 3.63"
+ },
+ {
+  "dataset": "yelp",
+  "query": "4",
+  "run": "3",
+  "answer": "Restaurants (27 credit-card-accepting businesses), average rating 3.63"
+ },
+ {
+  "dataset": "yelp",
+  "query": "4",
+  "run": "4",
+  "answer": "Restaurants (27 businesses accepting credit cards), average rating 3.63"
+ },
+ {
+  "dataset": "yelp",
+  "query": "5",
+  "run": "0",
+  "answer": "Pennsylvania (PA) \u2014 8 businesses offering WiFi, average rating 3.48 stars"
+ },
+ {
+  "dataset": "yelp",
+  "query": "5",
+  "run": "1",
+  "answer": "Pennsylvania (PA) \u2014 8 businesses offering WiFi, average rating 3.48"
+ },
+ {
+  "dataset": "yelp",
+  "query": "5",
+  "run": "2",
+  "answer": "Pennsylvania (PA), with 8 WiFi-offering businesses and an average rating of 3.48"
+ },
+ {
+  "dataset": "yelp",
+  "query": "5",
+  "run": "3",
+  "answer": "Pennsylvania (PA) \u2014 8 businesses offering WiFi, average rating 3.48"
+ },
+ {
+  "dataset": "yelp",
+  "query": "5",
+  "run": "4",
+  "answer": "Pennsylvania (PA) \u2014 8 businesses offering WiFi, average rating 3.48"
+ },
+ {
+  "dataset": "yelp",
+  "query": "6",
+  "run": "0",
+  "answer": "Coffee House Too Cafe \u2014 average rating 4.375 (16 reviews); categories: Restaurants, Breakfast & Brunch, American (New), Cafes"
+ },
+ {
+  "dataset": "yelp",
+  "query": "6",
+  "run": "1",
+  "answer": "Coffee House Too Cafe (avg rating 4.375) \u2014 categories: Restaurants, Breakfast & Brunch, American (New), Cafes"
+ },
+ {
+  "dataset": "yelp",
+  "query": "6",
+  "run": "2",
+  "answer": "Coffee House Too Cafe \u2014 average rating 4.375; categories: Restaurants, Breakfast & Brunch, American (New), Cafes"
+ },
+ {
+  "dataset": "yelp",
+  "query": "6",
+  "run": "3",
+  "answer": "Coffee House Too Cafe \u2014 average rating 4.375 (16 reviews); categories: Restaurants, Breakfast & Brunch, American (New), Cafes"
+ },
+ {
+  "dataset": "yelp",
+  "query": "6",
+  "run": "4",
+  "answer": "Coffee House Too Cafe \u2014 average rating 4.375 (16 reviews Jan 1\u2013Jun 30, 2016); categories: Restaurants, Breakfast & Brunch, American (New), Cafes"
+ },
+ {
+  "dataset": "yelp",
+  "query": "7",
+  "run": "0",
+  "answer": "Restaurants (58 reviews), Food (38), American (New) (24), Shopping (20), Breakfast & Brunch (19)"
+ },
+ {
+  "dataset": "yelp",
+  "query": "7",
+  "run": "1",
+  "answer": "Restaurants (58 reviews), Food (38), American (New) (24), Shopping (20), Breakfast & Brunch (19)"
+ },
+ {
+  "dataset": "yelp",
+  "query": "7",
+  "run": "2",
+  "answer": "Restaurants (58 reviews), Food (38), American (New) (24), Shopping (20), Breakfast & Brunch (19)"
+ },
+ {
+  "dataset": "yelp",
+  "query": "7",
+  "run": "3",
+  "answer": "Restaurants (58 reviews), Food (38), American (New) (24), Shopping (20), Breakfast & Brunch (19)"
+ },
+ {
+  "dataset": "yelp",
+  "query": "7",
+  "run": "4",
+  "answer": "Restaurants (58 reviews), Food (38), American (New) (24), Shopping (20), Breakfast & Brunch (19)"
+ }
+]

--- a/leaderboard_submissions/phoenix_cli.json
+++ b/leaderboard_submissions/phoenix_cli.json
@@ -3,13 +3,13 @@
   "dataset": "DEPS_DEV_V1",
   "query": "1",
   "run": "0",
-  "answer": "@dmrvos/infrajs>0.0.5>typescript (2.6.2, 94931 stars); @dmrvos/infrajs>0.0.6>typescript (2.6.2, 94931 stars); @docly/web (0.2.3, 89398 stars); @dylanvann/svelte (3.25.4, 73499 stars); @dumc11/tailwindcss (0.4.0, 73464 stars)"
+  "answer": "@dylanvann/svelte 3.25.4 (73,499 stars); @dumc11/tailwindcss 0.4.0 (73,464 stars); @dreampie/semantic-ui 2.2.11 (51,069 stars); @dongls/pdfjs-dist 3.2.72 (44,231 stars); @dman777/shadow-dom-quill-temp 1.0.0 (42,407 stars)"
  },
  {
   "dataset": "DEPS_DEV_V1",
   "query": "1",
   "run": "1",
-  "answer": "@dmrvos/infrajs>0.0.5>typescript (2.6.2, 94,931 stars); @dmrvos/infrajs>0.0.6>typescript (2.6.2, 94,931 stars); @docly/web (0.2.3, 89,398 stars); @dylanvann/svelte (3.25.4, 73,499 stars); @dumc11/tailwindcss (0.4.0, 73,464 stars)"
+  "answer": "@dylanvann/svelte 3.25.4 (73,499 stars); @dumc11/tailwindcss 0.4.0 (73,464 stars); @dreampie/semantic-ui 2.2.11 (51,069 stars); @dongls/pdfjs-dist 3.2.72 (44,231 stars); @dman777/shadow-dom-quill-temp 1.0.0 (42,407 stars)"
  },
  {
   "dataset": "DEPS_DEV_V1",
@@ -27,19 +27,19 @@
   "dataset": "DEPS_DEV_V1",
   "query": "1",
   "run": "4",
-  "answer": "@dmrvos/infrajs>0.0.5>typescript v2.6.2 (microsoft/typescript, 94,931 stars); @dmrvos/infrajs>0.0.6>typescript v2.6.2 (microsoft/typescript, 94,931 stars); @dylanvann/svelte v3.25.4 (sveltejs/svelte, 73,499 stars); @dumc11/tailwindcss v0.4.0 (tailwindcss/tailwindcss, 73,464 stars); @dollarshaveclub/cli>1.0.0>lodash v4.17.4 (lodash/lodash, 57,779 stars \u2014 tied with 94 other lodash-sourced packages)"
+  "answer": "@dylanvann/svelte 3.25.4 (73,499 stars); @dumc11/tailwindcss 0.4.0 (73,464 stars); @dreampie/semantic-ui 2.2.11 (51,069 stars); @dongls/pdfjs-dist 3.2.72 (44,231 stars); @dman777/shadow-dom-quill-temp 1.0.0 (42,407 stars)"
  },
  {
   "dataset": "DEPS_DEV_V1",
   "query": "2",
   "run": "0",
-  "answer": "mui-org/material-ui (30,522 forks), moment/moment (7,201 forks), semantic-org/semantic-ui (4,955 forks), react-native-elements/react-native-elements (4,623 forks), sveltejs/svelte (4,091 forks)"
+  "answer": "mui-org/material-ui (30,522 forks), moment/moment (7,201), semantic-org/semantic-ui (4,955), react-native-elements/react-native-elements (4,623), sveltejs/svelte (4,091)"
  },
  {
   "dataset": "DEPS_DEV_V1",
   "query": "2",
   "run": "1",
-  "answer": "mui-org/material-ui (30,522 forks), moment/moment (7,201 forks), semantic-org/semantic-ui (4,955 forks), react-native-elements/react-native-elements (4,623 forks), sveltejs/svelte (4,091 forks)"
+  "answer": "mui-org/material-ui (30,522 forks), moment/moment (7,201), semantic-org/semantic-ui (4,955), react-native-elements/react-native-elements (4,623), sveltejs/svelte (4,091)"
  },
  {
   "dataset": "DEPS_DEV_V1",
@@ -51,7 +51,7 @@
   "dataset": "DEPS_DEV_V1",
   "query": "2",
   "run": "3",
-  "answer": "mui-org/material-ui (30,522 forks), moment/moment (7,201 forks), semantic-org/semantic-ui (4,955 forks), react-native-elements/react-native-elements (4,623 forks), sveltejs/svelte (4,091 forks)"
+  "answer": "mui-org/material-ui (30,522 forks), moment/moment (7,201), semantic-org/semantic-ui (4,955), react-native-elements/react-native-elements (4,623), sveltejs/svelte (4,091)"
  },
  {
   "dataset": "DEPS_DEV_V1",
@@ -63,13 +63,13 @@
   "dataset": "GITHUB_REPOS",
   "query": "1",
   "run": "0",
-  "answer": "1/3 \u2248 0.3333 (33.33%) \u2014 1 of 3 README.md files in non-Python repositories contains copyright information"
+  "answer": "~17.8% (18 of 101 non-Python repositories' README.md files contain copyright information)"
  },
  {
   "dataset": "GITHUB_REPOS",
   "query": "1",
   "run": "1",
-  "answer": "About 14.85% (15 of 101 non-Python repositories' README.md files contain copyright information)"
+  "answer": "~14.9% (15 of 101 non-Python repositories' README.md files contain copyright information)"
  },
  {
   "dataset": "GITHUB_REPOS",
@@ -81,13 +81,13 @@
   "dataset": "GITHUB_REPOS",
   "query": "1",
   "run": "3",
-  "answer": "14.85% (15 of 101 README.md files from non-Python repositories)"
+  "answer": "\u224814.9% (15 of 101 non-Python repositories' README.md files contain copyright information; 17.8% \u2014 18 of 101 \u2014 if \u00a9 / \"(c) year\" notices are also counted)"
  },
  {
   "dataset": "GITHUB_REPOS",
   "query": "1",
   "run": "4",
-  "answer": "\u224814.85% (15 of 101 non-Python repositories' README.md files contain copyright information)"
+  "answer": "18% (18 of 100 non-Python repositories' README.md files contain copyright information)"
  },
  {
   "dataset": "GITHUB_REPOS",
@@ -117,7 +117,7 @@
   "dataset": "GITHUB_REPOS",
   "query": "2",
   "run": "4",
-  "answer": "SwiftAndroid/swift"
+  "answer": "uacaps/PageMenu"
  },
  {
   "dataset": "GITHUB_REPOS",
@@ -153,7 +153,7 @@
   "dataset": "GITHUB_REPOS",
   "query": "4",
   "run": "0",
-  "answer": "apple/swift, twbs/bootstrap, Microsoft/vscode, facebook/react, tensorflow/tensorflow"
+  "answer": "torvalds/linux, apple/swift, twbs/bootstrap, Microsoft/vscode, facebook/react"
  },
  {
   "dataset": "GITHUB_REPOS",
@@ -165,13 +165,13 @@
   "dataset": "GITHUB_REPOS",
   "query": "4",
   "run": "2",
-  "answer": "apple/swift, twbs/bootstrap, Microsoft/vscode, facebook/react, tensorflow/tensorflow"
+  "answer": "torvalds/linux, apple/swift, twbs/bootstrap, Microsoft/vscode, facebook/react"
  },
  {
   "dataset": "GITHUB_REPOS",
   "query": "4",
   "run": "3",
-  "answer": "apple/swift, twbs/bootstrap, Microsoft/vscode, facebook/react, tensorflow/tensorflow"
+  "answer": "torvalds/linux, apple/swift, twbs/bootstrap, Microsoft/vscode, facebook/react"
  },
  {
   "dataset": "GITHUB_REPOS",
@@ -189,19 +189,19 @@
   "dataset": "PANCANCER_ATLAS",
   "query": "1",
   "run": "1",
-  "answer": "Astrocytoma: 2.5713, Oligoastrocytoma: 2.7136, Oligodendroglioma: 2.6825"
+  "answer": "Astrocytoma = 2.5713, Oligoastrocytoma = 2.7136, Oligodendroglioma = 2.6825"
  },
  {
   "dataset": "PANCANCER_ATLAS",
   "query": "1",
   "run": "2",
-  "answer": "Astrocytoma: 2.5713, Oligodendroglioma: 2.6825, Oligoastrocytoma: 2.7136"
+  "answer": "Astrocytoma: 2.5713 (2.571298), Oligoastrocytoma: 2.7136 (2.713571), Oligodendroglioma: 2.6825 (2.682458)"
  },
  {
   "dataset": "PANCANCER_ATLAS",
   "query": "1",
   "run": "3",
-  "answer": "Astrocytoma: 2.5713, Oligoastrocytoma: 2.7136, Oligodendroglioma: 2.6825"
+  "answer": "Astrocytoma: 2.5713 (2.571298), Oligoastrocytoma: 2.7136 (2.713571), Oligodendroglioma: 2.6825 (2.682458)"
  },
  {
   "dataset": "PANCANCER_ATLAS",
@@ -213,13 +213,13 @@
   "dataset": "PANCANCER_ATLAS",
   "query": "2",
   "run": "0",
-  "answer": "Infiltrating Lobular Carcinoma (50.56%), Mixed Histology (please specify) (16.67%), Other  specify (8.33%)"
- },
- {
-  "dataset": "PANCANCER_ATLAS",
-  "query": "2",
-  "run": "1",
   "answer": "Infiltrating Lobular Carcinoma (50.56%), Mixed Histology (please specify) (16.67%), Other, specify (8.33%)"
+ },
+ {
+  "dataset": "PANCANCER_ATLAS",
+  "query": "2",
+  "run": "1",
+  "answer": "Infiltrating Lobular Carcinoma (50.6%), Mixed Histology (please specify) (16.7%), Other specify (8.3%)"
  },
  {
   "dataset": "PANCANCER_ATLAS",
@@ -255,21 +255,21 @@
   "dataset": "PANCANCER_ATLAS",
   "query": "3",
   "run": "2",
+  "answer": "305.12"
+ },
+ {
+  "dataset": "PANCANCER_ATLAS",
+  "query": "3",
+  "run": "3",
+  "answer": "\u03c7\u00b2 \u2248 305.12 (df = 4)"
+ },
+ {
+  "dataset": "PANCANCER_ATLAS",
+  "query": "3",
+  "run": "4",
   "answer": "305.12 (chi-square statistic, df = 4)"
  },
  {
-  "dataset": "PANCANCER_ATLAS",
-  "query": "3",
-  "run": "3",
-  "answer": "305.12"
- },
- {
-  "dataset": "PANCANCER_ATLAS",
-  "query": "3",
-  "run": "4",
-  "answer": "305.12"
- },
- {
   "dataset": "PATENTS",
   "query": "1",
   "run": "0",
@@ -303,19 +303,19 @@
   "dataset": "PATENTS",
   "query": "2",
   "run": "0",
-  "answer": "A61 \u2014 MEDICAL OR VETERINARY SCIENCE; HYGIENE \u2014 best year 2016; H04 \u2014 ELECTRIC COMMUNICATION TECHNIQUE \u2014 best year 2015 (both with the highest EMA of 2.0)"
+  "answer": "A61 \u2014 \"MEDICAL OR VETERINARY SCIENCE; HYGIENE\" \u2014 best year 2016 (EMA 2.0); H04 \u2014 \"ELECTRIC COMMUNICATION TECHNIQUE\" \u2014 best year 2015 (EMA 2.0)"
  },
  {
   "dataset": "PATENTS",
   "query": "2",
   "run": "1",
-  "answer": "A61 \u2014 MEDICAL OR VETERINARY SCIENCE; HYGIENE \u2014 best year 2016 (EMA 2.0); H04 \u2014 ELECTRIC COMMUNICATION TECHNIQUE \u2014 best year 2015 (EMA 2.0)"
+  "answer": "H04 \u2014 ELECTRIC COMMUNICATION TECHNIQUE, best year 2015 (EMA 2.0); A61 \u2014 MEDICAL OR VETERINARY SCIENCE; HYGIENE, best year 2016 (EMA 2.0)"
  },
  {
   "dataset": "PATENTS",
   "query": "2",
   "run": "2",
-  "answer": "A47 \u2014 \"FURNITURE; DOMESTIC ARTICLES OR APPLIANCES; COFFEE MILLS; SPICE MILLS; SUCTION CLEANERS IN GENERAL\" \u2014 best year 2016 (EMA 2.0); G01 \u2014 \"MEASURING; TESTING\" \u2014 best year 2014 (EMA 2.0); G06 \u2014 \"COMPUTING; CALCULATING OR COUNTING\" \u2014 best year 2016 (EMA 2.0)"
+  "answer": "H04 \u2014 ELECTRIC COMMUNICATION TECHNIQUE, best year 2015 (EMA 2.0); A61 \u2014 MEDICAL OR VETERINARY SCIENCE; HYGIENE, best year 2016 (EMA 2.0)"
  },
  {
   "dataset": "PATENTS",
@@ -327,7 +327,7 @@
   "dataset": "PATENTS",
   "query": "2",
   "run": "4",
-  "answer": "A61 \u2014 MEDICAL OR VETERINARY SCIENCE; HYGIENE \u2014 best year 2016 (EMA 2.0); H04 \u2014 ELECTRIC COMMUNICATION TECHNIQUE \u2014 best year 2015 (EMA 2.0)"
+  "answer": "H04 \u2014 \"ELECTRIC COMMUNICATION TECHNIQUE\" \u2014 best year 2015 (EMA 2.0); A61 \u2014 \"MEDICAL OR VETERINARY SCIENCE; HYGIENE\" \u2014 best year 2016 (EMA 2.0)"
  },
  {
   "dataset": "PATENTS",
@@ -351,13 +351,13 @@
   "dataset": "PATENTS",
   "query": "3",
   "run": "3",
-  "answer": "BLOOM ENERGY CORP \u2014 H01M: PROCESSES OR MEANS, e.g. BATTERIES, FOR THE DIRECT CONVERSION OF CHEMICAL ENERGY INTO ELECTRICAL ENERGY; CRYSTAL IS INC \u2014 C30B: SINGLE-CRYSTAL GROWTH; UNIDIRECTIONAL SOLIDIFICATION OF EUTECTIC MATERIAL OR UNIDIRECTIONAL DEMIXING OF EUTECTOID MATERIAL; REFINING BY ZONE-MELTING OF MATERIAL; PRODUCTION OF A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; SINGLE CRYSTALS OR HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; AFTER-TREATMENT OF SINGLE CRYSTALS OR A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; APPARATUS THEREFOR; SCHOWALTER LEO J \u2014 H01L: SEMICONDUCTOR DEVICES NOT COVERED BY CLASS H10"
+  "answer": "BLOOM ENERGY CORP \u2014 H01M: \"PROCESSES OR MEANS, e.g. BATTERIES, FOR THE DIRECT CONVERSION OF CHEMICAL ENERGY INTO ELECTRICAL ENERGY\"; CRYSTAL IS INC \u2014 C30B: \"SINGLE-CRYSTAL GROWTH; UNIDIRECTIONAL SOLIDIFICATION OF EUTECTIC MATERIAL OR UNIDIRECTIONAL DEMIXING OF EUTECTOID MATERIAL; REFINING BY ZONE-MELTING OF MATERIAL; PRODUCTION OF A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; SINGLE CRYSTALS OR HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; AFTER-TREATMENT OF SINGLE CRYSTALS OR A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; APPARATUS THEREFOR\"; SCHOWALTER LEO J \u2014 H01L: \"SEMICONDUCTOR DEVICES NOT COVERED BY CLASS H10\""
  },
  {
   "dataset": "PATENTS",
   "query": "3",
   "run": "4",
-  "answer": "BLOOM ENERGY CORP \u2014 H01M: PROCESSES OR MEANS, e.g. BATTERIES, FOR THE DIRECT CONVERSION OF CHEMICAL ENERGY INTO ELECTRICAL ENERGY; CRYSTAL IS INC \u2014 C30B: SINGLE-CRYSTAL GROWTH; UNIDIRECTIONAL SOLIDIFICATION OF EUTECTIC MATERIAL OR UNIDIRECTIONAL DEMIXING OF EUTECTOID MATERIAL; REFINING BY ZONE-MELTING OF MATERIAL; PRODUCTION OF A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; SINGLE CRYSTALS OR HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; AFTER-TREATMENT OF SINGLE CRYSTALS OR A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; APPARATUS THEREFOR; SCHOWALTER LEO J \u2014 H01L: SEMICONDUCTOR DEVICES NOT COVERED BY CLASS H10"
+  "answer": "BLOOM ENERGY CORP \u2014 H01M: \"PROCESSES OR MEANS, e.g. BATTERIES, FOR THE DIRECT CONVERSION OF CHEMICAL ENERGY INTO ELECTRICAL ENERGY\"; CRYSTAL IS INC \u2014 C30B: \"SINGLE-CRYSTAL GROWTH; UNIDIRECTIONAL SOLIDIFICATION OF EUTECTIC MATERIAL OR UNIDIRECTIONAL DEMIXING OF EUTECTOID MATERIAL; REFINING BY ZONE-MELTING OF MATERIAL; PRODUCTION OF A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; SINGLE CRYSTALS OR HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; AFTER-TREATMENT OF SINGLE CRYSTALS OR A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; APPARATUS THEREFOR\"; SCHOWALTER LEO J \u2014 H01L: \"SEMICONDUCTOR DEVICES NOT COVERED BY CLASS H10\""
  },
  {
   "dataset": "agnews",
@@ -393,77 +393,77 @@
   "dataset": "agnews",
   "query": "2",
   "run": "0",
-  "answer": "26/111 \u2248 0.234 (23.4%)"
+  "answer": "\u2248 0.216 (24 of 111 articles, about 21.6%)"
  },
  {
   "dataset": "agnews",
   "query": "2",
   "run": "1",
-  "answer": "25/111 \u2248 0.225 (22.5%)"
+  "answer": "23/111 \u2248 0.21 (about 20.7% of Amy Jones's 111 articles are Science/Technology)"
  },
  {
   "dataset": "agnews",
   "query": "2",
   "run": "2",
-  "answer": "24/111 \u2248 0.216 (21.6% \u2014 24 of Amy Jones's 111 articles are Science/Technology)"
+  "answer": "24/111 \u2248 0.216 (about 21.6%)"
  },
  {
   "dataset": "agnews",
   "query": "2",
   "run": "3",
-  "answer": "25/111 \u2248 0.225 (22.5%)"
+  "answer": "23/111 \u2248 0.207 (about 20.7%)"
  },
  {
   "dataset": "agnews",
   "query": "2",
   "run": "4",
-  "answer": "26/111 \u2248 0.234 (23.4%)"
+  "answer": "24/111 \u2248 0.216 (about 21.6%)"
  },
  {
   "dataset": "agnews",
   "query": "3",
   "run": "0",
-  "answer": "\u2248 340 business articles per year (about 3,755 total across 2010\u20132020)"
+  "answer": "\u2248358 business articles per year (about 3,940 total in Europe from 2010 to 2020)"
  },
  {
   "dataset": "agnews",
   "query": "3",
   "run": "1",
-  "answer": "\u2248337.5 business articles per year (3,713 total over 2010\u20132020)"
+  "answer": "\u2248302 business articles per year (3,319 total over 2010\u20132020, 301.7/year)"
  },
  {
   "dataset": "agnews",
   "query": "3",
   "run": "2",
-  "answer": "\u2248338 business articles per year (about 3,720 Business articles in Europe over 2010\u20132020)"
+  "answer": "~337 business articles per year (approximately 3,700 business articles in Europe over 2010\u20132020)"
  },
  {
   "dataset": "agnews",
   "query": "3",
   "run": "3",
-  "answer": "337"
+  "answer": "\u2248345 business articles per year (about 3,800 total over 2010\u20132020)"
  },
  {
   "dataset": "agnews",
   "query": "3",
   "run": "4",
-  "answer": "approximately 321 business articles per year (3,528 Business articles in Europe over 2010\u20132020 \u00f7 11 years = 320.7)"
+  "answer": "approximately 340 business articles per year (~3,750 total over 2010\u20132020)"
  },
  {
   "dataset": "agnews",
   "query": "4",
   "run": "0",
+  "answer": "North America (350 World-category articles in 2015)"
+ },
+ {
+  "dataset": "agnews",
+  "query": "4",
+  "run": "1",
   "answer": "North America"
  },
  {
   "dataset": "agnews",
   "query": "4",
-  "run": "1",
-  "answer": "Pass A (ornith-9b) is running over all 6,696 articles from 2015. I'll report once it checkpoints."
- },
- {
-  "dataset": "agnews",
-  "query": "4",
   "run": "2",
   "answer": "North America"
  },
@@ -477,7 +477,7 @@
   "dataset": "agnews",
   "query": "4",
   "run": "4",
-  "answer": "Pass 1 is running in the background. Waiting for it to complete."
+  "answer": "Africa"
  },
  {
   "dataset": "bookreview",
@@ -495,7 +495,7 @@
   "dataset": "bookreview",
   "query": "1",
   "run": "2",
-  "answer": "2020s"
+  "answer": "2020s (average rating \u2248 4.66)"
  },
  {
   "dataset": "bookreview",
@@ -519,23 +519,23 @@
   "dataset": "bookreview",
   "query": "2",
   "run": "1",
-  "answer": "Reunion: The Children of Lauderdale Park; The Prophet: With Original 1923 Illustrations by the Author; The Melancholy Strumpet Master; Child Of The King A Journey of Hope Book 1: Earthly Story With A Heavenly Message; Fire Cracker; Local Honey; Hollywood Confessions: Hollywood Headlines Book #3 (Hollywood Headlines Mysteries); Knowing When To Die: Uncollected Stories; Childe Harold of Dysna; Forged in Blood (Freehold); Exits, Desires, & Slow Fires; Kennebago Moments; The Sludge; Liza of Lambeth; Something That Feels Like Truth (Switchgrass Books)"
+  "answer": "15 books: Reunion: The Children of Lauderdale Park; The Prophet: With Original 1923 Illustrations by the Author; The Melancholy Strumpet Master; Child Of The King A Journey of Hope Book 1: Earthly Story With A Heavenly Message; Fire Cracker; Local Honey; Hollywood Confessions: Hollywood Headlines Book #3 (Hollywood Headlines Mysteries); Knowing When To Die: Uncollected Stories; Childe Harold of Dysna; Forged in Blood (Freehold); Exits, Desires, & Slow Fires; Kennebago Moments; The Sludge; Liza of Lambeth; Something That Feels Like Truth (Switchgrass Books)"
  },
  {
   "dataset": "bookreview",
   "query": "2",
   "run": "2",
+  "answer": "15 books: Reunion: The Children of Lauderdale Park; The Prophet: With Original 1923 Illustrations by the Author; The Melancholy Strumpet Master; Child Of The King A Journey of Hope Book 1: Earthly Story With A Heavenly Message; Fire Cracker; Local Honey; Hollywood Confessions: Hollywood Headlines Book #3 (Hollywood Headlines Mysteries); Knowing When To Die: Uncollected Stories; Childe Harold of Dysna; Forged in Blood (Freehold); Exits, Desires, & Slow Fires; Kennebago Moments; The Sludge; Liza of Lambeth; Something That Feels Like Truth (Switchgrass Books)"
+ },
+ {
+  "dataset": "bookreview",
+  "query": "2",
+  "run": "3",
   "answer": "15 books \u2014 Reunion: The Children of Lauderdale Park; The Prophet: With Original 1923 Illustrations by the Author; The Melancholy Strumpet Master; Child Of The King A Journey of Hope Book 1: Earthly Story With A Heavenly Message; Fire Cracker; Local Honey; Hollywood Confessions: Hollywood Headlines Book #3 (Hollywood Headlines Mysteries); Knowing When To Die: Uncollected Stories; Childe Harold of Dysna; Forged in Blood (Freehold); Exits, Desires, & Slow Fires; Kennebago Moments; The Sludge; Liza of Lambeth; Something That Feels Like Truth (Switchgrass Books)"
  },
  {
   "dataset": "bookreview",
   "query": "2",
-  "run": "3",
-  "answer": "15 books \u2014 Reunion: The Children of Lauderdale Park; The Prophet: With Original 1923 Illustrations by the Author; The Melancholy Strumpet Master; Child Of The King A Journey of Hope Book 1: Earthly Story With A Heavenly Message; Fire Cracker; Local Honey; Hollywood Confessions: Hollywood Headlines Book #3 (Hollywood Headlines Mysteries); Knowing When To Die: Uncollected Stories; Childe Harold of Dysna; Forged in Blood (Freehold); Exits, Desires, & Slow Fires; Kennebago Moments; The Sludge; Liza of Lambeth; Something That Feels Like Truth (Switchgrass Books)"
- },
- {
-  "dataset": "bookreview",
-  "query": "2",
   "run": "4",
   "answer": "Reunion: The Children of Lauderdale Park; The Prophet: With Original 1923 Illustrations by the Author; The Melancholy Strumpet Master; Child Of The King A Journey of Hope Book 1: Earthly Story With A Heavenly Message; Fire Cracker; Local Honey; Hollywood Confessions: Hollywood Headlines Book #3 (Hollywood Headlines Mysteries); Knowing When To Die: Uncollected Stories; Childe Harold of Dysna; Forged in Blood (Freehold); Exits, Desires, & Slow Fires; Kennebago Moments; The Sludge; Liza of Lambeth; Something That Feels Like Truth (Switchgrass Books)"
  },
@@ -549,58 +549,298 @@
   "dataset": "bookreview",
   "query": "3",
   "run": "1",
-  "answer": "Monstrous Stories #4: The Day the Mice Stood Still (5.0); The Old Man and the Pirate Princess (5.0); Egypt (Enchantment of the World) (5.0); Favorite Thorton W. Burgess Stories: 6 Books (5.0); Behind the Wheel (Choose Your Own Adventure #35) (5.0); Cheer Up, Ben Franklin! (Young Historians) (5.0); The Library Book (5.0); Benny Goes To The Moon (5.0); LunaLu the Llamacorn (5.0); Around the World Mazes (5.0); Pok\u00e9mon: Sun & Moon, Vol. 8 (5.0); Trouble in the CTC!: The Terra Prime Adventures Book 2 (4.9); Clark the Shark: Tooth Trouble, No. 1 (4.75); Cleo Porter and the Body Electric (4.71)"
+  "answer": "14 books: Monstrous Stories #4: The Day the Mice Stood Still (5.0); The Old Man and the Pirate Princess (5.0); Egypt (Enchantment of the World) (5.0); Favorite Thorton W. Burgess Stories: 6 Books (5.0); Behind the Wheel (Choose Your Own Adventure #35) (5.0); Cheer Up, Ben Franklin! (Young Historians) (5.0); The Library Book (5.0); Benny Goes To The Moon (5.0); LunaLu the Llamacorn (5.0); Around the World Mazes (5.0); Pok\u00e9mon: Sun & Moon, Vol. 8 (5.0); Trouble in the CTC!: The Terra Prime Adventures Book 2 (4.9); Clark the Shark: Tooth Trouble, No. 1 (4.75); Cleo Porter and the Body Electric (4.71)"
  },
  {
   "dataset": "bookreview",
   "query": "3",
   "run": "2",
-  "answer": "Monstrous Stories #4: The Day the Mice Stood Still (5.0); The Old Man and the Pirate Princess (5.0); Egypt (Enchantment of the World) (5.0); Favorite Thorton W. Burgess Stories: 6 Books (5.0); Behind the Wheel (Choose Your Own Adventure #35) (5.0); Cheer Up, Ben Franklin! (Young Historians) (5.0); The Library Book (5.0); Benny Goes To The Moon (5.0); LunaLu the Llamacorn (5.0); Around the World Mazes (5.0); Pok\u00e9mon: Sun & Moon, Vol. 8 (5.0); Trouble in the CTC!: The Terra Prime Adventures Book 2 (4.9); Clark the Shark: Tooth Trouble, No. 1 (4.75); Cleo Porter and the Body Electric (4.71)"
+  "answer": "The Library Book (5.0); Benny Goes To The Moon: The great new book from Top Children's entertainer Gerry Ogilvie (1) (5.0); The Old Man and the Pirate Princess (5.0); LunaLu the Llamacorn (5.0); Around the World Mazes (5.0); Pok\u00e9mon: Sun & Moon, Vol. 8 (8) (5.0); Monstrous Stories #4: The Day the Mice Stood Still (5.0); Egypt (Enchantment of the World) (5.0); Favorite Thorton W. Burgess Stories: 6 Books (5.0); Behind the Wheel (Choose Your Own Adventure #35)(Paperback/Revised) (5.0); Cheer Up, Ben Franklin! (Young Historians) (5.0); Trouble in the CTC!: The Terra Prime Adventures Book 2 (4.9); Clark the Shark: Tooth Trouble, No. 1 (4.75); Cleo Porter and the Body Electric (4.71)"
  },
  {
   "dataset": "bookreview",
   "query": "3",
   "run": "3",
-  "answer": "Monstrous Stories #4: The Day the Mice Stood Still (5.0); The Old Man and the Pirate Princess (5.0); Egypt (Enchantment of the World) (5.0); Favorite Thorton W. Burgess Stories: 6 Books (5.0); Behind the Wheel (Choose Your Own Adventure #35)(Paperback/Revised) (5.0); Cheer Up, Ben Franklin! (Young Historians) (5.0); The Library Book (5.0); Benny Goes To The Moon: The great new book from Top Children's entertainer Gerry Ogilvie (1) (5.0); LunaLu the Llamacorn (5.0); Around the World Mazes (5.0); Pok\u00e9mon: Sun & Moon, Vol. 8 (8) (5.0); Trouble in the CTC!: The Terra Prime Adventures Book 2 (4.9); Clark the Shark: Tooth Trouble, No. 1 (4.75); Cleo Porter and the Body Electric (4.71)"
+  "answer": "Monstrous Stories #4: The Day the Mice Stood Still (5.0); The Old Man and the Pirate Princess (5.0); Egypt (Enchantment of the World) (5.0); Clark the Shark: Tooth Trouble, No. 1 (4.75); Favorite Thorton W. Burgess Stories: 6 Books (5.0); Behind the Wheel (Choose Your Own Adventure #35)(Paperback/Revised) (5.0); Cheer Up, Ben Franklin! (Young Historians) (5.0); The Library Book (5.0); Benny Goes To The Moon: The great new book from Top Children's entertainer Gerry Ogilvie (1) (5.0); LunaLu the Llamacorn (5.0); Trouble in the CTC!: The Terra Prime Adventures Book 2 (4.9); Around the World Mazes (5.0); Cleo Porter and the Body Electric (4.71); Pok\u00e9mon: Sun & Moon, Vol. 8 (8) (5.0)"
  },
  {
   "dataset": "bookreview",
   "query": "3",
   "run": "4",
-  "answer": "Monstrous Stories #4: The Day the Mice Stood Still (5.0); The Old Man and the Pirate Princess (5.0); Egypt (Enchantment of the World) (5.0); Favorite Thorton W. Burgess Stories: 6 Books (5.0); Behind the Wheel (Choose Your Own Adventure #35)(Paperback/Revised) (5.0); Cheer Up, Ben Franklin! (Young Historians) (5.0); The Library Book (5.0); Benny Goes To The Moon: The great new book from Top Children's entertainer Gerry Ogilvie (1) (5.0); LunaLu the Llamacorn (5.0); Around the World Mazes (5.0); Pok\u00e9mon: Sun & Moon, Vol. 8 (8) (5.0); Trouble in the CTC!: The Terra Prime Adventures Book 2 (4.9); Clark the Shark: Tooth Trouble, No. 1 (4.75); Cleo Porter and the Body Electric (4.71)"
+  "answer": "14 books: Monstrous Stories #4: The Day the Mice Stood Still (5.0); The Old Man and the Pirate Princess (5.0); Egypt (Enchantment of the World) (5.0); Favorite Thorton W. Burgess Stories: 6 Books (5.0); Behind the Wheel (Choose Your Own Adventure #35) (5.0); Cheer Up, Ben Franklin! (Young Historians) (5.0); The Library Book (5.0); Benny Goes To The Moon (5.0); LunaLu the Llamacorn (5.0); Around the World Mazes (5.0); Pok\u00e9mon: Sun & Moon, Vol. 8 (5.0); Trouble in the CTC!: The Terra Prime Adventures Book 2 (4.9); Clark the Shark: Tooth Trouble, No. 1 (4.75); Cleo Porter and the Body Electric (4.71)"
  },
  {
   "dataset": "crmarenapro",
   "query": "1",
   "run": "0",
-  "answer": "Authority, Timeline"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "1",
-  "run": "1",
-  "answer": "Authority, Timeline"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "1",
-  "run": "2",
-  "answer": "Authority, Timeline"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "1",
-  "run": "3",
-  "answer": "Budget, Authority, Timeline"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "1",
-  "run": "4",
   "answer": "Budget, Authority"
  },
  {
   "dataset": "crmarenapro",
+  "query": "1",
+  "run": "1",
+  "answer": "Authority"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "1",
+  "run": "2",
+  "answer": "Budget, Authority"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "1",
+  "run": "3",
+  "answer": "Authority"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "1",
+  "run": "4",
+  "answer": "Authority, Timeline"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "2",
+  "run": "0",
+  "answer": "ka0Wt000000Ens5IAC"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "2",
+  "run": "1",
+  "answer": "ka0Wt000000Ens5IAC"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "2",
+  "run": "2",
+  "answer": "ka0Wt000000Eq0MIAS"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "2",
+  "run": "3",
+  "answer": "ka0Wt000000Eq0MIAS"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "2",
+  "run": "4",
+  "answer": "ka0Wt000000Eq0MIAS"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "3",
+  "run": "0",
+  "answer": "Quote"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "3",
+  "run": "1",
+  "answer": "Negotiation"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "3",
+  "run": "2",
+  "answer": "Quote"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "3",
+  "run": "3",
+  "answer": "Quote"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "3",
+  "run": "4",
+  "answer": "Negotiation"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "4",
+  "run": "0",
+  "answer": "November"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "4",
+  "run": "1",
+  "answer": "November"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "4",
+  "run": "2",
+  "answer": "November"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "4",
+  "run": "3",
+  "answer": "November"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "4",
+  "run": "4",
+  "answer": "November"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "5",
+  "run": "0",
+  "answer": "a03Wt00000JqnHwIAJ"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "5",
+  "run": "1",
+  "answer": "a03Wt00000JqnHwIAJ"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "5",
+  "run": "2",
+  "answer": "a03Wt00000JqnHwIAJ"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "5",
+  "run": "3",
+  "answer": "a03Wt00000JqnHwIAJ"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "5",
+  "run": "4",
+  "answer": "a03Wt00000JqnHwIAJ"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "6",
+  "run": "0",
+  "answer": "ka0Wt000000EnwvIAC"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "6",
+  "run": "1",
+  "answer": "ka0Wt000000EnwvIAC"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "6",
+  "run": "2",
+  "answer": "ka0Wt000000EnwvIAC"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "6",
+  "run": "3",
+  "answer": "ka0Wt000000EnwvIAC"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "6",
+  "run": "4",
+  "answer": "ka0Wt000000EnwvIAC"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "7",
+  "run": "0",
+  "answer": "ka0Wt000000EoD3IAK"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "7",
+  "run": "1",
+  "answer": "ka0Wt000000EpSUIA0"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "7",
+  "run": "2",
+  "answer": "ka0Wt000000EpSUIA0"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "7",
+  "run": "3",
+  "answer": "ka0Wt000000EoD3IAK"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "7",
+  "run": "4",
+  "answer": "ka0Wt000000EpSUIA0"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "8",
+  "run": "0",
+  "answer": "005Wt000003NIliIAG"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "8",
+  "run": "1",
+  "answer": "005Wt000003NIliIAG"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "8",
+  "run": "2",
+  "answer": "005Wt000003NGjuIAG"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "8",
+  "run": "3",
+  "answer": "005Wt000003NIliIAG"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "8",
+  "run": "4",
+  "answer": "005Wt000003NIliIAG"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "9",
+  "run": "0",
+  "answer": "MI"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "9",
+  "run": "1",
+  "answer": "MI"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "9",
+  "run": "2",
+  "answer": "MI"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "9",
+  "run": "3",
+  "answer": "MI"
+ },
+ {
+  "dataset": "crmarenapro",
+  "query": "9",
+  "run": "4",
+  "answer": "MI"
+ },
+ {
+  "dataset": "crmarenapro",
   "query": "10",
   "run": "0",
   "answer": "005Wt000003NDqDIAW"
@@ -711,271 +951,31 @@
   "dataset": "crmarenapro",
   "query": "13",
   "run": "3",
-  "answer": "005Wt000003NEa3IAG"
+  "answer": "005Wt000003NIXCIA4"
  },
  {
   "dataset": "crmarenapro",
   "query": "13",
   "run": "4",
-  "answer": "005Wt000003NEa3IAG"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "2",
-  "run": "0",
-  "answer": "ka0Wt000000Eq0MIAS"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "2",
-  "run": "1",
-  "answer": "ka0Wt000000Eq0MIAS"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "2",
-  "run": "2",
-  "answer": "ka0Wt000000Eq0MIAS"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "2",
-  "run": "3",
-  "answer": "ka0Wt000000Eq0MIAS"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "2",
-  "run": "4",
-  "answer": "ka0Wt000000Eq0MIAS"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "3",
-  "run": "0",
-  "answer": "Negotiation"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "3",
-  "run": "1",
-  "answer": "Negotiation"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "3",
-  "run": "2",
-  "answer": "Negotiation"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "3",
-  "run": "3",
-  "answer": "Negotiation"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "3",
-  "run": "4",
-  "answer": "Negotiation"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "4",
-  "run": "0",
-  "answer": "November"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "4",
-  "run": "1",
-  "answer": "November"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "4",
-  "run": "2",
-  "answer": "November"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "4",
-  "run": "3",
-  "answer": "November"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "4",
-  "run": "4",
-  "answer": "November"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "5",
-  "run": "0",
-  "answer": "a03Wt00000JqnHwIAJ"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "5",
-  "run": "1",
-  "answer": "a03Wt00000JqnHwIAJ"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "5",
-  "run": "2",
-  "answer": "a03Wt00000JqnHwIAJ"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "5",
-  "run": "3",
-  "answer": "a03Wt00000JqnHwIAJ"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "5",
-  "run": "4",
-  "answer": "a03Wt00000JqnHwIAJ"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "6",
-  "run": "0",
-  "answer": "ka0Wt000000EnwvIAC"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "6",
-  "run": "1",
-  "answer": "ka0Wt000000EnwvIAC"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "6",
-  "run": "2",
-  "answer": "ka0Wt000000EnwvIAC"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "6",
-  "run": "3",
-  "answer": "ka0Wt000000EnwvIAC"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "6",
-  "run": "4",
-  "answer": "ka0Wt000000EnwvIAC"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "7",
-  "run": "0",
-  "answer": "ka0Wt000000EpSUIA0"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "7",
-  "run": "1",
-  "answer": "ka0Wt000000EpSUIA0"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "7",
-  "run": "2",
-  "answer": "ka0Wt000000EoD3IAK"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "7",
-  "run": "3",
-  "answer": "ka0Wt000000EpSUIA0"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "7",
-  "run": "4",
-  "answer": "ka0Wt000000EoD3IAK"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "8",
-  "run": "0",
-  "answer": "005Wt000003NIliIAG"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "8",
-  "run": "1",
-  "answer": "005Wt000003NIliIAG"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "8",
-  "run": "2",
-  "answer": "005Wt000003NIliIAG"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "8",
-  "run": "3",
-  "answer": "005Wt000003NIliIAG"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "8",
-  "run": "4",
-  "answer": "005Wt000003NIliIAG"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "9",
-  "run": "0",
-  "answer": "MI"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "9",
-  "run": "1",
-  "answer": "MI"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "9",
-  "run": "2",
-  "answer": "MI"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "9",
-  "run": "3",
-  "answer": "MI"
- },
- {
-  "dataset": "crmarenapro",
-  "query": "9",
-  "run": "4",
-  "answer": "MI"
+  "answer": "005Wt000003NIXCIA4"
  },
  {
   "dataset": "googlelocal",
   "query": "1",
   "run": "0",
-  "answer": "Widows Peak Salon (4.86), City Textile (4.50), Nobel Textile Co (4.29), San Soo Dang (4.28), Nova Fabrics (3.33)"
+  "answer": "1. Widows Peak Salon (4.86), 2. City Textile (4.50), 3. Nobel Textile Co (4.29), 4. San Soo Dang (4.28), 5. Nova Fabrics (3.33)"
  },
  {
   "dataset": "googlelocal",
   "query": "1",
   "run": "1",
-  "answer": "Widows Peak Salon (4.86), City Textile (4.50), Nobel Textile Co (4.29), San Soo Dang (4.28), Nova Fabrics (3.33)"
+  "answer": "1. Widows Peak Salon (4.86), 2. City Textile (4.50), 3. Nobel Textile Co (4.29), 4. San Soo Dang (4.28), 5. Nova Fabrics (3.33)"
  },
  {
   "dataset": "googlelocal",
   "query": "1",
   "run": "2",
-  "answer": "Widows Peak Salon (4.86), City Textile (4.50), Nobel Textile Co (4.29), San Soo Dang (4.28), Nova Fabrics (3.33)"
+  "answer": "1. Widows Peak Salon (4.86), 2. City Textile (4.50), 3. Nobel Textile Co (4.29), 4. San Soo Dang (4.28), 5. Nova Fabrics (3.33)"
  },
  {
   "dataset": "googlelocal",
@@ -1023,31 +1023,31 @@
   "dataset": "googlelocal",
   "query": "3",
   "run": "0",
-  "answer": "Taba Rug Gallery (Mon\u2013Fri 10AM\u20137PM, 5.0); Beauty Divine Artistry (Mon\u2013Fri 9AM\u20138PM, 5.0); Mariscos el poblano (Mon 9AM\u20133:30AM, Thu open 24 hours, Tue/Wed/Fri 8AM\u20133:30PM, 5.0); TACOS LA CABANA (Mon & Fri 5\u201311PM, Tue\u2013Thu closed, 5.0); White Barn Candle Co (Mon\u2013Fri 10AM\u20139PM, 5.0)"
+  "answer": "Taba Rug Gallery (Mon\u2013Sat 10AM\u20137PM, Sun 11AM\u20136PM, 5.0); Beauty Divine Artistry (Mon\u2013Fri 9AM\u20138PM, Sat 10AM\u20137PM, Sun 11AM\u20136PM, 5.0); Mariscos el poblano (Mon 9AM\u20133:30AM, Tue/Wed 8AM\u20133:30PM, Thu Open 24 hours, Fri\u2013Sun 8AM\u20133:30PM, 5.0); White Barn Candle Co (Mon\u2013Sat 10AM\u20139PM, Sun 11AM\u20137PM, 5.0); TACOS LA CABANA (Mon 5\u201311PM, Tue\u2013Thu Closed, Fri\u2013Sun 5\u201311PM, 5.0)"
  },
  {
   "dataset": "googlelocal",
   "query": "3",
   "run": "1",
-  "answer": "Taba Rug Gallery (Mon\u2013Fri 10AM\u20137PM), avg rating 5.0; Beauty Divine Artistry (Mon\u2013Fri 9AM\u20138PM), avg rating 5.0; Mariscos el poblano (Thu open 24 hours, Mon 9AM\u20133:30AM, Tue/Wed/Fri 8AM\u20133:30PM), avg rating 5.0; White Barn Candle Co (Mon\u2013Fri 10AM\u20139PM), avg rating 5.0; TACOS LA CABANA (Mon and Fri 5\u201311PM), avg rating 5.0"
+  "answer": "Taba Rug Gallery (Mon\u2013Sat 10AM\u20137PM, Sun 11AM\u20136PM) \u2014 5.0; Beauty Divine Artistry (Mon\u2013Fri 9AM\u20138PM, Sat 10AM\u20137PM, Sun 11AM\u20136PM) \u2014 5.0; Mariscos el poblano (Mon 9AM\u20133:30AM, Thu open 24 hours, Tue/Wed/Fri\u2013Sun 8AM\u20133:30PM) \u2014 5.0; White Barn Candle Co (Mon\u2013Sat 10AM\u20139PM, Sun 11AM\u20137PM) \u2014 5.0; TACOS LA CABANA (Fri\u2013Mon 5\u201311PM, Tue\u2013Thu closed) \u2014 5.0"
  },
  {
   "dataset": "googlelocal",
   "query": "3",
   "run": "2",
-  "answer": "1) Taba Rug Gallery \u2014 Mon\u2013Sat 10AM\u20137PM, Sun 11AM\u20136PM \u2014 5.0; 2) Beauty Divine Artistry \u2014 Mon\u2013Fri 9AM\u20138PM, Sat 10AM\u20137PM, Sun 11AM\u20136PM \u2014 5.0; 3) Mariscos el poblano \u2014 Thu Open 24 hours, Mon 9AM\u20133:30AM, Tue/Wed/Fri\u2013Sun 8AM\u20133:30PM \u2014 5.0; 4) TACOS LA CABANA \u2014 Fri\u2013Mon 5\u201311PM, Tue\u2013Thu Closed \u2014 5.0; 5) White Barn Candle Co \u2014 Mon\u2013Sat 10AM\u20139PM, Sun 11AM\u20137PM \u2014 5.0"
+  "answer": "Taba Rug Gallery (Mon\u2013Fri 10AM\u20137PM, avg 5.0); Beauty Divine Artistry (Mon\u2013Fri 9AM\u20138PM, avg 5.0); Mariscos el poblano (Mon 9AM\u20133:30AM, Tue\u2013Wed 8AM\u20133:30PM, Thu Open 24 hours, Fri 8AM\u20133:30PM, avg 5.0); White Barn Candle Co (Mon\u2013Fri 10AM\u20139PM, avg 5.0); TACOS LA CABANA (Mon 5\u201311PM, Tue\u2013Thu Closed, Fri 5\u201311PM, avg 5.0)"
  },
  {
   "dataset": "googlelocal",
   "query": "3",
   "run": "3",
-  "answer": "1. Taba Rug Gallery \u2014 Mon\u2013Sat 10AM\u20137PM, Sun 11AM\u20136PM \u2014 5.00; 2. Beauty Divine Artistry \u2014 Mon\u2013Fri 9AM\u20138PM, Sat 10AM\u20137PM, Sun 11AM\u20136PM \u2014 5.00; 3. Mariscos el poblano \u2014 Mon 9AM\u20133:30AM, Tue/Wed 8AM\u20133:30PM, Thu Open 24 hours, Fri\u2013Sun 8AM\u20133:30PM \u2014 5.00; 4. White Barn Candle Co \u2014 Mon\u2013Sat 10AM\u20139PM, Sun 11AM\u20137PM \u2014 5.00; 5. TACOS LA CABANA \u2014 Mon 5\u201311PM, Tue\u2013Thu Closed, Fri\u2013Sun 5\u201311PM \u2014 5.00"
+  "answer": "Taba Rug Gallery (Mon\u2013Fri 10AM\u20137PM, avg 5.0); Beauty Divine Artistry (Mon\u2013Fri 9AM\u20138PM, avg 5.0); Mariscos el poblano (Mon 9AM\u20133:30AM, Tue/Wed 8AM\u20133:30PM, Thu Open 24 hours, Fri 8AM\u20133:30PM, avg 5.0); White Barn Candle Co (Mon\u2013Fri 10AM\u20139PM, avg 5.0); TACOS LA CABANA (Mon 5\u201311PM, Fri 5\u201311PM, Tue\u2013Thu closed, avg 5.0)"
  },
  {
   "dataset": "googlelocal",
   "query": "3",
   "run": "4",
-  "answer": "Taba Rug Gallery (Mon\u2013Sat 10AM\u20137PM, Sun 11AM\u20136PM; avg 5.0), Beauty Divine Artistry (Mon\u2013Fri 9AM\u20138PM, Sat 10AM\u20137PM, Sun 11AM\u20136PM; avg 5.0), Mariscos el poblano (Mon 9AM\u20133:30AM, Tue\u2013Wed 8AM\u20133:30PM, Thu Open 24 hours, Fri\u2013Sun 8AM\u20133:30PM; avg 5.0), TACOS LA CABANA (Mon 5\u201311PM, Tue\u2013Thu Closed, Fri\u2013Sun 5\u201311PM; avg 5.0), White Barn Candle Co (Mon\u2013Sat 10AM\u20139PM, Sun 11AM\u20137PM; avg 5.0)"
+  "answer": "Taba Rug Gallery (Mon\u2013Fri 10AM\u20137PM; Sat 10AM\u20137PM, Sun 11AM\u20136PM) \u2014 5.0; Beauty Divine Artistry (Mon\u2013Fri 9AM\u20138PM; Sat 10AM\u20137PM, Sun 11AM\u20136PM) \u2014 5.0; Mariscos el poblano (Thu Open 24 hours, Mon 9AM\u20133:30AM, Tue/Wed/Fri/Sat/Sun 8AM\u20133:30PM) \u2014 5.0; White Barn Candle Co (Mon\u2013Sat 10AM\u20139PM, Sun 11AM\u20137PM) \u2014 5.0; TACOS LA CABANA (Mon & Fri\u2013Sun 5\u201311PM, Tue\u2013Thu Closed) \u2014 5.0"
  },
  {
   "dataset": "googlelocal",
@@ -1065,13 +1065,13 @@
   "dataset": "googlelocal",
   "query": "4",
   "run": "2",
-  "answer": "Encino Dermatology & Laser: Alex Khadavi MD (19), The Boochyard @ Local Roots (17), Aurora Massage (14)"
+  "answer": "Encino Dermatology & Laser: Alex Khadavi MD \u2014 19; The Boochyard @ Local Roots \u2014 17; Aurora Massage \u2014 14"
  },
  {
   "dataset": "googlelocal",
   "query": "4",
   "run": "3",
-  "answer": "Encino Dermatology & Laser: Alex Khadavi MD (19), The Boochyard @ Local Roots (17), Aurora Massage (14)"
+  "answer": "Encino Dermatology & Laser: Alex Khadavi MD \u2014 19 reviews; The Boochyard @ Local Roots \u2014 17 reviews; Aurora Massage \u2014 14 reviews"
  },
  {
   "dataset": "googlelocal",
@@ -1083,43 +1083,43 @@
   "dataset": "music_brainz_20k",
   "query": "1",
   "run": "0",
-  "answer": "$1059.46 USD"
+  "answer": "$1,059.46 USD"
  },
  {
   "dataset": "music_brainz_20k",
   "query": "1",
   "run": "1",
-  "answer": "$1059.46"
+  "answer": "$1059.46 USD"
  },
  {
   "dataset": "music_brainz_20k",
   "query": "1",
   "run": "2",
-  "answer": "1059.46 USD"
+  "answer": "$1,059.46 USD"
  },
  {
   "dataset": "music_brainz_20k",
   "query": "1",
   "run": "3",
-  "answer": "$1059.46"
+  "answer": "$1,059.46 USD"
  },
  {
   "dataset": "music_brainz_20k",
   "query": "1",
   "run": "4",
-  "answer": "$1059.46 USD"
+  "answer": "$1,059.46 USD"
  },
  {
   "dataset": "music_brainz_20k",
   "query": "2",
   "run": "0",
-  "answer": "Amazon Music ($1,108.99 USD)"
+  "answer": "Amazon Music (approximately $1,108.99 USD)"
  },
  {
   "dataset": "music_brainz_20k",
   "query": "2",
   "run": "1",
-  "answer": "Amazon Music (1108.99 USD)"
+  "answer": "Amazon Music ($682.23 USD)"
  },
  {
   "dataset": "music_brainz_20k",
@@ -1131,13 +1131,13 @@
   "dataset": "music_brainz_20k",
   "query": "2",
   "run": "3",
-  "answer": "Amazon Music (1108.99 USD)"
+  "answer": "Amazon Music (1,108.99 USD)"
  },
  {
   "dataset": "music_brainz_20k",
   "query": "2",
   "run": "4",
-  "answer": "Amazon Music (1108.99 USD)"
+  "answer": "Amazon Music (approximately $1,108.99 USD)"
  },
  {
   "dataset": "music_brainz_20k",
@@ -1149,115 +1149,115 @@
   "dataset": "music_brainz_20k",
   "query": "3",
   "run": "1",
-  "answer": "Zo gaat het leven aan je voor \u2014 Syb van der Ploeg (total revenue $9,013.69 USD)"
+  "answer": "\"Zo gaat het leven aan je voor\" by Syb van der Ploeg \u2014 $9,013.69 USD"
  },
  {
   "dataset": "music_brainz_20k",
   "query": "3",
   "run": "2",
-  "answer": "\"Zo gaat het leven aan je voor\" by Syb van der Ploeg (album: Hillich fjoer | Heilig vuur), with $9,013.69 USD in total revenue"
+  "answer": "\"Zo gaat het leven aan je voor\" by Syb van der Ploeg \u2014 $9,013.69 USD"
  },
  {
   "dataset": "music_brainz_20k",
   "query": "3",
   "run": "3",
+  "answer": "\"Zo gaat het leven aan je voor\" by Syb van der Ploeg \u2014 $9,013.69 USD"
+ },
+ {
+  "dataset": "music_brainz_20k",
+  "query": "3",
+  "run": "4",
   "answer": "\"Zo gaat het leven aan je voor\" by Syb van der Ploeg \u2014 $9,013.69 USD total revenue"
  },
  {
-  "dataset": "music_brainz_20k",
-  "query": "3",
-  "run": "4",
-  "answer": "\"Zo gaat het leven aan je voor\" by Syb van der Ploeg \u2014 9013.69 USD"
- },
- {
   "dataset": "stockindex",
   "query": "1",
   "run": "0",
-  "answer": "399001.SZ (Shenzhen Component Index, Shenzhen Stock Exchange) \u2014 average intraday volatility \u2248 0.01834 (1.83%)"
+  "answer": "399001.SZ (Shenzhen Component Index, Shenzhen Stock Exchange) \u2014 average intraday volatility of about 1.83% ((High\u2212Low)/Open) since 2020"
  },
  {
   "dataset": "stockindex",
   "query": "1",
   "run": "1",
-  "answer": "399001.SZ"
+  "answer": "399001.SZ \u2014 the SZSE Component Index (Shenzhen Stock Exchange), with an average intraday volatility of about 0.0183 (1.83%) since 2020"
  },
  {
   "dataset": "stockindex",
   "query": "1",
   "run": "2",
-  "answer": "399001.SZ (Shenzhen Stock Exchange) \u2014 average intraday volatility \u2248 0.0183 (1.83%)"
+  "answer": "Shenzhen Stock Exchange \u2014 SZSE Component Index (399001.SZ), with an average intraday volatility of ~1.83% ((High\u2212Low)/Open) since 2020"
  },
  {
   "dataset": "stockindex",
   "query": "1",
   "run": "3",
-  "answer": "Shenzhen Stock Exchange \u2014 the Shenzhen Component Index (399001.SZ), with an average intraday volatility of approximately 1.83% ((High \u2212 Low) / Open) since 2020"
+  "answer": "399001.SZ \u2014 the Shenzhen Stock Exchange (Shenzhen Component Index), with an average intraday volatility of ~1.83% ((High\u2212Low)/Open) since 2020"
  },
  {
   "dataset": "stockindex",
   "query": "1",
   "run": "4",
-  "answer": "399001.SZ \u2014 the Shenzhen Component Index (Shenzhen Stock Exchange), with an average intraday volatility of about 1.83% ((High\u2212Low)/Open, 342 trading days since 2020-01-01)"
+  "answer": "399001.SZ (Shenzhen Stock Exchange Component Index), with an average intraday volatility of ~0.01834 (1.83%) since 2020"
  },
  {
   "dataset": "stockindex",
   "query": "2",
   "run": "0",
-  "answer": "IXIC (NASDAQ Composite) \u2014 131 up days vs 120 down days in 2018; it was the only North American index with more up days than down days (NYA: 125 up / 126 down; GSPTSE: 115 up / 135 down)"
+  "answer": "IXIC (NASDAQ) \u2014 131 up days vs 120 down days"
  },
  {
   "dataset": "stockindex",
   "query": "2",
   "run": "1",
-  "answer": "IXIC (NASDAQ Composite) \u2014 131 up days vs 120 down days in 2018"
+  "answer": "IXIC (NASDAQ Composite) \u2014 131 up days vs 120 down days; it was the only North American index with more up days than down days in 2018 (NYA: 125 up / 126 down; GSPTSE: 115 up / 135 down)"
  },
  {
   "dataset": "stockindex",
   "query": "2",
   "run": "2",
-  "answer": "IXIC (NASDAQ Composite) \u2014 131 up days vs 120 down days in 2018 (the only North American index with more up than down days; NYA 125 up/126 down, GSPTSE 115 up/135 down)"
+  "answer": "IXIC (NASDAQ) \u2014 131 up days vs 120 down days in 2018"
  },
  {
   "dataset": "stockindex",
   "query": "2",
   "run": "3",
-  "answer": "NASDAQ (IXIC) \u2014 131 up days vs 120 down days in 2018"
+  "answer": "IXIC (NASDAQ Composite) \u2014 131 up days vs 120 down days in 2018 (NYA: 125 up/126 down and GSPTSE: 115 up/135 down did not)"
  },
  {
   "dataset": "stockindex",
   "query": "2",
   "run": "4",
-  "answer": "IXIC (NASDAQ Composite) \u2014 131 up days vs 120 down days in 2018; NYA (125 up / 126 down) and GSPTSE (115 up / 135 down) did not."
+  "answer": "IXIC (NASDAQ Composite) \u2014 131 up days vs. 120 down days in 2018"
  },
  {
   "dataset": "stockindex",
   "query": "3",
   "run": "0",
-  "answer": "IXIC (NASDAQ Composite) \u2014 United States, +382.7%; 399001.SZ (Shenzhen Component) \u2014 China, +137.5%; NSEI (Nifty 50) \u2014 India, +135.8%; GDAXI (DAX) \u2014 Germany, +134.7%; TWII (TAIEX) \u2014 Taiwan, +129.8%"
+  "answer": "IXIC/NASDAQ Composite (United States, +382.7%), 399001.SZ/SZSE Component (China, +137.5%), GDAXI/DAX (Germany, +134.7%), TWII (Taiwan, +129.8%), N225/Nikkei 225 (Japan, +115.9%) \u2014 note NSEI (India, +135.8%) would rank 3rd but only has data from 2007, not 2000."
  },
  {
   "dataset": "stockindex",
   "query": "3",
   "run": "1",
-  "answer": "IXIC (NASDAQ Composite, United States, +382.7%); NSEI (NIFTY 50, India, +135.8%); 399001.SZ (Shenzhen Component, China, +134.8%); GDAXI (DAX, Germany, +134.7%); TWII (TAIEX, Taiwan, +129.8%)"
+  "answer": "IXIC (NASDAQ Composite) \u2014 United States, +383%; NSEI (Nifty 50) \u2014 India, +136%; 399001.SZ (Shenzhen Component) \u2014 China, +135%; GDAXI (DAX) \u2014 Germany, +135%; TWII (TAIEX) \u2014 Taiwan, +130%"
  },
  {
   "dataset": "stockindex",
   "query": "3",
   "run": "2",
-  "answer": "NASDAQ Composite (IXIC) \u2014 United States, +382.7%; Nifty 50 (NSEI) \u2014 India, +135.8%; Shenzhen Component (399001.SZ) \u2014 China, +134.8%; DAX (GDAXI) \u2014 Germany, +134.7%; TAIEX (TWII) \u2014 Taiwan, +129.8%"
+  "answer": "IXIC/NASDAQ Composite (NASDAQ, United States) +382.7%; NSEI/Nifty 50 (National Stock Exchange of India, India) +135.8%; 399001.SZ/SZSE Component (Shenzhen Stock Exchange, China) +134.8%; GDAXI/DAX (Frankfurt Stock Exchange, Germany) +134.7%; TWII (Taiwan Stock Exchange, Taiwan) +129.8%"
  },
  {
   "dataset": "stockindex",
   "query": "3",
   "run": "3",
-  "answer": "IXIC (NASDAQ, United States) +382.69%; NSEI (National Stock Exchange of India, India) +135.84%; 399001.SZ (Shenzhen Stock Exchange, China) +134.75%; GDAXI (Frankfurt Stock Exchange, Germany) +134.70%; TWII (Taiwan Stock Exchange, Taiwan) +129.82%"
+  "answer": "IXIC (NASDAQ Composite, NASDAQ \u2014 United States, +383%); NSEI (Nifty 50, National Stock Exchange of India \u2014 India, +136%); 399001.SZ (SZSE Component, Shenzhen Stock Exchange \u2014 China, +135%); GDAXI (DAX, Frankfurt Stock Exchange \u2014 Germany, +135%); TWII (TAIEX, Taiwan Stock Exchange \u2014 Taiwan, +130%)"
  },
  {
   "dataset": "stockindex",
   "query": "3",
   "run": "4",
-  "answer": "IXIC (NASDAQ Composite, United States, +382.7%); NSEI (NIFTY 50, India, +135.8%); 399001.SZ (Shenzhen Component, China, +134.8%); GDAXI (DAX, Germany, +134.7%); TWII (Taiwan Weighted Index, Taiwan, +129.8%)"
+  "answer": "NASDAQ Composite (IXIC) \u2013 United States, +383%; Nifty 50 (NSEI) \u2013 India, +136%; SZSE Component (399001.SZ) \u2013 China, +135%; DAX (GDAXI) \u2013 Germany, +135%; TAIEX (TWII) \u2013 Taiwan, +130%"
  },
  {
   "dataset": "stockmarket",
@@ -1269,13 +1269,13 @@
   "dataset": "stockmarket",
   "query": "1",
   "run": "1",
-  "answer": "18.44 USD (18.440000534057617, on 2020-01-03)"
+  "answer": "$18.44"
  },
  {
   "dataset": "stockmarket",
   "query": "1",
   "run": "2",
-  "answer": "$18.44 (18.440000534057617, on 2020-01-03, ticker REAL)"
+  "answer": "$18.44"
  },
  {
   "dataset": "stockmarket",
@@ -1293,7 +1293,7 @@
   "dataset": "stockmarket",
   "query": "2",
   "run": "0",
-  "answer": "31 ETFs \u2014 UVXY, GUSH, COM, RTL, JDST, HYUP, SOXS, VPC, DUST, LBJ, PTIN, GFIN, ERX, LABD, VIXY, BZQ, JNUG, SDOW, BOIL, YANG, EDZ, FAZ, XES, TZA, SSG, MDY, TECS, LABU, XOP, FXP, JPN"
+  "answer": "31 ETFs \u2014 BOIL, BZQ, COM, DUST, EDZ, ERX, FAZ, FXP, GFIN, GUSH, HYUP, JDST, JNUG, JPN, LABD, LABU, LBJ, MDY, PTIN, RTL, SDOW, SOXS, SSG, TECS, TZA, UVXY, VIXY, VPC, XES, XOP, YANG"
  },
  {
   "dataset": "stockmarket",
@@ -1317,37 +1317,37 @@
   "dataset": "stockmarket",
   "query": "2",
   "run": "4",
-  "answer": "31 ETFs \u2014 UVXY, GUSH, COM, RTL, JDST, HYUP, SOXS, VPC, DUST, LBJ, PTIN, GFIN, ERX, LABD, VIXY, BZQ, JNUG, SDOW, BOIL, YANG, EDZ, FAZ, XES, TZA, SSG, MDY, TECS, LABU, XOP, FXP, JPN"
+  "answer": "31 ETFs \u2014 BOIL, BZQ, COM, DUST, EDZ, ERX, FAZ, FXP, GFIN, GUSH, HYUP, JDST, JNUG, JPN, LABD, LABU, LBJ, MDY, PTIN, RTL, SDOW, SOXS, SSG, TECS, TZA, UVXY, VIXY, VPC, XES, XOP, YANG"
  },
  {
   "dataset": "stockmarket",
   "query": "3",
   "run": "0",
+  "answer": "Frontier Communications Corporation (FTR) 254,397.63; Correvio Pharma Corp. (CORV) 145,247.83; CBAK Energy Technology, Inc. (CBAT) 86,223.32; Sypris Solutions, Inc. (SYPR) 36,836.36; Apex Global Brands Inc. (APEX) 23,781.42; DASAN Zhone Solutions, Inc. (DZSI) 15,578.66; BIO-key International, Inc. (BKYI) 10,988.14; Pacific Ethanol, Inc. (PEIX) 10,706.72; China Ceramics Co., Ltd. (CCCL) 4,366.80; Synthesis Energy Systems, Inc. (SES) 2,390.51; Sunesis Pharmaceuticals, Inc. (SNSS) 781.82; CounterPath Corporation (CPAH) 375.49; Ocean Power Technologies, Inc. (OPTT) 254.15; Ideanomics, Inc. (IDEX) 10.28; Future FinTech Group Inc. (FTFT) 9.85 \u2014 all in shares/day"
+ },
+ {
+  "dataset": "stockmarket",
+  "query": "3",
+  "run": "1",
   "answer": "Frontier Communications Corporation (FTR) 254,397.63; Correvio Pharma Corp. (CORV) 145,247.83; CBAK Energy Technology, Inc. (CBAT) 86,223.32; Sypris Solutions, Inc. (SYPR) 36,836.36; Apex Global Brands Inc. (APEX) 23,781.42; DASAN Zhone Solutions, Inc. (DZSI) 15,578.66; BIO-key International, Inc. (BKYI) 10,988.14; Pacific Ethanol, Inc. (PEIX) 10,706.72; China Ceramics Co., Ltd. (CCCL) 4,366.80; Synthesis Energy Systems, Inc. (SES) 2,390.51; Sunesis Pharmaceuticals, Inc. (SNSS) 781.82; CounterPath Corporation (CPAH) 375.49; Ocean Power Technologies, Inc. (OPTT) 254.15; Ideanomics, Inc. (IDEX) 10.28; Future FinTech Group Inc. (FTFT) 9.85 \u2014 average daily shares traded in 2008"
  },
  {
   "dataset": "stockmarket",
   "query": "3",
-  "run": "1",
-  "answer": "Frontier Communications Corporation (FTR) 254,397.63; Correvio Pharma Corp. (CORV) 145,247.83; CBAK Energy Technology, Inc. (CBAT) 86,223.32; Sypris Solutions, Inc. (SYPR) 36,836.36; Apex Global Brands Inc. (APEX) 23,781.42; DASAN Zhone Solutions, Inc. (DZSI) 15,578.66; BIO-key International, Inc. (BKYI) 10,988.14; Pacific Ethanol, Inc. (PEIX) 10,706.72; China Ceramics Co., Ltd. (CCCL) 4,366.80; Synthesis Energy Systems, Inc. (SES) 2,390.51; Sunesis Pharmaceuticals, Inc. (SNSS) 781.82; CounterPath Corporation (CPAH) 375.49; Ocean Power Technologies, Inc. (OPTT) 254.15; Ideanomics, Inc. (IDEX) 10.28; Future FinTech Group Inc. (FTFT) 9.85"
- },
- {
-  "dataset": "stockmarket",
-  "query": "3",
   "run": "2",
-  "answer": "Frontier Communications Corporation (FTR) 254397.63; Correvio Pharma Corp. (CORV) 145247.83; CBAK Energy Technology, Inc. (CBAT) 86223.32; Sypris Solutions, Inc. (SYPR) 36836.36; Apex Global Brands Inc. (APEX) 23781.42; DASAN Zhone Solutions, Inc. (DZSI) 15578.66; BIO-key International, Inc. (BKYI) 10988.14; Pacific Ethanol, Inc. (PEIX) 10706.72; China Ceramics Co., Ltd. (CCCL) 4366.80; Synthesis Energy Systems, Inc. (SES) 2390.51; Sunesis Pharmaceuticals, Inc. (SNSS) 781.82; CounterPath Corporation (CPAH) 375.49; Ocean Power Technologies, Inc. (OPTT) 254.15; Ideanomics, Inc. (IDEX) 10.28; Future FinTech Group Inc. (FTFT) 9.85"
+  "answer": "Frontier Communications Corporation (FTR) 254,397.63; Correvio Pharma Corp. (CORV) 145,247.83; CBAK Energy Technology, Inc. (CBAT) 86,223.32; Sypris Solutions, Inc. (SYPR) 36,836.36; Apex Global Brands Inc. (APEX) 23,781.42; DASAN Zhone Solutions, Inc. (DZSI) 15,578.66; BIO-key International, Inc. (BKYI) 10,988.14; Pacific Ethanol, Inc. (PEIX) 10,706.72; China Ceramics Co., Ltd. (CCCL) 4,366.80; Synthesis Energy Systems, Inc. (SES) 2,390.51; Sunesis Pharmaceuticals, Inc. (SNSS) 781.82; CounterPath Corporation (CPAH) 375.49; Ocean Power Technologies, Inc. (OPTT) 254.15; Ideanomics, Inc. (IDEX) 10.28; Future FinTech Group Inc. (FTFT) 9.85 \u2014 all values are average daily shares traded in 2008"
  },
  {
   "dataset": "stockmarket",
   "query": "3",
   "run": "3",
-  "answer": "Frontier Communications Corporation 254397.63; Correvio Pharma Corp. 145247.83; CBAK Energy Technology, Inc. 86223.32; Sypris Solutions, Inc. 36836.36; Apex Global Brands Inc. 23781.42; DASAN Zhone Solutions, Inc. 15578.66; BIO-key International, Inc. 10988.14; Pacific Ethanol, Inc. 10706.72; China Ceramics Co., Ltd. 4366.80; Synthesis Energy Systems, Inc. 2390.51; Sunesis Pharmaceuticals, Inc. 781.82; CounterPath Corporation 375.49; Ocean Power Technologies, Inc. 254.15; Ideanomics, Inc. 10.28; Future FinTech Group Inc. 9.85 (shares/day)"
+  "answer": "Frontier Communications Corporation (FTR) 254,397.63; Correvio Pharma Corp. (CORV) 145,247.83; CBAK Energy Technology, Inc. (CBAT) 86,223.32; Sypris Solutions, Inc. (SYPR) 36,836.36; Apex Global Brands Inc. (APEX) 23,781.42; DASAN Zhone Solutions, Inc. (DZSI) 15,578.66; BIO-key International, Inc. (BKYI) 10,988.14; Pacific Ethanol, Inc. (PEIX) 10,706.72; China Ceramics Co., Ltd. (CCCL) 4,366.80; Synthesis Energy Systems, Inc. (SES) 2,390.51; Sunesis Pharmaceuticals, Inc. (SNSS) 781.82; CounterPath Corporation (CPAH) 375.49; Ocean Power Technologies, Inc. (OPTT) 254.15; Ideanomics, Inc. (IDEX) 10.28; Future FinTech Group Inc. (FTFT) 9.85 \u2014 average daily shares traded in 2008"
  },
  {
   "dataset": "stockmarket",
   "query": "3",
   "run": "4",
-  "answer": "Frontier Communications Corporation: 254,397.63; Correvio Pharma Corp.: 145,247.83; CBAK Energy Technology, Inc.: 86,223.32; Sypris Solutions, Inc.: 36,836.36; Apex Global Brands Inc.: 23,781.42; DASAN Zhone Solutions, Inc.: 15,578.66; BIO-key International, Inc.: 10,988.14; Pacific Ethanol, Inc.: 10,706.72; China Ceramics Co., Ltd.: 4,366.80; Synthesis Energy Systems, Inc.: 2,390.51; Sunesis Pharmaceuticals, Inc.: 781.82; CounterPath Corporation: 375.49; Ocean Power Technologies, Inc.: 254.15; Ideanomics, Inc.: 10.28; Future FinTech Group Inc.: 9.85"
+  "answer": "Frontier Communications Corporation (FTR) 254,397.63; Correvio Pharma Corp. (CORV) 145,247.83; CBAK Energy Technology, Inc. (CBAT) 86,223.32; Sypris Solutions, Inc. (SYPR) 36,836.36; Apex Global Brands Inc. (APEX) 23,781.42; DASAN Zhone Solutions, Inc. (DZSI) 15,578.66; BIO-key International, Inc. (BKYI) 10,988.14; Pacific Ethanol, Inc. (PEIX) 10,706.72; China Ceramics Co., Ltd. (CCCL) 4,366.80; Synthesis Energy Systems, Inc. (SES) 2,390.51; Sunesis Pharmaceuticals, Inc. (SNSS) 781.82; CounterPath Corporation (CPAH) 375.49; Ocean Power Technologies, Inc. (OPTT) 254.15; Ideanomics, Inc. (IDEX) 10.28; Future FinTech Group Inc. (FTFT) 9.85 \u2014 average daily shares traded in 2008"
  },
  {
   "dataset": "stockmarket",
@@ -1419,31 +1419,31 @@
   "dataset": "yelp",
   "query": "1",
   "run": "1",
-  "answer": "3.55"
+  "answer": "3.50 (average of the 8 Indianapolis businesses' ratings; 3.4975 unrounded)"
  },
  {
   "dataset": "yelp",
   "query": "1",
   "run": "2",
-  "answer": "3.50 stars"
+  "answer": "3.55 (average rating across all 117 reviews of the 8 Indianapolis, IN businesses; equal-weighted per-business average = 3.50)"
  },
  {
   "dataset": "yelp",
   "query": "1",
   "run": "3",
-  "answer": "3.55"
+  "answer": "3.50 stars (average of the 8 Indianapolis, IN businesses' ratings; 3.4975)"
  },
  {
   "dataset": "yelp",
   "query": "1",
   "run": "4",
-  "answer": "3.50"
+  "answer": "3.50 stars (average of the 8 Indianapolis, IN businesses' ratings = 3.4975)"
  },
  {
   "dataset": "yelp",
   "query": "2",
   "run": "0",
-  "answer": "Pennsylvania (PA), with 662 reviews and an average rating of 3.70"
+  "answer": "Pennsylvania (PA) \u2014 662 reviews, average rating 3.70"
  },
  {
   "dataset": "yelp",
@@ -1455,22 +1455,22 @@
   "dataset": "yelp",
   "query": "2",
   "run": "2",
-  "answer": "Pennsylvania (PA), with 662 reviews and an average rating of 3.70"
- },
- {
-  "dataset": "yelp",
-  "query": "2",
-  "run": "3",
-  "answer": "Pennsylvania (PA), with 662 reviews and an average rating of 3.70"
- },
- {
-  "dataset": "yelp",
-  "query": "2",
-  "run": "4",
   "answer": "Pennsylvania (PA) \u2014 662 reviews, average rating 3.70"
  },
  {
   "dataset": "yelp",
+  "query": "2",
+  "run": "3",
+  "answer": "Pennsylvania (PA), with 662 reviews and an average rating of 3.70"
+ },
+ {
+  "dataset": "yelp",
+  "query": "2",
+  "run": "4",
+  "answer": "Pennsylvania (PA), with 662 reviews and an average rating of 3.70 stars"
+ },
+ {
+  "dataset": "yelp",
   "query": "3",
   "run": "0",
   "answer": "35"
@@ -1503,91 +1503,91 @@
   "dataset": "yelp",
   "query": "4",
   "run": "0",
-  "answer": "Restaurants, with 27 credit-card-accepting businesses and an average rating of 3.63"
+  "answer": "Restaurants \u2014 27 credit-card-accepting businesses, average rating 3.63"
  },
  {
   "dataset": "yelp",
   "query": "4",
   "run": "1",
-  "answer": "Restaurants (27 businesses accepting credit cards), average rating 3.63"
+  "answer": "Restaurants \u2014 27 credit-card-accepting businesses, average rating \u2248 3.63 (out of 5)"
  },
  {
   "dataset": "yelp",
   "query": "4",
   "run": "2",
-  "answer": "Restaurants (27 businesses accepting credit cards), average rating 3.63"
+  "answer": "Restaurants \u2014 27 credit-card-accepting businesses, average rating 3.63"
  },
  {
   "dataset": "yelp",
   "query": "4",
   "run": "3",
-  "answer": "Restaurants (27 credit-card-accepting businesses), average rating 3.63"
+  "answer": "Restaurants \u2014 27 credit-card-accepting businesses, average rating 3.63 (out of 5)"
  },
  {
   "dataset": "yelp",
   "query": "4",
   "run": "4",
-  "answer": "Restaurants (27 businesses accepting credit cards), average rating 3.63"
+  "answer": "Restaurants \u2014 27 businesses, average rating 3.63"
  },
  {
   "dataset": "yelp",
   "query": "5",
   "run": "0",
-  "answer": "Pennsylvania (PA) \u2014 8 businesses offering WiFi, average rating 3.48 stars"
- },
- {
-  "dataset": "yelp",
-  "query": "5",
-  "run": "1",
-  "answer": "Pennsylvania (PA) \u2014 8 businesses offering WiFi, average rating 3.48"
- },
- {
-  "dataset": "yelp",
-  "query": "5",
-  "run": "2",
   "answer": "Pennsylvania (PA), with 8 WiFi-offering businesses and an average rating of 3.48"
  },
  {
   "dataset": "yelp",
   "query": "5",
+  "run": "1",
+  "answer": "Pennsylvania (PA), with 8 WiFi-offering businesses and an average rating of 3.48"
+ },
+ {
+  "dataset": "yelp",
+  "query": "5",
+  "run": "2",
+  "answer": "Pennsylvania (PA) \u2014 8 businesses offering WiFi, average rating \u2248 3.48 stars"
+ },
+ {
+  "dataset": "yelp",
+  "query": "5",
   "run": "3",
-  "answer": "Pennsylvania (PA) \u2014 8 businesses offering WiFi, average rating 3.48"
+  "answer": "Pennsylvania (PA) \u2014 8 WiFi-offering businesses, average rating 3.48 stars"
  },
  {
   "dataset": "yelp",
   "query": "5",
   "run": "4",
-  "answer": "Pennsylvania (PA) \u2014 8 businesses offering WiFi, average rating 3.48"
+  "answer": "Pennsylvania (PA), with 8 WiFi-offering businesses and an average rating of 3.48"
  },
  {
   "dataset": "yelp",
   "query": "6",
   "run": "0",
-  "answer": "Coffee House Too Cafe \u2014 average rating 4.375 (16 reviews); categories: Restaurants, Breakfast & Brunch, American (New), Cafes"
+  "answer": "Coffee House Too Cafe (business_id businessid_9), average rating 4.375 from 16 reviews \u2014 categories: Restaurants, Breakfast & Brunch, American (New), Cafes"
  },
  {
   "dataset": "yelp",
   "query": "6",
   "run": "1",
-  "answer": "Coffee House Too Cafe (avg rating 4.375) \u2014 categories: Restaurants, Breakfast & Brunch, American (New), Cafes"
+  "answer": "Coffee House Too Cafe \u2014 average rating 4.375 (16 reviews); categories: Restaurants, Breakfast & Brunch, American (New), Cafes"
  },
  {
   "dataset": "yelp",
   "query": "6",
   "run": "2",
-  "answer": "Coffee House Too Cafe \u2014 average rating 4.375; categories: Restaurants, Breakfast & Brunch, American (New), Cafes"
+  "answer": "Coffee House Too Cafe \u2014 average rating 4.375 (16 reviews, Jan 1\u2013Jun 30, 2016); categories: Restaurants, Breakfast & Brunch, American (New), Cafes"
  },
  {
   "dataset": "yelp",
   "query": "6",
   "run": "3",
-  "answer": "Coffee House Too Cafe \u2014 average rating 4.375 (16 reviews); categories: Restaurants, Breakfast & Brunch, American (New), Cafes"
+  "answer": "Coffee House Too Cafe \u2014 average rating 4.375 (16 reviews, Jan 1\u2013Jun 30 2016); categories: Restaurants, Breakfast & Brunch, American (New), Cafes"
  },
  {
   "dataset": "yelp",
   "query": "6",
   "run": "4",
-  "answer": "Coffee House Too Cafe \u2014 average rating 4.375 (16 reviews Jan 1\u2013Jun 30, 2016); categories: Restaurants, Breakfast & Brunch, American (New), Cafes"
+  "answer": "Coffee House Too Cafe \u2014 average rating 4.375 (16 reviews); categories: Restaurants, Breakfast & Brunch, American (New), Cafes"
  },
  {
   "dataset": "yelp",
@@ -1605,7 +1605,7 @@
   "dataset": "yelp",
   "query": "7",
   "run": "2",
-  "answer": "Restaurants (58 reviews), Food (38), American (New) (24), Shopping (20), Breakfast & Brunch (19)"
+  "answer": "Restaurants (58), Food (38), American (New) (24), Shopping (20), Breakfast & Brunch (19)"
  },
  {
   "dataset": "yelp",


### PR DESCRIPTION
## Phoenix-CLI: Leaderboard Submission (isolated rerun, replaces the 2026-08-30 corpus)

**Agent name:** Phoenix-CLI
**Backbone LLM:** `claude-opus-5`
**Hints:** Yes (`db_description_withhint.txt`)
**Tuned prompt:** No. Generic data-analyst framing plus the data-access helper's usage; no DAB-specific rules, parsing conventions, or answer shapes.
**Trials:** 5 per query, 54 queries, 12 datasets = 270 runs
**Stratified Pass@1:** **0.7556**

## Why this is a rerun

The first corpus on this PR ran the agent with the dataset directory as its working directory, so every query folder sat beside it. Six of 270 traces opened `ground_truth.csv` or `validate.py` and five passed on what they read (maintainer comment above; our sweep confirmed it). That corpus is withdrawn. Every run below was produced with the evaluation material unreadable to the agent, and the traces carry the evidence.

## Isolation (structural, verified per run)

- **Separate Unix user.** The agent runs as an unprivileged user (`dabrun`) whose readable filesystem holds only each dataset's `db_config.yaml`, schema descriptions, and data files, in a root-owned read-only tree. The clone, its git history, ground truth, validators, prior answers, and `leaderboard_submissions/` live under the operator's home, mode 700.
- **Preflight that can fail.** Before any run, the runner (a) plants a canary ground truth and requires the sweep to detect it, (b) walks the whole filesystem *as the agent user* and requires zero readable eval material, (c) walks the operator home judging every eval-shaped file by mode bits for a stranger, (d) resolves `claude`/`codex`/`agy` on the agent's PATH and requires the refusing shims (exit 42). The first run on one node was refused by this gate because a forgotten world-readable second clone existed; it was closed before any run started.
- **Per-run hygiene.** Fresh scratch working directory per run, private `/tmp` and `/var/tmp` via a mount namespace, wall-clock budget enforced inside the agent's own process chain.
- **No web tools.** `--disallowedTools WebSearch WebFetch`; web tool calls across all traces: **0**.
- **Two nodes, same mechanism.** Runs were produced on two Linux machines set up identically (Claude Code CLI 2.1.237 for 7 runs, 2.1.252 for 263 runs); each run's `isolation.json` records which.
- **Evidence.** Every run directory in the traces contains `isolation.json` (agent uid, sweep results, shim checks, claude version, data-door check, manifest hash) next to `stream.jsonl`; the preflight records are under `preflight/`.

Tool usage across all traces: `Bash` 3493, `Read` 93, `ToolSearch` 1.
Nested model-CLI attempts: 0.

## Results

| Dataset | Pass@1 |
|---|---|
| bookreview | 1.00 (15/15) |
| music_brainz_20k | 1.00 (15/15) |
| stockindex | 1.00 (15/15) |
| stockmarket | 1.00 (25/25) |
| yelp | 0.91 (32/35) |
| googlelocal | 0.90 (18/20) |
| crmarenapro | 0.77 (50/65) |
| PANCANCER_ATLAS | 0.67 (10/15) |
| PATENTS | 0.67 (10/15) |
| DEPS_DEV_V1 | 0.50 (5/10) |
| GITHUB_REPOS | 0.35 (7/20) |
| agnews | 0.30 (6/20) |
| **Stratified Pass@1** | **0.7556** |

Micro (mean over all 270 runs): 0.7704.
Credible-only micro (passes on the three validators that accept content-free answers, `agnews/query4`, `bookreview/query1`, `crmarenapro/query1`, counted as failures; see #93): 0.7296.

## Execution traces

All 270 `stream.jsonl` traces with their per-run `isolation.json` and the preflight records, laid out `query_<dataset>/query<N>/run_<R>/`, as a release asset:

https://github.com/marc-shade/DataAgentBench/releases/tag/phoenix-cli-traces-2026-09-04

The runner, the isolation tool, and the node setup script are in the same release so the mechanism can be reproduced.
