### PR TITLE
[Leaderboard] Qwen3.8-Flash-Next (DAB scaffold, hints): 70.87% Pass@1

### DIFF
--- a/leaderboard_submissions/qwen38flash_parallel_v1/README.md
+++ b/leaderboard_submissions/qwen38flash_parallel_v1/README.md
@@ -1,0 +1,104 @@
+# Qwen3.8-Flash-Next with the DAB DataAgent scaffold
+
+This submission contains five independent runs of every official query: **12 datasets, 54 queries, 270 trials**. The agent is the built-in DAB DataAgent with a Qwen-compatible OpenAI client and dataset-level parallel scheduling. Hints were used. The dataset-weighted **Pass@1 is 0.7086721612 (70.87%)**, before maintainer review.
+
+## Results and coverage
+
+`results.json` contains exactly one `{dataset, query, run, answer}` object per trial, with run IDs `0`–`4`. Answers were copied verbatim from `final_agent.json`. All 270 attempts are included: 265 returned an answer and five ended in context-limit errors. The five failures have `answer: ""` and count as non-passes. No retries, answer selection, or replacement runs were used in this batch.
+
+| Dataset | Passing trials | Pass@1 |
+| --- | ---: | ---: |
+| DEPS_DEV_V1 | 5 / 10 | 0.5000 |
+| GITHUB_REPOS | 11 / 20 | 0.5500 |
+| PANCANCER_ATLAS | 10 / 15 | 0.6667 |
+| PATENTS | 6 / 15 | 0.4000 |
+| agnews | 6 / 20 | 0.3000 |
+| bookreview | 15 / 15 | 1.0000 |
+| crmarenapro | 57 / 65 | 0.8769 |
+| googlelocal | 14 / 20 | 0.7000 |
+| music_brainz_20k | 14 / 15 | 0.9333 |
+| stockindex | 15 / 15 | 1.0000 |
+| stockmarket | 18 / 25 | 0.7200 |
+| yelp | 30 / 35 | 0.8571 |
+| **Mean over datasets** | **201 / 270 overall** | **0.7087** |
+
+The unweighted trial average is 201/270 = 0.7444444444; it is not the leaderboard score. The score above first averages each query's five outcomes within its dataset, then gives each dataset equal weight. Failures remain in all denominators. `metrics.json` and `trial_scores.json` provide the detailed calculations.
+
+The batch ran on 2026-09-11 from 17:41:21 to 22:24:39 UTC+08:00. The recorded peak concurrency was 12; no two tasks from the same dataset overlapped. The maximum concurrency is an execution setting, not an additional model sample budget.
+
+## Agent and inference configuration
+
+- **Agent:** DAB built-in DataAgent, adapted for a Qwen OpenAI-compatible endpoint.
+- **Backbone:** `Qwen/Qwen3.8-Flash-Next`, self-hosted with vLLM; this is the locally hosted checkpoint, not the managed Qwen3.8-Flash API.
+- **Hints:** Yes, `db_description.txt` plus `db_description_withhint.txt`.
+- **Tuned prompt:** No additional task-specific prompt. The standard scaffold system prompt is retained; the Qwen dispatch branch uses the existing `locals()[storage_key]` tool-result access instruction.
+- **Tools:** `query_db`, `list_db`, `execute_python`, `return_answer`.
+- **Requested sampling:** temperature 1.0, top_p 0.95, top_k 20, min_p 0.0, presence_penalty 0.0, repetition_penalty 1.0, max_tokens 131072.
+- **Thinking:** enabled; returned reasoning is preserved in subsequent assistant messages; requested reasoning_effort is `xhigh`.
+- **Budgets:** up to 300 iterations, 7200-second LLM timeout, 600-second Python execution timeout. No sampling seed was recorded.
+- **Serving:** 8 NVIDIA L40S GPUs, tensor parallelism 8, bfloat16 checkpoint configuration, 262144-token context. The observed vLLM version is `0.1.dev20073+g8e685d198`; full deployment metadata is in `model_deployment.json`.
+- **Data services:** PostgreSQL 18.4, MongoDB 8.0.30; Python client package versions and executor image ID are recorded in `run_config.json`.
+
+The exact upstream weight revision was not recorded and could not be recovered from the local weight-directory metadata. `model_deployment.json` reports this as unknown and supplies hashes of the model configuration, tokenizer configuration, chat template, and shard index; these metadata hashes are not hashes of the weight tensors. The serving container was created and started before the batch. Deployment metadata was inspected after the run, on 2026-09-12.
+
+The archived `harness/` directory contains the actual runner and scaffold source overlay, including Qwen support, trace logging, executor networking changes, PostgreSQL port handling and dataset-level scheduling. It is provided as reproduction material; this PR does not propose replacing the official harness.
+
+## Failed trials
+
+`agnews/query4/run1`, `run2`, `run3`, `run4`, and `music_brainz_20k/query3/run2` ended with an HTTP 400 context-limit error. Each request reserved 131072 output tokens while the input exceeded 131072 tokens, exceeding the 262144-token context window. The harness retried the same request and then recorded the failure. No context compression or dynamic output-token reduction was used. Full failure traces are included; see `failures.json`.
+
+## Traces and verification
+
+Download the complete archive and its checksum from the [trace release](https://github.com/qiboyu301-crypto/DataAgentBench/releases/tag/qwen38flash-parallel-v1-traces):
+
+- `qwen38flash_parallel_v1-traces.tar.gz`
+- `SHA256SUMS`
+
+The archive retains each original `query_<dataset>/query<N>/logs/data_agent/qwen38flash_parallel_v1_run_<R>/` directory. It includes all 270 `final_agent.json`, `llm_calls.jsonl`, and `tool_calls.jsonl` files, generated Python code and intermediate artifacts, console logs, batch configuration/session records, the source overlay, and an artifact manifest. Binary intermediate files are supplied for completeness; the verifier does not execute or deserialize them.
+
+The public copy redacts known credentials and replaces the text-file model endpoint, evaluation-root prefix and lock-directory prefix with placeholders. Final answer strings are unchanged. Binary intermediates are unchanged and were checked for known credentials. The original private files were left untouched. `artifact_manifest.json` in the archive records both original and published file hashes and the transformations applied; batch trace indexes still carry their original artifact hashes. `export_summary.json` records the archive checksum and redaction counts.
+
+From this submission directory:
+
+```bash
+sha256sum -c SHA256SUMS
+python verify_submission.py --archive qwen38flash_parallel_v1-traces.tar.gz
+# Optional: re-score using a separate checkout of the official validators.
+python verify_submission.py --archive qwen38flash_parallel_v1-traces.tar.gz --validators-root /path/to/DataAgentBench
+```
+
+The verification script checks all 270 task keys, verbatim answers and return-answer tool calls, all published artifact hashes, failure coverage, and recorded score arithmetic. With `--validators-root`, it also independently re-runs every non-empty answer through that checkout's `validate.py`. It does not invoke the model.
+
+The questions, description/hint files, validators and 54 ground-truth files were hash-compared with official revision `881bab89f69ac4f150e2586357ede8c5b95719d5` and matched. Scoring was performed externally after the runs; no scoring feedback was fed back into the agent. The original batch configuration records launch-time hashes for 29 raw dataset files; those large databases were not rehashed during the submission audit.
+
+## Data-access audit and limitations
+
+The audit checked all 270 initial system/user prompt pairs and scanned 5603 raw tool calls, with targeted inspection of file-access matches. The prompts match the official query and description/hint inputs plus scaffold boilerplate. No external answer download or reading of gold/validator contents was identified in the inspected calls. This is a heuristic scan with targeted review, not a claim of exhaustive semantic verification.
+
+The following environment-access behavior is disclosed for maintainer review:
+
+- `stockmarket/query2/run0` and `run4` used DuckDB `glob` to enumerate repository files, exposing `ground_truth.csv` filenames; run0 also enumerated `validate.py` filenames. The returned values were directory entries, not file contents. They were subsequently carried in the tool's stored result environment.
+- `stockmarket/query2/run0` queried `count(*)` over `read_text` of its database configuration; the returned value was a count, not the configuration body. Two `read_blob` attempts against the sanctioned stock-trade database failed.
+- `stockmarket/query2/run2` enumerated directories and read `/proc/self/cmdline`. This returned process information, not answer data.
+- The parquet file read in `agnews/query1/run4` was created during that same trial from the agent's own database-query results.
+
+All five `stockmarket/query2` answers passed the validators. We found no evidence that forbidden answer content was obtained and caused these passes, but the SQL executor's host filesystem access was not structurally restricted. Disconnecting the Python execution container from networking does not close this SQL path. These traces are retained without removing the concerning calls, and the reported score is subject to the maintainers' rubric review.
+
+## Reproducing the run
+
+Use the official dataset setup instructions with the checked validator revision, then overlay `harness/` from the archive onto that checkout. The source commit recorded by the evaluation runner is `200fcd9ae313521b3077bf8a330b1708e8f1c697`; the archived files and hashes are the reproduction reference. Install the archived `requirements.lock.txt` in a Python 3.12 environment and build the executor image from the archived Dockerfile. Configure the model endpoint and database services in a private `.env` (`OPENAI_BASE_URL`, `OPENAI_API_KEY`, `PG_HOST`, `PG_PORT`, `PG_USER`, `PG_PASSWORD`, and `MONGO_URI`).
+
+```bash
+python run_benchmark.py \
+  --prefix qwen38flash_reproduction \
+  --model Qwen/Qwen3.8-Flash-Next \
+  --runs 5 --use-hints --max-parallel 12 \
+  --lock-dir /path/to/shared-dab-locks \
+  --iterations 300 --llm-timeout 7200 \
+  --temperature 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 \
+  --presence-penalty 0.0 --repetition-penalty 1.0 \
+  --max-tokens 131072 --enable-thinking --preserve-thinking \
+  --reasoning-effort xhigh
+```
+
+The original sampling was nondeterministic. This command reproduces the recorded settings and task matrix, not a promise of identical answers. Any experiment with a changed context policy should be reported separately from this fixed batch.

--- a/leaderboard_submissions/qwen38flash_parallel_v1/SHA256SUMS
+++ b/leaderboard_submissions/qwen38flash_parallel_v1/SHA256SUMS
@@ -1,0 +1,1 @@
+3b2715552f6e77ca893e5fdeb5af7fe2a631fef17039475df2859271a174cb67  qwen38flash_parallel_v1-traces.tar.gz

--- a/leaderboard_submissions/qwen38flash_parallel_v1/export_summary.json
+++ b/leaderboard_submissions/qwen38flash_parallel_v1/export_summary.json
@@ -1,0 +1,14 @@
+{
+  "archive": "qwen38flash_parallel_v1-traces.tar.gz",
+  "archive_sha256": "3b2715552f6e77ca893e5fdeb5af7fe2a631fef17039475df2859271a174cb67",
+  "archive_bytes": 669024657,
+  "archived_files": 3982,
+  "public_results": 270,
+  "failed_trials_retained": 5,
+  "redactions": {
+    "model_endpoint": 2,
+    "lock_directory": 3,
+    "evaluation_root": 10020
+  },
+  "policy": "Credentials, model endpoint, evaluation-root and lock-directory prefixes are redacted from text files. Binary intermediates are unchanged and checked for known credentials. Answers are verbatim; original files are unchanged. Original and public file hashes are supplied."
+}

--- a/leaderboard_submissions/qwen38flash_parallel_v1/failures.json
+++ b/leaderboard_submissions/qwen38flash_parallel_v1/failures.json
@@ -1,0 +1,42 @@
+[
+  {
+    "dataset": "agnews",
+    "query": "4",
+    "run": "1",
+    "status": "failed:process_exit",
+    "reason": "llm_response_failed (BadRequestError): Error code: 400 - {'error': {'message': \"This model's maximum context length is 262144 tokens. However, you requested 131072 output tokens and your prompt contains at least 131073 input tokens, for a total of at least 262145 tokens. Please reduce the length of the input prompt or the number of requested output tokens. (parameter=input_tokens, value=131073)\", 'type': 'BadRequestError', 'param': 'input_tokens', 'code': 400}}",
+    "trace": "query_agnews/query4/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "agnews",
+    "query": "4",
+    "run": "2",
+    "status": "failed:process_exit",
+    "reason": "llm_response_failed (BadRequestError): Error code: 400 - {'error': {'message': \"This model's maximum context length is 262144 tokens. However, you requested 131072 output tokens and your prompt contains at least 131073 input tokens, for a total of at least 262145 tokens. Please reduce the length of the input prompt or the number of requested output tokens. (parameter=input_tokens, value=131073)\", 'type': 'BadRequestError', 'param': 'input_tokens', 'code': 400}}",
+    "trace": "query_agnews/query4/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "agnews",
+    "query": "4",
+    "run": "3",
+    "status": "failed:process_exit",
+    "reason": "llm_response_failed (BadRequestError): Error code: 400 - {'error': {'message': \"This model's maximum context length is 262144 tokens. However, you requested 131072 output tokens and your prompt contains at least 131073 input tokens, for a total of at least 262145 tokens. Please reduce the length of the input prompt or the number of requested output tokens. (parameter=input_tokens, value=131073)\", 'type': 'BadRequestError', 'param': 'input_tokens', 'code': 400}}",
+    "trace": "query_agnews/query4/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "agnews",
+    "query": "4",
+    "run": "4",
+    "status": "failed:process_exit",
+    "reason": "llm_response_failed (BadRequestError): Error code: 400 - {'error': {'message': \"This model's maximum context length is 262144 tokens. However, you requested 131072 output tokens and your prompt contains at least 131073 input tokens, for a total of at least 262145 tokens. Please reduce the length of the input prompt or the number of requested output tokens. (parameter=input_tokens, value=131073)\", 'type': 'BadRequestError', 'param': 'input_tokens', 'code': 400}}",
+    "trace": "query_agnews/query4/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "3",
+    "run": "2",
+    "status": "failed:process_exit",
+    "reason": "llm_response_failed (BadRequestError): Error code: 400 - {'error': {'message': \"This model's maximum context length is 262144 tokens. However, you requested 131072 output tokens and your prompt contains at least 131073 input tokens, for a total of at least 262145 tokens. Please reduce the length of the input prompt or the number of requested output tokens. (parameter=input_tokens, value=131073)\", 'type': 'BadRequestError', 'param': 'input_tokens', 'code': 400}}",
+    "trace": "query_music_brainz_20k/query3/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  }
+]

--- a/leaderboard_submissions/qwen38flash_parallel_v1/metrics.json
+++ b/leaderboard_submissions/qwen38flash_parallel_v1/metrics.json
@@ -1,0 +1,121 @@
+{
+  "coverage": {
+    "expected": 270,
+    "recorded": 270,
+    "unique": 270,
+    "missing": [],
+    "extra": [],
+    "duplicates": []
+  },
+  "passed": 201,
+  "micro_accuracy": 0.7444444444444445,
+  "macro_pass_at_1": 0.7086721611721613,
+  "per_dataset": {
+    "DEPS_DEV_V1": {
+      "trials": 10,
+      "passed": 5,
+      "failed_execution": 0,
+      "queries": 2,
+      "pass_at_1": 0.5
+    },
+    "GITHUB_REPOS": {
+      "trials": 20,
+      "passed": 11,
+      "failed_execution": 0,
+      "queries": 4,
+      "pass_at_1": 0.55
+    },
+    "PANCANCER_ATLAS": {
+      "trials": 15,
+      "passed": 10,
+      "failed_execution": 0,
+      "queries": 3,
+      "pass_at_1": 0.6666666666666666
+    },
+    "PATENTS": {
+      "trials": 15,
+      "passed": 6,
+      "failed_execution": 0,
+      "queries": 3,
+      "pass_at_1": 0.4
+    },
+    "agnews": {
+      "trials": 20,
+      "passed": 6,
+      "failed_execution": 4,
+      "queries": 4,
+      "pass_at_1": 0.3
+    },
+    "bookreview": {
+      "trials": 15,
+      "passed": 15,
+      "failed_execution": 0,
+      "queries": 3,
+      "pass_at_1": 1.0
+    },
+    "crmarenapro": {
+      "trials": 65,
+      "passed": 57,
+      "failed_execution": 0,
+      "queries": 13,
+      "pass_at_1": 0.8769230769230769
+    },
+    "googlelocal": {
+      "trials": 20,
+      "passed": 14,
+      "failed_execution": 0,
+      "queries": 4,
+      "pass_at_1": 0.7
+    },
+    "music_brainz_20k": {
+      "trials": 15,
+      "passed": 14,
+      "failed_execution": 1,
+      "queries": 3,
+      "pass_at_1": 0.9333333333333333
+    },
+    "stockindex": {
+      "trials": 15,
+      "passed": 15,
+      "failed_execution": 0,
+      "queries": 3,
+      "pass_at_1": 1.0
+    },
+    "stockmarket": {
+      "trials": 25,
+      "passed": 18,
+      "failed_execution": 0,
+      "queries": 5,
+      "pass_at_1": 0.72
+    },
+    "yelp": {
+      "trials": 35,
+      "passed": 30,
+      "failed_execution": 0,
+      "queries": 7,
+      "pass_at_1": 0.8571428571428571
+    }
+  },
+  "per_run": {
+    "0": [
+      43,
+      54
+    ],
+    "1": [
+      42,
+      54
+    ],
+    "2": [
+      40,
+      54
+    ],
+    "3": [
+      39,
+      54
+    ],
+    "4": [
+      37,
+      54
+    ]
+  }
+}

--- a/leaderboard_submissions/qwen38flash_parallel_v1/model_deployment.json
+++ b/leaderboard_submissions/qwen38flash_parallel_v1/model_deployment.json
@@ -1,0 +1,65 @@
+{
+  "inspected_at": "2026-09-12T01:10:58.938284+00:00",
+  "model_name": "Qwen/Qwen3.8-Flash-Next",
+  "exact_weight_revision": null,
+  "revision_note": "Not captured by original run; no upstream commit or download-cache revision present in local model metadata. Metadata hashes below do not hash weight tensors.",
+  "container_created_at": "2026-09-10T04:52:47.317515501Z",
+  "container_started_at": "2026-09-10T04:52:47.336295551Z",
+  "serving_image": "m.daocloud.io/docker.io/vllm/vllm-openai:qwen38-flash-next",
+  "serving_image_id": "sha256:fc120ece0a388cc0aa1caad4a9f1cd92113484ab7ec2fd0efadd62585be05bf8",
+  "serving_image_repo_digests": [
+    "m.daocloud.io/docker.io/vllm/vllm-openai@sha256:fc120ece0a388cc0aa1caad4a9f1cd92113484ab7ec2fd0efadd62585be05bf8"
+  ],
+  "serving_command": [
+    "/model",
+    "--served-model-name",
+    "Qwen/Qwen3.8-Flash-Next",
+    "--api-key",
+    "[REDACTED_CREDENTIAL]",
+    "--tensor-parallel-size",
+    "8",
+    "--moe-backend",
+    "triton",
+    "--gpu-memory-utilization",
+    "0.90",
+    "--max-model-len",
+    "auto",
+    "--max-num-batched-tokens",
+    "8192",
+    "--max-num-seqs",
+    "64",
+    "--enable-prefix-caching",
+    "--no-enable-flashinfer-autotune",
+    "--disable-custom-all-reduce",
+    "--enable-auto-tool-choice",
+    "--tool-call-parser",
+    "qwen3_xml",
+    "--reasoning-parser",
+    "qwen3"
+  ],
+  "versions": {
+    "vllm": "0.1.dev20073+g8e685d198",
+    "transformers": "5.15.1",
+    "torch": "2.13.0+cu130"
+  },
+  "gpu_inventory": [
+    "NVIDIA L40S, 46068 MiB",
+    "NVIDIA L40S, 46068 MiB",
+    "NVIDIA L40S, 46068 MiB",
+    "NVIDIA L40S, 46068 MiB",
+    "NVIDIA L40S, 46068 MiB",
+    "NVIDIA L40S, 46068 MiB",
+    "NVIDIA L40S, 46068 MiB",
+    "NVIDIA L40S, 46068 MiB"
+  ],
+  "checkpoint_config_dtype": "bfloat16",
+  "quantization_config": null,
+  "max_context_tokens": 262144,
+  "metadata_sha256": {
+    "config.json": "889658f2508e8c61d409b02e70e0d78d8d4452ec65aaafbe129805d213d2e74b",
+    "generation_config.json": "e70c136c1b78ddc1fb0905bac8e733a4dc448d4f852a5dd75143fffc70be550e",
+    "model.safetensors.index.json": "99e815241ef03325536b0aaa4441deea45174c17fae31e10f0bb456410c590de",
+    "chat_template.jinja": "c3cf9e34abf4f9e36c2d72165aa9c132d3e2a725b6c2586aaa3a8af9d7a81041",
+    "tokenizer_config.json": "b11349aafa7cdc6a320767cf7ceb29ed82f7eda5d65e8e0819e76f0ce947bf27"
+  }
+}

--- a/leaderboard_submissions/qwen38flash_parallel_v1/results.json
+++ b/leaderboard_submissions/qwen38flash_parallel_v1/results.json
@@ -1,0 +1,1622 @@
+[
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "1",
+    "run": "0",
+    "answer": "Top 5 NPM packages by GitHub stars of their source repository (each package counted only at its latest release version, i.e. highest Ordinal with IsRelease = true in packageinfo → matched to project_packageversion on System/Name/Version → stars parsed from project_info.Project_Information):\n\n1. @dmrvos/infrajs>0.0.5>typescript — version 2.6.2 — repo microsoft/typescript — 94,931 stars\n2. @dmrvos/infrajs>0.0.6>typescript — version 2.6.2 — repo microsoft/typescript — 94,931 stars\n3. @dylanvann/svelte — version 3.25.4 — repo sveltejs/svelte — 73,499 stars\n4. @dumc11/tailwindcss — version 0.4.0 — repo tailwindcss/tailwindcss — 73,464 stars\n5. lodash (many tied entries at 57,779 stars, repo lodash/lodash), e.g. @dollarshaveclub/cli>1.0.0>lodash — version 4.17.4 (also @dummmy/webpack-cli>1.0.7>lodash — 4.17.19, @dollarshaveclub/cli>1.13.1>lodash — 4.17.11, etc.)\n\nNotes:\n- Entries 1, 2 and 5 are flattened transitive-dependency package names (\"parent>version>child\"; they have no npmjs.org ORIGIN link). If only genuine registry packages are counted, the ranking becomes: 1) @dylanvann/svelte 3.25.4 (sveltejs/svelte, 73,499), 2) @dumc11/tailwindcss 0.4.0 (tailwindcss/tailwindcss, 73,464), 3) @edgarai/strapi-provider-upload-local 3.6.3-devgar-fork.2 (strapi/strapi, 57,236), 4) @dolsem/actioncable 7.0.0-alpha-simple-backoff (rails/rails, 55,319), 5) @dreampie/semantic-ui 2.2.11 (semantic-org/semantic-ui, 51,069)."
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "1",
+    "run": "1",
+    "answer": "Top 5 NPM packages by GitHub stars, using each package's latest release version (highest Ordinal with IsRelease = true in packageinfo), joined to project_packageversion on System/Name/Version and to project_info for the star count:\n\n1. @dylanvann/svelte — version 3.25.4 — 73,499 stars (sveltejs/svelte)\n2. @dumc11/tailwindcss — version 0.4.0 — 73,464 stars (tailwindcss/tailwindcss)\n3. @dreampie/semantic-ui — version 2.2.11 — 51,069 stars (semantic-org/semantic-ui)\n4. @dongls/pdfjs-dist — version 3.2.72 — 44,231 stars (mozilla/pdf.js)\n5. @dman777/shadow-dom-quill-temp — version 1.0.0 — 42,407 stars (quilljs/quill)\n\n(Note: dependency-path pseudo-names such as \"@dmrvos/infrajs>0.0.5>typescript\" / \"@dollarshaveclub/cli>...>lodash\", which map to microsoft/typescript (94,931 stars) and lodash/lodash (57,779 stars), were excluded as they are not real npm package names.)"
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "1",
+    "run": "2",
+    "answer": "Top 5 NPM packages (by GitHub stars of their linked GitHub project, keeping only each package's latest release version):\n\n1. @dylanvann/svelte — latest version 3.25.4 — repo sveltejs/svelte (73,499 stars)\n2. @dumc11/tailwindcss — latest version 0.4.0 — repo tailwindcss/tailwindcss (73,464 stars)\n3. @edgarai/strapi-provider-upload-local — latest version 3.6.3-devgar-fork.2 — repo strapi/strapi (57,236 stars)\n4. @dolsem/actioncable — latest version 7.0.0-alpha-simple-backoff — repo rails/rails (55,319 stars)\n5. @dreampie/semantic-ui — latest version 2.2.11 — repo semantic-org/semantic-ui (51,069 stars)\n\nNotes: \"latest release version\" per package was taken as the highest VersionInfo Ordinal among its NPM rows in packageinfo; packageinfo rows were joined to project_packageversion on (System, Name, Version) and the stars were parsed from project_info.Project_Information. Repos with more stars (microsoft/typescript 94,931; lodash/lodash 57,779) only link flattened dependency-path pseudo-names (e.g. \"@dummmy/webpack-cli>1.0.6>lodash\"), not real package names, and mui-org/material-ui (89,398) links only @docly/web whose latest version 0.2.3 has no project mapping (mapping stops at 0.2.1), so these do not qualify."
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "1",
+    "run": "3",
+    "answer": "Top 5 NPM packages (considering only each package's latest release version) ranked by the GitHub star count of their source repository:\n\n1. @dylanvann/svelte — version 3.25.4 — sveltejs/svelte — 73,499 stars\n2. @dumc11/tailwindcss — version 0.4.0 — tailwindcss/tailwindcss — 73,464 stars\n3. @dreampie/semantic-ui — version 2.2.11 — semantic-org/semantic-ui — 51,069 stars\n4. @dongls/pdfjs-dist — version 3.2.72 — mozilla/pdf.js — 44,231 stars\n5. @dman777/shadow-dom-quill-temp — version 1.0.0 — quilljs/quill — 42,407 stars\n\nMethod: in package_database.packageinfo, for each distinct NPM package name the latest release version was taken as the version with the highest VersionInfo Ordinal among IsRelease = true versions; these (Name, Version) pairs were joined to project_database.project_packageversion on System/Name/Version to get ProjectName, then to project_info (star count parsed from Project_Information) for the star numbers.\n\nNotes: (a) if dependency-path style entries stored as package names (containing \">\") are counted as packages, the higher-ranked rows would be @dmrvos/infrajs>0.0.5>typescript and @dmrvos/infrajs>0.0.6>typescript (version 2.6.2, microsoft/typescript, 94,931 stars), followed by the two packages listed above at 73k stars, plus many ties for the lodash/lodash (57,779 stars) paths. (b) @docly/web maps to mui-org/material-ui (89,398 stars) but is excluded here because its latest release (0.2.3) has no GitHub project mapping — only versions up to 0.2.1 are mapped."
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "1",
+    "run": "4",
+    "answer": "Top 5 NPM packages (using only each package's latest release version, i.e. max VersionInfo.Ordinal with IsRelease=true, joined to its GitHub project) ranked by GitHub stars:\n\n1. @dylanvann/svelte — version 3.25.4 — repo sveltejs/svelte — 73,499 stars\n2. @dumc11/tailwindcss — version 0.4.0 — repo tailwindcss/tailwindcss — 73,464 stars\n3. @dreampie/semantic-ui — version 2.2.11 — repo semantic-org/semantic-ui — 51,069 stars\n4. @dongls/pdfjs-dist — version 3.2.72 — repo mozilla/pdf.js — 44,231 stars\n5. @dman777/shadow-dom-quill-temp — version 1.0.0 — repo quilljs/quill — 42,407 stars\n\n(Runners-up: @dothq/styled-components 1.0.0 and @dynasty/styled-components 3.2.1, both styled-components/styled-components, 39,660 stars; then @ec-nordbund/leaflet 1.7.1, leaflet/leaflet, 38,715 stars.)\n\nNote: malformed dependency-path entries that exist in both tables (e.g. \"@dmrvos/infrajs>0.0.5>typescript\" v2.6.2 → microsoft/typescript, 94,931 stars, and \"@dollarshaveclub/cli>1.0.0>lodash\" v4.17.4 → lodash/lodash, 57,779 stars) were excluded, since names containing \">\" are not valid/distinct NPM package names."
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "2",
+    "run": "0",
+    "answer": "Top 5 GitHub projects (NPM packages, project license = MIT, package version marked as release / IsRelease = true) by GitHub fork count:\n\n1. mui-org/material-ui — 30,522 forks (via @docly/web)\n2. moment/moment — 7,201 forks (via moment dependency packages, e.g. @dmrvos/infrajs>0.0.5>moment)\n3. semantic-org/semantic-ui — 4,955 forks (via @dreampie/semantic-ui)\n4. react-native-elements/react-native-elements — 4,623 forks (via @dplus/themed, @dplus/rn-ui)\n5. sveltejs/svelte — 4,091 forks (via @dylanvann/svelte)\n\nNote: rails/rails (21,423 forks) and microsoft/monaco-editor (3,407 forks) also have MIT project licenses, but all of their linked package versions (@dolsem/actioncable 7.0.0-alpha* and @docid/monaco-editor 0.31.1-x1) are NOT marked as releases, so they are excluded. Next qualifying project is tailwindcss/tailwindcss with 3,848 forks."
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "2",
+    "run": "1",
+    "answer": "Top 5 GitHub projects (project license = \"MIT\") linked to NPM packages whose versions are marked as releases, ranked by fork count:\n\n1. mui-org/material-ui — 30,522 forks (e.g., @docly/web 0.2.3, release)\n2. moment/moment — 7,201 forks (e.g., @dollarshaveclub/cli>2.2.2>moment 2.24.0, release)\n3. semantic-org/semantic-ui — 4,955 forks (e.g., @dreampie/semantic-ui 2.2.11, release)\n4. react-native-elements/react-native-elements — 4,623 forks (e.g., @dplus/themed 4.0.2, release)\n5. sveltejs/svelte — 4,091 forks (e.g., @dylanvann/svelte 3.25.4, release)\n\nNote: rails/rails (21,423 forks) and microsoft/monaco-editor (3,407 forks) also have MIT project licenses and linked NPM packages, but none of their linked package versions are marked as releases, so they are excluded."
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "2",
+    "run": "2",
+    "answer": "Top 5 NPM projects (project license = MIT, packages marked as release) by GitHub fork count:\n\n1. mui-org/material-ui — 30,522 forks (e.g. @docly/web 0.2.3, MIT, IsRelease=true)\n2. moment/moment — 7,201 forks (e.g. moment dependency paths such as \"@dollarshaveclub/cli>2.2.2>moment\" 2.24.0, MIT, IsRelease=true)\n3. semantic-org/semantic-ui — 4,955 forks (@dreampie/semantic-ui 2.2.11, MIT, IsRelease=true)\n4. react-native-elements/react-native-elements — 4,623 forks (@dplus/themed 4.0.2 / @dplus/rn-ui 0.0.2, MIT, IsRelease=true)\n5. sveltejs/svelte — 4,091 forks (@dylanvann/svelte 3.25.4, MIT, IsRelease=true)\n\nNote: rails/rails (MIT, 21,423 forks) is excluded because all of its mapped package versions (@dolsem/actioncable, all 7.x alpha) are flagged IsRelease=false. tailwindcss/tailwindcss (3,848 forks) is the next qualifying project after these five."
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "2",
+    "run": "3",
+    "answer": "Top 5 GitHub projects (MIT-licensed projects linked to NPM packages that have at least one version marked IsRelease = true), ranked by GitHub fork count:\n\n1. mui-org/material-ui — 30,522 forks (89,398 stars) — via package @docly/web (e.g. v0.2.1, release)\n2. moment/moment — 7,201 forks (47,549 stars) — via moment dependency-linked packages (e.g. @dollarshaveclub/cli>1.8.0>moment v2.21.0, release)\n3. semantic-org/semantic-ui — 4,955 forks (51,069 stars) — via @dreampie/semantic-ui v2.2.11 (release)\n4. react-native-elements/react-native-elements — 4,623 forks (24,814 stars) — via @dplus/themed / @dplus/base (release)\n5. sveltejs/svelte — 4,091 forks (73,499 stars) — via @dylanvann/svelte (e.g. v3.25.4, release)\n\nNote: rails/rails (21,423 forks) and microsoft/monaco-editor (3,407 forks) also have MIT project licenses and NPM links, but their linked package versions (@dolsem/actioncable 7.0.0-alpha*, @docid/monaco-editor 0.31.1-x1) are all marked IsRelease = false, so they are excluded."
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "2",
+    "run": "4",
+    "answer": "Top 5 GitHub projects (project license = MIT) linked to NPM packages that are marked as releases (VersionInfo IsRelease = true), ranked by fork count:\n\n1. mui-org/material-ui — 30,522 forks (e.g., @docly/web 0.2.3, MIT, released)\n2. moment/moment — 7,201 forks (e.g., @dollarshaveclub/cli>2.2.2>moment 2.24.0, MIT, released)\n3. semantic-org/semantic-ui — 4,955 forks (@dreampie/semantic-ui 2.2.11, MIT, released)\n4. react-native-elements/react-native-elements — 4,623 forks (@dplus/themed 4.0.2, MIT, released)\n5. sveltejs/svelte — 4,091 forks (@dylanvann/svelte 3.25.4, MIT, released)\n\nNote: rails/rails (21,423 forks) and microsoft/monaco-editor (3,407 forks) also have MIT project licenses, but their mapped NPM packages (@dolsem/actioncable, @docid/monaco-editor) have IsRelease = false for every version, so they are excluded."
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "1",
+    "run": "0",
+    "answer": "About 14% — roughly 1 in 7.\n\nDetails: The artifacts_database contains 128 repositories with a root-level README.md in the contents table. 17 of them declare Python in the languages table, leaving 111 non-Python repositories. Of those 111 README.md files, 16 contain an explicit copyright notice/statement (the word \"copyright\", case-insensitive) → 16/111 ≈ 0.144 (14.4%).\n\nIf you also count READMEs that only carry a ©-style attribution line (e.g. \"MIT © Author\"), the number rises to 19/111 ≈ 0.171 (17.1%). Restricting to repositories that actually have language metadata (101 non-Python repos) gives essentially the same result: 15/101 ≈ 14.9% (16.8% including ©-only notices)."
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "1",
+    "run": "1",
+    "answer": "About 14.4% — 16 out of 111 README.md files in non-Python repositories contain copyright information.\n\nDetails: Of the 128 repository README.md blobs available in the artifacts_database contents table (sample_path = 'README.md'), 17 belong to repositories whose language_description mentions Python, leaving 111 non-Python repositories. Case-insensitive search for \"copyright\" in their README.md content matched 16 files → 16/111 ≈ 0.144 (14.4%). (If the 10 repositories with no language information are excluded, the figure is 15/101 ≈ 14.9%.)"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "1",
+    "run": "2",
+    "answer": "About 14.9% (≈0.15).\n\nDetails: The artifacts `contents` table has 128 root-level README.md files (128 distinct repos). Joining repo_name to the `languages` table gives 118 matches; 17 of those declare Python, leaving 101 non-Python repos. Of these 101, 15 README.md files contain copyright information (case-insensitive \"copyright\" in the file content), i.e. 15/101 ≈ 0.1485 → ~14.9%.\n\n(Sensitivity: including the 10 README repos with no entry in the languages table as non-Python gives 16/111 ≈ 14.4%.)"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "1",
+    "run": "3",
+    "answer": "About 14.9% (15 out of 101, proportion ≈ 0.1485).\n\nDetail: Of the 128 repositories that have a README.md in the artifacts contents table, 118 have language metadata, and 17 of those declare Python as one of their languages. That leaves 101 non-Python repositories; 15 of their README.md files contain copyright text (case-insensitive match on \"copyright\"), i.e. 15/101 ≈ 0.1485 ≈ 14.9%."
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "1",
+    "run": "4",
+    "answer": "About 15% of the README.md files in non‑Python repositories contain copyright information.\n\nDetails:\n- 133 repositories in the artifacts database have a README.md (contents.sample_path = 'README.md'/'readme.md').\n- 18 of them declare Python in their language breakdown (languages.language_description), leaving 115 repositories that do not use Python.\n- Of those 115, 17 README.md files mention \"copyright\" (case‑insensitive) → 17/115 = 0.148 ≈ 14.8%.\n- If only repositories with an explicit non‑Python language breakdown are counted (excluding 10 repos absent from the languages table and 6 whose language info is unavailable), the figure is 16/99 ≈ 16.2%.\n- Including the \"©\" symbol as an indicator raises the non‑Python rate slightly to 20/115 ≈ 17.4%.\n\nSo roughly one in six/seven (≈15%) non‑Python repos document copyright information in their README.md."
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "2",
+    "run": "0",
+    "answer": "Repository: SwiftAndroid/swift (a repository containing Swift code — Swift ≈ 12,538,936 bytes in languages.language_description).\n\nMost frequently copied non-binary .swift file, when files are restricted to / uniquely keyed by the blob id in the files table (files.id = contents.id):\n- Path: validation-test/compiler_crashers_fixed/27485-swift-bracestmt-create.swift\n- File id (files.id / contents.id): 71a17ce92451858f3eb01aa8082551e48bc5550d\n- Metadata: 470 bytes, non-binary, mode 33188, copied 23 times (highest among such files; next is practicalswift/swift-compiler-crashes – crashes-duplicates/22401-llvm-foldingset-swift-tupletype-nodeequals.swift, id cc41f22d46f21f11c9e716b30cbaeb11f4ef80fc, 15 copies).\n\nNote: if the \"id must exist in the files table\" constraint is dropped and all rows of contents are considered, the overall maximum is uacaps/PageMenu with Demos/Demo 4/PageMenuDemoTabbar/PageMenuDemoTabbar/ContactTableViewCell.swift (id 6f4cdb70f044b0486a24a07403600cb964a02672, 708 bytes, non-binary, 38 copies), whose blob id does not appear in the files table."
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "2",
+    "run": "1",
+    "answer": "Repository: **uacaps/PageMenu**\n\n- It contains Swift code (languages table: \"The codebase includes: Swift (56,461 bytes), Objective-C (51,756 bytes), Ruby (5,999 bytes)\" — Swift is the main language by bytes).\n- It holds the most frequently copied non-binary .swift file in the dataset:\n  - Path: `Demos/Demo 4/PageMenuDemoTabbar/PageMenuDemoTabbar/ContactTableViewCell.swift`\n  - Blob ID (files/contents id): `6f4cdb70f044b0486a24a07403600cb964a02672`\n  - Metadata: \"It is a non-binary file of 708 bytes, repeated 38 times in the dataset under mode 33188.\" → 38 copies (highest of all non-binary .swift blobs; runner-up: kostiakoval/Mirror `Pods/Nimble/Nimble/Expectation.swift`, id a34c3d906831a12ffffa1b5d0fc30505126e9b69, 35 copies)."
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "2",
+    "run": "2",
+    "answer": "uacaps/PageMenu\n\nDetails: The most frequently copied non-binary Swift (.swift) file in the dataset is \"Demos/Demo 4/PageMenuDemoTabbar/PageMenuDemoTabbar/ContactTableViewCell.swift\" (blob id 6f4cdb70f044b0486a24a07403600cb964a02672, 708 bytes, mode 33188), which appears 38 times. It resides in the repository uacaps/PageMenu, whose language profile confirms Swift code: \"The codebase includes: Swift (56,461 bytes), Objective-C (51,756 bytes), Ruby (5,999 bytes).\""
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "2",
+    "run": "3",
+    "answer": "uacaps/PageMenu\n\nThe most frequently copied non-binary Swift file in the dataset is blob id 6f4cdb70f044b0486a24a07403600cb964a02672 (\"Demos/Demo 4/PageMenuDemoTabbar/PageMenuDemoTabbar/ContactTableViewCell.swift\"), which is a 708-byte, non-binary file copied 38 times. It resides in the repository uacaps/PageMenu, which contains Swift code (Swift is its dominant language: Swift 56,461 bytes, Objective-C 51,756 bytes, Ruby 5,999 bytes)."
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "2",
+    "run": "4",
+    "answer": "uacaps/PageMenu\n\nIt is the only repository containing the most frequently copied non-binary .swift file in the dataset: \"Demos/Demo 4/PageMenuDemoTabbar/PageMenuDemoTabbar/ContactTableViewCell.swift\" (blob id 6f4cdb70f044b0486a24a07403600cb964a02672, 708 bytes, mode 33188, copied/seen 38 times — the maximum among all non-binary .swift blobs). The metadata_database languages table confirms uacaps/PageMenu contains Swift code (Swift 56,461 bytes, Objective-C 51,756 bytes, Ruby 5,999 bytes)."
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "3",
+    "run": "0",
+    "answer": "1077"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "3",
+    "run": "1",
+    "answer": "1077"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "3",
+    "run": "2",
+    "answer": "1077"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "3",
+    "run": "3",
+    "answer": "1077"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "3",
+    "run": "4",
+    "answer": "1077"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "4",
+    "run": "0",
+    "answer": "Top five repositories (main language ≠ Python), ordered by number of commits:\n\n1. apple/swift — 1,051 commits (main language: C++)\n2. twbs/bootstrap — 340 commits (main language: JavaScript)\n3. Microsoft/vscode — 190 commits (main language: TypeScript)\n4. facebook/react — 178 commits (main language: JavaScript)\n5. tensorflow/tensorflow — 156 commits (main language: C++)\n\nRepository names: apple/swift, twbs/bootstrap, Microsoft/vscode, facebook/react, tensorflow/tensorflow\n\n(Note: torvalds/linux has the most commits (16,061) but has no entry in the languages metadata table, so its main language cannot be determined from the data.)"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "4",
+    "run": "1",
+    "answer": "Top 5 repositories (main language ≠ Python), ranked by number of commits in the commits table:\n\n1. apple/swift — 1,051 commits (main language: C++, 49,043,456 bytes)\n2. twbs/bootstrap — 340 commits (main language: JavaScript, 865,640 bytes)\n3. Microsoft/vscode — 190 commits (main language: TypeScript, 21,066,876 bytes)\n4. facebook/react — 178 commits (main language: JavaScript, 6,256,474 bytes)\n5. tensorflow/tensorflow — 156 commits (main language: C++, 126,099,822 bytes)\n\nNote: torvalds/linux has the most commits (16,061) but has no entry in the metadata languages table, so its main language could not be evaluated; it is excluded (as it would be by an inner join with the languages table). None of the five repositories listed above has Python as its main language (Python is only a secondary language in apple/swift and tensorflow/tensorflow)."
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "4",
+    "run": "2",
+    "answer": "Top 5 repositories (main language determined by highest byte count in languages.language_description — none is Python), ordered by number of commits (descending):\n\n1. apple/swift — main language: C++ — 1,051 commits\n2. twbs/bootstrap — main language: JavaScript — 340 commits\n3. Microsoft/vscode — main language: TypeScript — 190 commits\n4. facebook/react — main language: JavaScript — 178 commits\n5. tensorflow/tensorflow — main language: C++ (Python is only second, 42.8M vs 126.1M bytes) — 156 commits\n\n(torvalds/linux has more commits but has no entry in the languages table, so it cannot be attributed a main language.)"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "4",
+    "run": "3",
+    "answer": "Top 5 repositories (main language ≠ Python) by number of commits:\n\n1. apple/swift — 1,051 commits (main language: C++)\n2. twbs/bootstrap — 340 commits (main language: JavaScript)\n3. Microsoft/vscode — 190 commits (main language: TypeScript)\n4. facebook/react — 178 commits (main language: JavaScript)\n5. tensorflow/tensorflow — 156 commits (main language: C++)\n\nNote: torvalds/linux has the most commits (16,061) but has no entry in the languages table, so its main language cannot be determined and it is excluded."
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "4",
+    "run": "4",
+    "answer": "Top 5 repositories (main language determined by the largest byte count in languages.language_description, excluding Python), ranked by number of commits in the commits table:\n\n1. apple/swift — 1,051 commits (main language: C++, 49,043,456 bytes)\n2. twbs/bootstrap — 340 commits (main language: JavaScript, 865,640 bytes)\n3. Microsoft/vscode — 190 commits (main language: TypeScript, 21,066,876 bytes)\n4. facebook/react — 178 commits (main language: JavaScript, 6,256,474 bytes)\n5. tensorflow/tensorflow — 156 commits (main language: C++, 126,099,822 bytes)\n\nNote: torvalds/linux has the most commits (16,061) but has no entry in the languages table, so its main language cannot be determined."
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "1",
+    "run": "0",
+    "answer": "Average log10-transformed IGF2 expression (mean of log10(normalized_count + 1)) for LGG (Brain lower grade glioma) patients, grouped by histological type (23 patients with both a valid IGF2 expression value and a non-bracketed histology annotation):\n\n- Astrocytoma: 2.5713 (2.571298, n = 10)\n- Oligodendroglioma: 2.6825 (2.682458, n = 8)\n- Oligoastrocytoma: 2.7136 (2.713571, n = 5)\n\n(Oligoastrocytoma has the highest average IGF2 expression, Astrocytoma the lowest.)"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "1",
+    "run": "1",
+    "answer": "Average log10(normalized_count + 1) IGF2 expression in LGG (Brain lower grade glioma) patients, grouped by histological type (23 patients had valid IGF2 expression; all histology labels were valid, i.e. none were bracketed like \"[Discrepancy]\"):\n\n- Astrocytoma (n = 10): 2.5713\n- Oligodendroglioma (n = 8): 2.6825\n- Oligoastrocytoma (n = 5): 2.7136\n- All LGG histologies combined (n = 23): 2.6409\n\nDetails: 513 LGG patients were identified from clinical_info (Patient_description mentioning \"Brain lower grade glioma\"), matched by TCGA barcode to ParticipantBarcode in RNASeq_Expression for Symbol = 'IGF2'; 23 of them had a non-null normalized_count (all primary tumour, TP samples). More precise values: Astrocytoma 2.571298, Oligodendroglioma 2.682458, Oligoastrocytoma 2.713571."
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "1",
+    "run": "2",
+    "answer": "Average log10(normalized_count + 1) IGF2 expression for LGG (Brain lower grade glioma) patients, grouped by histological type (23 patients with valid IGF2 expression; all histology labels were non-bracketed: Astrocytoma, Oligodendroglioma, Oligoastrocytoma):\n\n- Astrocytoma: 2.5713 (2.571298; n = 10)\n- Oligodendroglioma: 2.6825 (2.682458; n = 8)\n- Oligoastrocytoma: 2.7136 (2.713571; n = 5)\n\n(Overall average across all 23 LGG samples: 2.6409)"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "1",
+    "run": "3",
+    "answer": "Average log10-transformed IGF2 expression (mean of log10(normalized_count + 1)) for LGG (Brain lower grade glioma) patients, grouped by histological type (23 patients with valid IGF2 expression; all histology values were un-bracketed):\n\n- Astrocytoma (n = 10): 2.5713 (2.571298)\n- Oligodendroglioma (n = 8): 2.6825 (2.682458)\n- Oligoastrocytoma (n = 5): 2.7136 (2.713571)\n\nOverall across the 23 patients: 2.6409"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "1",
+    "run": "4",
+    "answer": "Average log10-transformed IGF2 expression (mean of log10(normalized_count + 1)) for LGG (Brain lower grade glioma) patients with valid IGF2 expression and non-bracketed histology annotations:\n\n- Astrocytoma: 2.5713 (n = 10 patients)\n- Oligodendroglioma: 2.6825 (n = 8 patients)\n- Oligoastrocytoma: 2.7136 (n = 5 patients)\n\nOverall average across all 23 qualifying LGG patients: 2.6409 (all values from primary solid tumor samples; more precise values: Astrocytoma 2.571298, Oligoastrocytoma 2.713571, Oligodendroglioma 2.682458)."
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "2",
+    "run": "0",
+    "answer": "Top 3 histological types by CDH1 mutation frequency among alive BRCA (Breast Invasive Carcinoma) patients in the PanCancer Atlas (936 alive patients; CDH1-mutant = any mutation call in Mutation_Data for Hugo_Symbol = 'CDH1'):\n\n1. Infiltrating Lobular Carcinoma — 90/178 = 50.6%\n2. Mixed Histology (please specify) — 4/24 = 16.7%\n3. Other (specify) — 3/36 = 8.3%\n\n(For reference, Infiltrating Ductal Carcinoma is far lower at 14/671 = 2.1%; Medullary, Mucinous, Metaplastic and Infiltrating Carcinoma NOS show 0%. The same ranking holds if only FILTER = 'PASS' calls are counted: 50.3%, 13.6%, 8.6% of sequenced patients, or 41.6%, 12.5%, 8.3% of all alive patients.)"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "2",
+    "run": "1",
+    "answer": "Top 3 histological types by CDH1 mutation frequency among ALIVE BRCA (Breast Invasive Carcinoma) patients in the PanCancer Atlas (936 alive patients; CDH1-mutated = patient has ≥1 CDH1 mutation in Mutation_Data):\n\n1. Infiltrating Lobular Carcinoma — 90/178 ≈ 50.6%\n2. Mixed Histology (please specify) — 4/24 ≈ 16.7%\n3. Other (specify) — 3/36 ≈ 8.3%\n\n(For reference, Infiltrating Ductal Carcinoma, the largest group, is only 14/671 ≈ 2.1%; ranking is unchanged if the denominator is restricted to mutation-profiled patients — 61.2% / 18.2% / 8.6% — or if only FILTER = PASS calls are used — 41.6% / 12.5% / 8.3%.)"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "2",
+    "run": "2",
+    "answer": "Top 3 histological types (BRCA / Breast invasive carcinoma patients with vital status \"Alive\") by percentage carrying a CDH1 mutation:\n\n1. Infiltrating Lobular Carcinoma — 90/178 = 50.6%\n2. Mixed Histology (please specify) — 4/24 = 16.7%\n3. Other  specify — 3/36 = 8.3%\n\n(For reference, Infiltrating Ductal Carcinoma, the most common type, is only 14/671 = 2.1%. The same ranking holds if the denominator is restricted to patients with mutation profiling data: 61.2%, 18.2%, 8.6%.)"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "2",
+    "run": "3",
+    "answer": "Top 3 histological types by CDH1 mutation frequency among alive BRCA (Breast invasive carcinoma) PanCancer Atlas patients (936 patients):\n\n1. Infiltrating Lobular Carcinoma — 90/178 = 50.6%\n2. Mixed Histology (please specify) — 4/24 = 16.7%\n3. Other (specify) — 3/36 = 8.3%\n\n(For reference, Infiltrating Ductal Carcinoma, the largest group, is only 14/671 = 2.1%; results are unchanged if restricted to sequenced patients or to FILTER = PASS variants.)"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "2",
+    "run": "4",
+    "answer": "Top 3 histological types with the highest CDH1 mutation rate among alive BRCA (Breast Invasive Carcinoma) patients in the PanCancer Atlas:\n\n1. Infiltrating Lobular Carcinoma — 50.6% (90/178 patients with CDH1 mutation)\n2. Mixed Histology (please specify) — 16.7% (4/24)\n3. \"Other — specify\" — 8.3% (3/36)\n\n(For comparison, Infiltrating Ductal Carcinoma had only 2.1% (14/671); ranking is identical if the denominator is restricted to patients with available mutation data: 61.2%, 18.2%, 8.6%.)"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "3",
+    "run": "0",
+    "answer": "Chi-square statistic ≈ 305.12 (χ² = 305.1239)\n\nDetails: Female BRCA (Breast invasive carcinoma) patients with known histological_type (n = 1074), CDH1 mutation status from reliable entries only (FILTER = 'PASS'). Categories with marginal totals ≤ 10 were dropped (Metaplastic Carcinoma = 8, Medullary Carcinoma = 6, Infiltrating Carcinoma NOS = 1).\n\nContingency table (no CDH1 mut / CDH1 PASS mut):\n- Infiltrating Ductal Carcinoma: 757 / 9 (766)\n- Infiltrating Lobular Carcinoma: 118 / 83 (201)\n- Other specify: 42 / 3 (45)\n- Mixed Histology: 26 / 4 (30)\n- Mucinous Carcinoma: 17 / 0 (17)\nColumn totals: 960 / 99, grand total 1059 → χ² = Σ(O−E)²/E = 305.1239 (df = 4)."
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "3",
+    "run": "1",
+    "answer": "Chi-square statistic ≈ 305.12 (χ² = 305.124, df = 4)\n\nMethod / cohort:\n- BRCA (Breast invasive carcinoma) female patients in clinical_info: 1,075; with a known histological_type: 1,074 (1 record with \"None\" dropped).\n- Reliable CDH1 mutation calls = Mutation_Data rows with Hugo_Symbol = 'CDH1' AND FILTER = 'PASS' (247 participants cohort-wide; 100 of these BRCA females).\n\nContingency table (patients with row totals > 10; Metaplastic 8, Medullary 6, Infiltrating Carcinoma NOS 1 excluded):\n\nHistological type | CDH1-mutant | CDH1 wild-type | Row total | Expected(mut/wt)\nInfiltrating Ductal Carcinoma | 9 | 757 | 766 | 71.61 / 694.39\nInfiltrating Lobular Carcinoma | 83 | 118 | 201 | 18.79 / 182.21\nOther (specify) | 3 | 42 | 45 | 4.21 / 40.79\nMixed Histology | 4 | 26 | 30 | 2.80 / 27.20\nMucinous Carcinoma | 0 | 17 | 17 | 1.59 / 15.41\nColumn totals | 99 | 960 | 1,059 |\n\nχ² = Σ (O−E)²/E = 305.12 (4 degrees of freedom), indicating a very strong association between histological type and CDH1 mutation (driven by lobular carcinoma: 83 observed vs 18.8 expected).\n\nNote: if the cohort is additionally restricted to the 984 patients that actually have mutation profiling data (77 without molecular data dropped), χ² = 364.17."
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "3",
+    "run": "2",
+    "answer": "Chi-square statistic ≈ 305.12 (χ² = 305.1239, 4 df)\n\nDetails: Female BRCA (Breast invasive carcinoma) patients with a known histological type = 1,074; CDH1 mutation status taken from Mutation_Data entries with Hugo_Symbol='CDH1' and FILTER='PASS'. After dropping histology categories with marginal totals ≤ 10 (Metaplastic 8, Medullary 6, Infiltrating Carcinoma NOS 1) and no columns qualifying, the 5×2 table (n = 1,059; CDH1-mutant = 99, non-mutant = 960):\n\n- Infiltrating Ductal Carcinoma: 9 mutant / 757 WT (row total 766) → contributions 54.74 + 5.65\n- Infiltrating Lobular Carcinoma: 83 / 118 (201) → 219.41 + 22.63\n- Other (specify): 3 / 42 (45) → 0.35 + 0.04\n- Mixed Histology: 4 / 26 (30) → 0.51 + 0.05\n- Mucinous Carcinoma: 0 / 17 (17) → 1.59 + 0.16\n\nΣ(O−E)²/E = 305.12 (driven mainly by strong CDH1 enrichment in lobular and depletion in ductal carcinoma)."
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "3",
+    "run": "3",
+    "answer": "χ² ≈ 305.12 (df = 4) — strong association between histological type and CDH1 mutation status.\n\nCohort: 1,075 female Breast Invasive Carcinoma (BRCA) PanCancer Atlas patients; 1 excluded for unknown histology (\"None\") → 1,074 with known histology. CDH1 mutation status taken only from reliable entries (FILTER = 'PASS') in Mutation_Data (100 CDH1-mutated patients).\n\nCategories dropped for marginal totals ≤ 10: Infiltrating Carcinoma NOS (1), Medullary Carcinoma (6), Metaplastic Carcinoma (8).\n\nFinal contingency table (CDH1 wild-type / CDH1-mutated):\n- Infiltrating Ductal Carcinoma: 757 / 9 (total 766)\n- Infiltrating Lobular Carcinoma: 118 / 83 (total 201)\n- Mixed Histology (please specify): 26 / 4 (total 30)\n- Mucinous Carcinoma: 17 / 0 (total 17)\n- Other (specify): 42 / 3 (total 45)\nColumn totals: 960 wild-type, 99 mutated; N = 1,059.\nχ² = Σ (O−E)²/E = 305.12 (highly significant; CDH1 mutations are strongly enriched in lobular carcinoma).\n\nNote: if the cohort is additionally restricted to the 998 patients with mutation-profiled samples (984 after histology/marginal filters), χ² = 364.17."
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "3",
+    "run": "4",
+    "answer": "Chi-square statistic ≈ 305.12\n\nDetails of the computation:\n- Cohort: 1,075 female \"Breast invasive carcinoma\" (BRCA) patients; 1 had no known histological type → 1,074 patients analysed.\n- CDH1 mutation status: patients with ≥1 mutation entry in Mutation_Data for Hugo_Symbol = 'CDH1' with FILTER = 'PASS' (reliable calls).\n- Histology × CDH1 status (Mutated / Not mutated):\n  • Infiltrating Ductal Carcinoma: 9 / 757 (766)\n  • Infiltrating Lobular Carcinoma: 83 / 118 (201)\n  • Other (specify): 3 / 42 (45)\n  • Mixed Histology: 4 / 26 (30)\n  • Mucinous Carcinoma: 0 / 17 (17)\n  Dropped (marginal total ≤ 10): Metaplastic Carcinoma (8), Medullary Carcinoma (6), Infiltrating Carcinoma NOS (1)\n- Final table totals: 99 mutated, 960 not mutated, grand total 1,059 → χ² = Σ(O−E)²/E = 305.12 (df = 4), indicating a very strong association (CDH1 mutations are strongly enriched in infiltrating lobular carcinoma)."
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "1",
+    "run": "0",
+    "answer": "Level-5 CPC group codes (subclasses, per cpc_definition level = 5) whose exponential moving average (alpha = 0.2) of yearly primary-CPC patent filings peaks in 2022 — 72 codes:\n\nA22B, A23J, A23P, A24D, A24F, A41G, A47F, A61G, A61H, A61P, A62D, A63H, B04B, B07B, B08B, B09C, B21J, B22F, B24B, B25B, B25D, B27C, B27M, B60D, B60L, B60P, B61H, B63C, B63G, B65G, B66F, C01D, C01G, C21B, C21C, C22C, D21B, E01H, E02B, E02D, E03B, E04B, E04G, E21D, E21F, F02K, F04F, F16M, F25J, F26B, G01H, G01L, G01S, G05D, G06N, G06Q, G06T, G06V, G08G, G09F, G10L, G16B, G16C, G16H, G21F, H01M, H02B, H02G, H02J, H03H, H04K, H05F\n\nMethod: for each publication, filing year was parsed from filing_date; only primary CPC codes (first = true) were used and each patent counted once per level-5 CPC group (its level-5 ancestor subclass, e.g. H01M10/0525 -> H01M); yearly counts were filled with zeros from each group's first to last filing year and an EMA with smoothing factor 0.2 computed; the earliest year attaining the maximum EMA was taken as the group's best year, and only groups whose best year is 2022 are listed."
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "1",
+    "run": "1",
+    "answer": "A22B, A23J, A23P, A24D, A24F, A41G, A47F, A61G, A61H, A61P, A62D, A63H, B04B, B07B, B08B, B09C, B21J, B22F, B24B, B25B, B25D, B27C, B27M, B60D, B60L, B60P, B61H, B63C, B63G, B65G, B66F, C01D, C01G, C21B, C21C, C22C, D21B, E01H, E02B, E02D, E03B, E04B, E04G, E21D, E21F, F02K, F04F, F16M, F25J, F26B, G01H, G01L, G01S, G05D, G06N, G06Q, G06T, G06V, G08G, G09F, G10L, G16B, G16C, G16H, G21F, H01M, H02B, H02G, H02J, H03H, H04K, H05F (72 level-5 CPC codes whose peak EMA year is 2022)"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "1",
+    "run": "2",
+    "answer": "72 level‑5 CPC group codes have 2022 as their peak (highest EMA, α = 0.2) year of patent filings:\n\nA22B, A23J, A23P, A24D, A24F, A41G, A47F, A61G, A61H, A61P, A62D, A63H, B04B, B07B, B08B, B09C, B21J, B22F, B24B, B25B, B25D, B27C, B27M, B60D, B60L, B60P, B61H, B63C, B63G, B65G, B66F, C01D, C01G, C21B, C21C, C22C, D21B, E01H, E02B, E02D, E03B, E04B, E04G, E21D, E21F, F02K, F04F, F16M, F25J, F26B, G01H, G01L, G01S, G05D, G06N, G06Q, G06T, G06V, G08G, G09F, G10L, G16B, G16C, G16H, G21F, H01M, H02B, H02G, H02J, H03H, H04K, H05F\n\n(Method: for each patent, only primary CPC entries (\"first\": true) were used and each patent counted once per level‑5 group code per filing year; years with no filings between a group's first and last filing year were counted as zero; EMA computed with α = 0.2; earliest year taken on ties. The strongest 2022 peaks include G06Q (ICT for administrative/commercial purposes, EMA ≈ 276.6), H01M (batteries, ≈ 183.1), G06T (image data processing, ≈ 171.7), G06V (image/video recognition, ≈ 99.0), G01S (radio navigation/radar, ≈ 78.3), G06N (AI/ML computing arrangements, ≈ 70.0) and B65G (transport/storage devices, ≈ 67.3).)"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "1",
+    "run": "3",
+    "answer": "72 CPC level‑5 group (subclass) codes reach the peak of their exponential moving average (α = 0.2) of yearly patent filings in 2022:\n\nA22B, A23J, A23P, A24D, A24F, A41G, A47F, A61G, A61H, A61P, A62D, A63H, B04B, B07B, B08B, B09C, B21J, B22F, B24B, B25B, B25D, B27C, B27M, B60D, B60L, B60P, B61H, B63C, B63G, B65G, B66F, C01D, C01G, C21B, C21C, C22C, D21B, E01H, E02B, E02D, E03B, E04B, E04G, E21D, E21F, F02K, F04F, F16M, F25J, F26B, G01H, G01L, G01S, G05D, G06N, G06Q, G06T, G06V, G08G, G09F, G10L, G16B, G16C, G16H, G21F, H01M, H02B, H02G, H02J, H03H, H04K, H05F\n\nMethod: each patent's primary CPC codes (entries with \"first\": true) were rolled up to their level‑5 CPC symbol (cpc_definition.level = 5, e.g. H01M), each patent counted once per group per filing year (filing_date year); the yearly series was filled with zeros from each group's first to last filing year and the EMA (EMA_t = 0.2·x_t + 0.8·EMA_{t‑1}, earliest year taken on ties) was computed; groups whose EMA maximum falls in 2022 were reported. (The only rolled‑up code not present at level 5 in the CPC definition table, F24J, peaks in 2010 and is therefore excluded anyway.)"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "1",
+    "run": "4",
+    "answer": "72 level-5 CPC group codes have their peak (highest) exponential moving average (α = 0.2, computed over every year from the group's first to its last filing year, missing years = 0) in 2022:\n\nA22B, A23J, A23P, A24D, A24F, A41G, A47F, A61G, A61H, A61P, A62D, A63H, B04B, B07B, B08B, B09C, B21J, B22F, B24B, B25B, B25D, B27C, B27M, B60D, B60L, B60P, B61H, B63C, B63G, B65G, B66F, C01D, C01G, C21B, C21C, C22C, D21B, E01H, E02B, E02D, E03B, E04B, E04G, E21D, E21F, F02K, F04F, F16M, F25J, F26B, G01H, G01L, G01S, G05D, G06N, G06Q, G06T, G06V, G08G, G09F, G10L, G16B, G16C, G16H, G21F, H01M, H02B, H02G, H02J, H03H, H04K, H05F\n\nMethod: for each patent, only primary CPC codes (first = true) were used and each patent counted once per level-5 group (the 4-character CPC symbol, i.e., level = 5 in cpc_definition); filings per year were taken from filing_date (277,813 publications; \"None Date\" rows excluded); ties on the peak EMA resolved to the earliest year."
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "2",
+    "run": "0",
+    "answer": "Scope found in the data: 34 Germany (country code DE) patent publications have a grant date in the second half of 2019 (Jul–Dec 2019); their primary CPC codes (first = true) map to 44 CPC groups at level 4 (main groups).\n\nHIGHEST EMA (α = 0.1) of yearly patent filings – Germany (German filings, areas selected by the H2‑2019 grant filter; missing years counted as 0):\n1. F02D41/00 – \"Electrical control of supply of combustible mixture or its constituents\" – peak EMA ≈ 2.60, best year 2016  ← highest\n2. B60N2/00 – \"Seats specially adapted for vehicles; Arrangement or mounting of seats in vehicles\" – peak EMA ≈ 2.21, best year 2019\n3. B60K6/00 – \"Arrangement or mounting of plural diverse prime-movers for mutual or common propulsion, e.g. hybrid propulsion systems comprising electric motors and internal combustion engines; Control systems therefor\" – peak EMA ≈ 1.72, best year 2020\n4. H01L23/00 – \"Details of semiconductor or other solid state devices\" – peak EMA ≈ 1.24, best year 2018\n5. B29C45/00 – \"Injection moulding, i.e. forcing the required volume of moulding material through a nozzle into a closed mould; Apparatus therefor\" – peak EMA ≈ 1.17, best year 2004\n(then B62D25/00 \"Superstructure or monocoque structure sub-units…\" 2013; H02J7/00 \"Circuit arrangements for charging or depolarising batteries…\" 2022)\n\nAlternative bases for the yearly filing counts (same 44 areas, same EMA method):\n• If the yearly filing series is taken over the whole corpus (all countries): H04W72/00 \"Local resource management\" is highest (peak EMA ≈ 51.9, best year 2021), then H01L23/00 \"Details of semiconductor or other solid state devices\" (≈ 44.3, 2022) and H02J7/00 \"Circuit arrangements for charging or depolarising batteries or for supplying loads from batteries\" (≈ 27.4, 2022); F02D41/00 ranks 7th (≈ 16.8, best year 2020).\n• If only the 34 patents granted in Germany in H2 2019 themselves are counted, every group has exactly one filing, so each group's EMA peaks at 1.0 (all tied) in that patent's filing year: A21C9/00 2015, A61B90/00 2016, A61F5/00 2016, B23K1/00 2015, B29C45/00 2012, B29C49/00 2007, B41F21/00 2007, B60K6/00 2013, B60N2/00 2009, B60S9/00 2016, B62D25/00 2010, B63B21/00 2014, C09K11/00 2015, E02F3/00 2012, E05B19/00 2012, F02D13/00 2018, F02D35/00 2017, F02D41/00 2010, F02M55/00 2014, F02M65/00 2010, F02P3/00 2011, F16C33/00 2011, F16D27/00 2014, F16H3/00 2009, F23B50/00 2018, F23N1/00 2018, F24B5/00 2018, F41H11/00 2012, G01F23/00 2008, G01L27/00 2017, G01M1/00 2018, G02B21/00 2018, G02B23/00 2016, G02B26/00 2018, G08B17/00 2017, H01J49/00 2013, H01L23/00 2008, H01L25/00 2008, H01R35/00 2018, H02J7/00 2009, H03L7/00 2015, H04L7/00 2015, H04W52/00 2015, H04W72/00 2015.\n\nShort answer: the top German level‑4 CPC area is F02D41/00 – \"Electrical control of supply of combustible mixture or its constituents\" – with its highest EMA of yearly filings in 2016 (≈ 2.6 filings); if the EMA is computed on worldwide filings the top area is H04W72/00 – \"Local resource management\" – peaking in 2021 (≈ 51.9 filings)."
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "2",
+    "run": "1",
+    "answer": "Analysis: 34 German (DE) patents granted between 1 Jul and 31 Dec 2019; their primary (first = true) CPC codes were rolled up to CPC level‑4 groups and yearly filing counts (filing‑date year, zero‑filled from each group's first to last year) were smoothed with an EMA, α = 0.1.\n\nHighest EMA (max EMA = 2.00):\n1) Group H04 — \"ELECTRIC COMMUNICATION TECHNIQUE\" — best year 2015 (2 filings, both in 2015 → EMA 2.00)\n2) Group A61 — \"MEDICAL OR VETERINARY SCIENCE; HYGIENE\" — best year 2016 (2 filings, both in 2016 → EMA 2.00; ties on EMA, later best year than H04)\n\nEverything else peaks at an EMA of 1.00 (single‑filing years), e.g.:\n- B29 \"WORKING OF PLASTICS; WORKING OF SUBSTANCES IN A PLASTIC STATE IN GENERAL\" — 2007 (EMA 1.00; counts 2007–2012 = 1,0,0,0,0,1, final EMA 0.69)\n- B41 \"PRINTING; LINING MACHINES; TYPEWRITERS; STAMPS\" — 2007 (EMA 1.00)\n- G01 \"MEASURING; TESTING\" — 2008 (EMA 1.00; 2008–2018 = 1,0,0,0,0,0,0,0,0,1,1, final 0.54)\n- H01 \"ELECTRIC ELEMENTS\" — 2008 (EMA 1.00; 2008–2018 = 1,0,0,0,0,1,0,0,0,0,1, final 0.51)\n- B60 \"VEHICLES IN GENERAL\" — 2009; F16 \"ENGINEERING ELEMENTS AND UNITS…\" — 2009; F02 \"COMBUSTION ENGINES…\" — 2010 (final EMA 0.36, 5 filings 2010–2018)\n\nSo the top CPC technology area is H04 (ELECTRIC COMMUNICATION TECHNIQUE), best year 2015, EMA 2.0 (tied at EMA 2.0 with A61 – MEDICAL OR VETERINARY SCIENCE; HYGIENE, best year 2016)."
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "2",
+    "run": "2",
+    "answer": "Universe used: German patent publications (country code DE in Patents_info) with a grant date in the second half of 2019 (1 Jul – 31 Dec 2019) = 34 patents. For each patent only its primary CPC codes (\"first\": true, de-duplicated) were kept, rolled up to the level‑4 CPC group (level = 4 in cpc_definition, e.g. \"A61\"), filings counted once per patent per group per filing year, and an EMA (alpha = 0.1, gaps filled with 0 from the group's first to last filing year) computed per group.\n\nHIGHEST EMA (tied at 2.00):\n1) A61 – \"MEDICAL OR VETERINARY SCIENCE; HYGIENE\" – peak EMA 2.00 in 2016 (2 filings, both in 2016)\n2) H04 – \"ELECTRIC COMMUNICATION TECHNIQUE\" – peak EMA 2.00 in 2015 (2 filings, both in 2015)\n\nFull ranking (CPC level‑4 group | full title | patents | filings by year | peak EMA | best year):\n- A61 | MEDICAL OR VETERINARY SCIENCE; HYGIENE | 2 | 2016:2 | 2.00 | 2016\n- H04 | ELECTRIC COMMUNICATION TECHNIQUE | 2 | 2015:2 | 2.00 | 2015\n- F02 | COMBUSTION ENGINES; HOT-GAS OR COMBUSTION-PRODUCT ENGINE PLANTS | 5 | 2010:1, 2011:1, 2014:1, 2017:1, 2018:1 | 1.00 | 2010\n- B60 | VEHICLES IN GENERAL | 3 | 2009:1, 2013:1, 2016:1 | 1.00 | 2009\n- F16 | ENGINEERING ELEMENTS AND UNITS; GENERAL MEASURES FOR PRODUCING AND MAINTAINING EFFECTIVE FUNCTIONING OF MACHINES OR INSTALLATIONS; THERMAL INSULATION IN GENERAL | 3 | 2009:1, 2011:1, 2014:1 | 1.00 | 2009\n- G01 | MEASURING; TESTING | 3 | 2008:1, 2017:1, 2018:1 | 1.00 | 2008\n- H01 | ELECTRIC ELEMENTS | 3 | 2008:1, 2013:1, 2018:1 | 1.00 | 2008\n- B29 | WORKING OF PLASTICS; WORKING OF SUBSTANCES IN A PLASTIC STATE IN GENERAL | 2 | 2007:1, 2012:1 | 1.00 | 2007\n- G02 | OPTICS | 2 | 2016:1, 2018:1 | 1.00 | 2016\n- A21 | BAKING; EDIBLE DOUGHS | 1 | 2015:1 | 1.00 | 2015\n- B23 | MACHINE TOOLS; METAL-WORKING NOT OTHERWISE PROVIDED FOR | 1 | 2015:1 | 1.00 | 2015\n- B41 | PRINTING; LINING MACHINES; TYPEWRITERS; STAMPS | 1 | 2007:1 | 1.00 | 2007\n- B62 | LAND VEHICLES FOR TRAVELLING OTHERWISE THAN ON RAILS | 1 | 2010:1 | 1.00 | 2010\n- B63 | SHIPS OR OTHER WATERBORNE VESSELS; RELATED EQUIPMENT | 1 | 2014:1 | 1.00 | 2014\n- C09 | DYES; PAINTS; POLISHES; NATURAL RESINS; ADHESIVES; COMPOSITIONS NOT OTHERWISE PROVIDED FOR; APPLICATIONS OF MATERIALS NOT OTHERWISE PROVIDED FOR | 1 | 2015:1 | 1.00 | 2015\n- E02 | HYDRAULIC ENGINEERING; FOUNDATIONS; SOIL SHIFTING | 1 | 2012:1 | 1.00 | 2012\n- E05 | LOCKS; KEYS; WINDOW OR DOOR FITTINGS; SAFES | 1 | 2012:1 | 1.00 | 2012\n- F23 | COMBUSTION APPARATUS; COMBUSTION PROCESSES | 1 | 2018:1 | 1.00 | 2018\n- F24 | HEATING; RANGES; VENTILATING | 1 | 2018:1 | 1.00 | 2018\n- F41 | WEAPONS | 1 | 2012:1 | 1.00 | 2012\n- G08 | SIGNALLING | 1 | 2017:1 | 1.00 | 2017\n- H02 | GENERATION; CONVERSION OR DISTRIBUTION OF ELECTRIC POWER | 1 | 2009:1 | 1.00 | 2009\n- H03 | ELECTRONIC CIRCUITRY | 1 | 2015:1 | 1.00 | 2015\n\n(Where several years tie for the highest average, the earliest year was taken.)"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "2",
+    "run": "3",
+    "answer": "Scope: 34 German (DE) patent publications whose grant date falls in July–December 2019. Each patent was counted once per level‑4 CPC group (cpc_definition.level = 4, i.e. the class‑level ancestor of each of its primary CPC codes, the entries with \"first\": true), filings were tallied by filing year, and a 0‑filled year series (first filing year → last filing year) was smoothed with EMA, α = 0.1.\n\nTop CPC technology areas in Germany (level‑4 group code | full title | best year | peak EMA):\n1. F02 | COMBUSTION ENGINES; HOT-GAS OR COMBUSTION-PRODUCT ENGINE PLANTS | best year 2018 | EMA 0.3465 (5 filings: 2010, 2011, 2014, 2017, 2018)\n2. F16 | ENGINEERING ELEMENTS AND UNITS; GENERAL MEASURES FOR PRODUCING AND MAINTAINING EFFECTIVE FUNCTIONING OF MACHINES OR INSTALLATIONS; THERMAL INSULATION IN GENERAL | best year 2014 | EMA 0.2319 (3 filings: 2009, 2011, 2014)\n3. G01 | MEASURING; TESTING | best year 2018 | EMA 0.2249 (3 filings: 2008, 2017, 2018)\n4. B60 | VEHICLES IN GENERAL | best year 2016 | EMA 0.2207 (3 filings: 2009, 2013, 2016)\n5. A61 | MEDICAL OR VETERINARY SCIENCE; HYGIENE | best year 2016 | EMA 0.2000 (2 filings, both 2016) — tied with H04 | ELECTRIC COMMUNICATION TECHNIQUE | best year 2015 | EMA 0.2000 (2 filings, both 2015)\n\nSo the leading area is F02 – COMBUSTION ENGINES; HOT-GAS OR COMBUSTION-PRODUCT ENGINE PLANTS, whose exponentially smoothed filing level peaks at 0.346 in 2018.\n\nNote on convention: if the EMA is instead seeded with the group's first-year count (pandas ewm(adjust=False), EMA₀ = count₀) rather than started from zero, the single-year spikes dominate and the top result becomes a tie at EMA = 2.0 between H04 (ELECTRIC COMMUNICATION TECHNIQUE, best year 2015) and A61 (MEDICAL OR VETERINARY SCIENCE; HYGIENE, best year 2016), with F02 next (peak 1.0, best year 2010)."
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "2",
+    "run": "4",
+    "answer": "Scope: German (DE) patent publications with grant dates between 1 Jul 2019 and 31 Dec 2019 → 34 granted patents. Only primary CPC codes (\"first\": true) were used, each patent counted once per CPC group; groups = cpc_definition rows with level = 4 (CPC classes). Yearly filing counts (filing_date year, zero-filled from each group's first to last filing year) were smoothed with EMA, α = 0.1.\n\nHighest EMA (best year in brackets):\n1. F02 — COMBUSTION ENGINES; HOT-GAS OR COMBUSTION-PRODUCT ENGINE PLANTS — max EMA ≈ 0.3465 (best year 2018; filings 2010:1, 2011:1, 2012:0, 2013:0, 2014:1, 2015:0, 2016:0, 2017:1, 2018:1; 5 patents — the most of any group)\n2. F16 — ENGINEERING ELEMENTS AND UNITS; GENERAL MEASURES FOR PRODUCING AND MAINTAINING EFFECTIVE FUNCTIONING OF MACHINES OR INSTALLATIONS; THERMAL INSULATION IN GENERAL — ≈ 0.2319 (best year 2014; 2009/2011/2014, 3 patents)\n3. G01 — MEASURING; TESTING — ≈ 0.2249 (best year 2018; 2008/2017/2018, 3 patents)\n4. B60 — VEHICLES IN GENERAL — ≈ 0.2207 (best year 2016; 2009/2013/2016, 3 patents)\n5. A61 — MEDICAL OR VETERINARY SCIENCE; HYGIENE — 0.2000 (best year 2016, 2 filings in that year)\n5. H04 — ELECTRIC COMMUNICATION TECHNIQUE — 0.2000 (best year 2015, 2 filings in that year)\n7. H01 — ELECTRIC ELEMENTS — ≈ 0.1939 (best year 2018)\n8. G02 — OPTICS — ≈ 0.1810 (best year 2018)\n\nAnswer: the leading CPC technology area is F02, \"COMBUSTION ENGINES; HOT-GAS OR COMBUSTION-PRODUCT ENGINE PLANTS\", whose EMA of patent filings peaks in 2018 (EMA ≈ 0.35); the other 22 level-4 groups (A21, B23, B29, B41, B62, B63, C09, E02, E05, F23, F24, F41, G08, H02, H03, etc.) all have lower averages (≤ 0.16).\n\nNote: if the EMA is instead seeded with the first observation (pandas ewm(adjust=False) style), every group's average is dominated by its seed and the top becomes a tie between A61 (2016) and H04 (2015) at 2.0, since each had 2 filings in a single year."
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "3",
+    "run": "0",
+    "answer": "Four non‑Berkeley assignees cite patents assigned to UNIV CALIFORNIA in this database (the 169 UNIV CALIFORNIA publications were matched against the `citation` lists of all 277,813 publications; UC self‑citations excluded). For each citing patent, its primary CPC codes (entries with \"first\": true) and the full CPC titles are:\n\n1) CALIFORNIA INST OF TECHN — citing pub. US-2005165588-A1, cites US-6237292-B1 (UNIV CALIFORNIA AT SAN DIEGO)\n   - Primary CPC G01V1/01 → \"Measuring or predicting earthquakes\" (subclass G01V: \"GEOPHYSICS; GRAVITATIONAL MEASUREMENTS; DETECTING MASSES OR OBJECTS; TAGS\")\n\n2) BLOOM ENERGY CORP — citing pub. US-10615444-B2, cites US-6767662-B2 (UNIV CALIFORNIA)\n   - Primary CPC H01M4/9066 → \"Metals or alloys specially used in fuel cell operating at high temperature, e.g. SOFC of metal-ceramic composites or mixtures, e.g. cermets\"\n   - Primary CPC H01M8/2425 → \"High-temperature cells with solid electrolytes\"\n   (subclass H01M: \"PROCESSES OR MEANS, e.g. BATTERIES, FOR THE DIRECT CONVERSION OF CHEMICAL ENERGY INTO ELECTRICAL ENERGY\")\n\n3) CRYSTAL IS INC — citing pub. US-9447521-B2, cites US-2010025717-A1 (UNIV CALIFORNIA)\n   - Primary CPC C30B11/003 → \"Heating or cooling of the melt or the crystallised material\"\n   - Primary CPC C30B25/10 → \"Heating of the reaction chamber or the substrate\"\n   - Primary CPC C30B25/16 → \"Controlling or regulating\"\n   (subclass C30B: \"SINGLE-CRYSTAL GROWTH; UNIDIRECTIONAL SOLIDIFICATION OF EUTECTIC MATERIAL OR UNIDIRECTIONAL DEMIXING OF EUTECTOID MATERIAL; REFINING BY ZONE-MELTING OF MATERIAL; PRODUCTION OF A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; SINGLE CRYSTALS OR HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; AFTER-TREATMENT OF SINGLE CRYSTALS OR A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; APPARATUS THEREFOR\")\n\n4) SCHOWALTER LEO J — citing pub. US-9437430-B2, cites US-2010025717-A1 (UNIV CALIFORNIA)\n   - Primary CPC H01L21/0262 → \"Reduction or decomposition of gaseous compounds, e.g. CVD\"\n   (subclass H01L: \"SEMICONDUCTOR DEVICES NOT COVERED BY CLASS H10\")\n\nSummary (assignee → CPC subclass full title):\n- CALIFORNIA INST OF TECHN → GEOPHYSICS; GRAVITATIONAL MEASUREMENTS; DETECTING MASSES OR OBJECTS; TAGS (G01V / G01V1/01 \"Measuring or predicting earthquakes\")\n- BLOOM ENERGY CORP → PROCESSES OR MEANS, e.g. BATTERIES, FOR THE DIRECT CONVERSION OF CHEMICAL ENERGY INTO ELECTRICAL ENERGY (H01M; H01M4/9066 and H01M8/2425 as above)\n- CRYSTAL IS INC → SINGLE-CRYSTAL GROWTH; … APPARATUS THEREFOR (C30B; C30B11/003, C30B25/10, C30B25/16 as above)\n- SCHOWALTER LEO J → SEMICONDUCTOR DEVICES NOT COVERED BY CLASS H10 (H01L; H01L21/0262 \"Reduction or decomposition of gaseous compounds, e.g. CVD\")"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "3",
+    "run": "1",
+    "answer": "In publication_database, 169 publications are assigned to UNIV CALIFORNIA (incl. \"UNIV CALIFORNIA AT SAN DIEGO\" / \"UNIV CALIFORNIA BUSINESS AND P\"; 172 including family members, 335 publication/application numbers). Scanning all 1,470,107 citation entries of all 277,813 publications, exactly 4 publications cite UNIV CALIFORNIA-assigned patents, held by 4 different (non‑UC) assignees:\n\n1) CALIFORNIA INST OF TECHN (US‑2005165588‑A1, app. US‑4007205‑A) — cites UCSD patent US‑6237292‑B1\n   Primary CPC: G01V1/01 → subclass G01V\n   Subclass title: \"GEOPHYSICS; GRAVITATIONAL MEASUREMENTS; DETECTING MASSES OR OBJECTS; TAGS\"\n\n2) BLOOM ENERGY CORP (US‑10615444‑B2, app. US‑201715785968‑A) — cites UC patent US‑6767662‑B2\n   Primary CPCs: H01M8/2425, H01M4/9066 → subclass H01M\n   Subclass title: \"PROCESSES OR MEANS, e.g. BATTERIES, FOR THE DIRECT CONVERSION OF CHEMICAL ENERGY INTO ELECTRICAL ENERGY\"\n\n3) CRYSTAL IS INC (US‑9447521‑B2, app. US‑201414520615‑A) — cites UC patent US‑2010025717‑A1\n   Primary CPCs: C30B11/003, C30B25/10, C30B25/16 → subclass C30B\n   Subclass title: \"SINGLE-CRYSTAL GROWTH; UNIDIRECTIONAL SOLIDIFICATION OF EUTECTIC MATERIAL OR UNIDIRECTIONAL DEMIXING OF EUTECTOID MATERIAL; REFINING BY ZONE-MELTING OF MATERIAL; PRODUCTION OF A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; SINGLE CRYSTALS OR HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; AFTER-TREATMENT OF SINGLE CRYSTALS OR A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; APPARATUS THEREFOR\"\n\n4) SCHOWALTER LEO J (US‑9437430‑B2, app. US‑2000608‑A) — cites UC patent US‑2010025717‑A1\n   Primary CPC: H01L21/0262 → subclass H01L\n   Subclass title: \"SEMICONDUCTOR DEVICES NOT COVERED BY CLASS H10\"\n\nSummary (assignee → CPC subclass → subclass title):\n- CALIFORNIA INST OF TECHN → G01V → GEOPHYSICS; GRAVITATIONAL MEASUREMENTS; DETECTING MASSES OR OBJECTS; TAGS\n- BLOOM ENERGY CORP → H01M → PROCESSES OR MEANS, e.g. BATTERIES, FOR THE DIRECT CONVERSION OF CHEMICAL ENERGY INTO ELECTRICAL ENERGY\n- CRYSTAL IS INC → C30B → SINGLE-CRYSTAL GROWTH; UNIDIRECTIONAL SOLIDIFICATION OF EUTECTIC MATERIAL OR UNIDIRECTIONAL DEMIXING OF EUTECTOID MATERIAL; REFINING BY ZONE-MELTING OF MATERIAL; PRODUCTION OF A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; SINGLE CRYSTALS OR HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; AFTER-TREATMENT OF SINGLE CRYSTALS OR A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; APPARATUS THEREFOR\n- SCHOWALTER LEO J → H01L → SEMICONDUCTOR DEVICES NOT COVERED BY CLASS H10"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "3",
+    "run": "2",
+    "answer": "Four non‑UC patents in the publication_database cite patents assigned to UNIV CALIFORNIA (incl. UNIV CALIFORNIA AT SAN DIEGO). Their assignees, the cited UC patent(s), and the primary (first = true) CPC codes with their full CPC titles are:\n\n1) CALIFORNIA INST OF TECHN (citing pub. US-2005165588-A1)\n   - Cites UC patent: US-6237292-B1 (UNIV CALIFORNIA AT SAN DIEGO)\n   - Primary CPC: G01V1/01 — \"Measuring or predicting earthquakes\"\n     (Subclass G01V — \"GEOPHYSICS; GRAVITATIONAL MEASUREMENTS; DETECTING MASSES OR OBJECTS; TAGS\")\n\n2) BLOOM ENERGY CORP (citing pub. US-10615444-B2)\n   - Cites UC patent: US-6767662-B2 (UNIV CALIFORNIA)\n   - Primary CPCs:\n     H01M4/9066 — \"Metals or alloys specially used in fuel cell operating at high temperature, e.g. SOFC of metal-ceramic composites or mixtures, e.g. cermets\"\n     H01M8/2425 — \"High-temperature cells with solid electrolytes\"\n     (Subclass H01M — \"PROCESSES OR MEANS, e.g. BATTERIES, FOR THE DIRECT CONVERSION OF CHEMICAL ENERGY INTO ELECTRICAL ENERGY\")\n\n3) CRYSTAL IS INC (citing pub. US-9447521-B2)\n   - Cites UC patent: US-2010025717-A1 (UNIV CALIFORNIA)\n   - Primary CPCs:\n     C30B11/003 — \"Heating or cooling of the melt or the crystallised material\"\n     C30B25/10 — \"Heating of the reaction chamber or the substrate\"\n     C30B25/16 — \"Controlling or regulating\"\n     (Subclass C30B — \"SINGLE-CRYSTAL GROWTH; UNIDIRECTIONAL SOLIDIFICATION OF EUTECTIC MATERIAL OR UNIDIRECTIONAL DEMIXING OF EUTECTOID MATERIAL; REFINING BY ZONE-MELTING OF MATERIAL; PRODUCTION OF A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; SINGLE CRYSTALS OR HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; AFTER-TREATMENT OF SINGLE CRYSTALS OR A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; APPARATUS THEREFOR\")\n\n4) SCHOWALTER LEO J (citing pub. US-9437430-B2)\n   - Cites UC patent: US-2010025717-A1 (UNIV CALIFORNIA)\n   - Primary CPC: H01L21/0262 — \"Reduction or decomposition of gaseous compounds, e.g. CVD\"\n     (Subclass H01L — \"SEMICONDUCTOR DEVICES NOT COVERED BY CLASS H10\")\n\nSummary of distinct citing assignees: CALIFORNIA INST OF TECHN, BLOOM ENERGY CORP, CRYSTAL IS INC, SCHOWALTER LEO J (no citing patent assigned to UNIV CALIFORNIA itself was found)."
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "3",
+    "run": "3",
+    "answer": "Only 4 publications in the database cite a UNIV CALIFORNIA-assigned patent, and all 4 have non-UC assignees:\n\n1) CALIFORNIA INST OF TECHN (citing pub. US-2005165588-A1; cited UC patent US-6237292-B1) – primary CPC subclass G01V: \"GEOPHYSICS; GRAVITATIONAL MEASUREMENTS; DETECTING MASSES OR OBJECTS; TAGS\"\n\n2) BLOOM ENERGY CORP (citing pub. US-10615444-B2; cited UC patent US-6767662-B2) – primary CPC subclass H01M: \"PROCESSES OR MEANS, e.g. BATTERIES, FOR THE DIRECT CONVERSION OF CHEMICAL ENERGY INTO ELECTRICAL ENERGY\"\n\n3) CRYSTAL IS INC (citing pub. US-9447521-B2; cited UC patent US-2010025717-A1) – primary CPC subclass C30B: \"SINGLE-CRYSTAL GROWTH; UNIDIRECTIONAL SOLIDIFICATION OF EUTECTIC MATERIAL OR UNIDIRECTIONAL DEMIXING OF EUTECTOID MATERIAL; REFINING BY ZONE-MELTING OF MATERIAL; PRODUCTION OF A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; SINGLE CRYSTALS OR HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; AFTER-TREATMENT OF SINGLE CRYSTALS OR A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; APPARATUS THEREFOR\"\n\n4) SCHOWALTER LEO J (citing pub. US-9437430-B2; cited UC patent US-2010025717-A1) – primary CPC subclass H01L: \"SEMICONDUCTOR DEVICES NOT COVERED BY CLASS H10\"\n\n(For reference, if the subclass is taken from the cited UC patents themselves rather than the citing patents: US-6237292-B1's primary code E04H9/021 belongs to subclass E04H – \"BUILDINGS OR LIKE STRUCTURES FOR PARTICULAR PURPOSES; SWIMMING OR SPLASH BATHS OR POOLS; MASTS; FENCING; TENTS OR CANOPIES, IN GENERAL\"; US-6767662-B2's primary code H01M4/0419 belongs to subclass H01M (title as above); and US-2010025717-A1's primary codes H01L33/22 and H01L33/30 belong to subclass H01L (title as above), which is therefore the subclass for both CRYSTAL IS INC and SCHOWALTER LEO J.)"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "3",
+    "run": "4",
+    "answer": "Four non‑\"UNIV CALIFORNIA\" assignees cite patents assigned to UNIV CALIFORNIA (matching the 169 UNIV CALIFORNIA‑assigned publications in publicationinfo against the citation lists of all 277,813 publications). For each citing patent, its primary CPC codes (entries flagged first = true) were mapped to their CPC subclass (level‑5 symbol), whose full title comes from cpc_definition.titleFull:\n\n1) CALIFORNIA INST OF TECHN — citing publication US‑2005165588‑A1, cites US‑6237292‑B1 (UNIV CALIFORNIA AT SAN DIEGO)\n   Primary CPC: G01V1/01 → subclass G01V: \"GEOPHYSICS; GRAVITATIONAL MEASUREMENTS; DETECTING MASSES OR OBJECTS; TAGS\"\n\n2) BLOOM ENERGY CORP — citing publication US‑10615444‑B2, cites US‑6767662‑B2 (UNIV CALIFORNIA)\n   Primary CPC: H01M8/2425, H01M4/9066 → subclass H01M: \"PROCESSES OR MEANS, e.g. BATTERIES, FOR THE DIRECT CONVERSION OF CHEMICAL ENERGY INTO ELECTRICAL ENERGY\"\n\n3) CRYSTAL IS INC — citing publication US‑9447521‑B2, cites US‑2010025717‑A1 (UNIV CALIFORNIA)\n   Primary CPC: C30B23/00, C30B25/16, C30B25/10 → subclass C30B: \"SINGLE‑CRYSTAL GROWTH; UNIDIRECTIONAL SOLIDIFICATION OF EUTECTIC MATERIAL OR UNIDIRECTIONAL DEMIXING OF EUTECTOID MATERIAL; REFINING BY ZONE‑MELTING OF MATERIAL; PRODUCTION OF A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; SINGLE CRYSTALS OR HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; AFTER‑TREATMENT OF SINGLE CRYSTALS OR A HOMOGENEOUS POLYCRYSTALLINE MATERIAL WITH DEFINED STRUCTURE; APPARATUS THEREFOR\"\n\n4) SCHOWALTER LEO J — citing publication US‑9437430‑B2, cites US‑2010025717‑A1 (UNIV CALIFORNIA)\n   Primary CPC: H01L21/0262 → subclass H01L: \"SEMICONDUCTOR DEVICES NOT COVERED BY CLASS H10\"\n\n(For reference, the full titles of the primary groups themselves: G01V1/01 \"Measuring or predicting earthquakes\"; H01M8/2425 \"High‑temperature cells with solid electrolytes\"; H01M4/9066 \"Metals or alloys specially used in fuel cell operating at high temperature, e.g. SOFC of metal‑ceramic composites or mixtures, e.g. cermets\"; C30B23/00 \"Single‑crystal growth by condensing evaporated or sublimed materials\"; C30B25/10 \"Heating of the reaction chamber or the substrate\"; C30B25/16 \"Controlling or regulating\"; H01L21/0262 \"Reduction or decomposition of gaseous compounds, e.g. CVD\".)"
+  },
+  {
+    "dataset": "agnews",
+    "query": "1",
+    "run": "0",
+    "answer": "The Rundown"
+  },
+  {
+    "dataset": "agnews",
+    "query": "1",
+    "run": "1",
+    "answer": "The Rundown"
+  },
+  {
+    "dataset": "agnews",
+    "query": "1",
+    "run": "2",
+    "answer": "The Rundown"
+  },
+  {
+    "dataset": "agnews",
+    "query": "1",
+    "run": "3",
+    "answer": "The Rundown"
+  },
+  {
+    "dataset": "agnews",
+    "query": "1",
+    "run": "4",
+    "answer": "\"The Rundown\" (article_id 69413) — a college football preview (Miami at N.C. State), whose description is 841 characters, the longest of any sports article. All 39 articles with longer descriptions are Sci/Tech, Business, or World/politics pieces."
+  },
+  {
+    "dataset": "agnews",
+    "query": "2",
+    "run": "0",
+    "answer": "About 0.16 of Amy Jones's articles are Science/Technology — 18 out of her 111 articles (18/111 = 6/37 ≈ 0.162, i.e. ~16.2%)."
+  },
+  {
+    "dataset": "agnews",
+    "query": "2",
+    "run": "1",
+    "answer": "Approximately 17% — 19 of Amy Jones's 111 articles (19/111 ≈ 0.171) fall into the Science/Technology category.\n\n(Breakdown of her 111 articles by inferred category: World 29, Business 35, Sports 28, Science/Technology 19.)"
+  },
+  {
+    "dataset": "agnews",
+    "query": "2",
+    "run": "2",
+    "answer": "About 0.18 (18%) — 20 of Amy Jones' 111 articles are Science/Technology (20/111 = 0.1802)."
+  },
+  {
+    "dataset": "agnews",
+    "query": "2",
+    "run": "3",
+    "answer": "About one in five — roughly 21 of Amy Jones's 111 articles (≈0.19, or 19%) fall into the Science/Technology category.\n\nDetails: Amy Jones (author_id 218) wrote 111 articles. Reading each title/description, ~21 are Science/Technology (e.g., GameBoy mini-games win prize; students' science competition; wave-energy science award; Iraq science rebuild; Genesis space probe crash; shuttle repair costs; Microsoft–Sendo tech settlement; EMC e-mail storage; Vodafone tech brief; space tourism doubt; blog vote-fraud story; crowd-fear study; Ontario water studies; HP virus-throttling software; XM satellite radio on phones; eBay \"Want It Now\"; Lenovo/IBM PC deal; PayPal–iTunes tie-up; US ocean research oversight; satellite-spy site). The rest split mainly across Sports, Business, and World news."
+  },
+  {
+    "dataset": "agnews",
+    "query": "2",
+    "run": "4",
+    "answer": "About 0.21 (roughly 1 in 5).\n\nAmy Jones (author_id 218) wrote 111 articles. Classifying each article's title/description into World, Sports, Business, or Science/Technology, about 23 of them fall under Science/Technology (e.g., the GameBoy mini-games prize, science-competition winners, NASA's Genesis probe crash, shuttle repair costs, Microsoft/Sendo settlement, EMC's e-mail storage product, HP's virus-throttling software, eBay's \"Want It Now\", PayPal–iTunes tie-up, space tourism doubt, the crowd-fear study, etc.).\n\n23/111 ≈ 0.207, i.e. ~21% of her articles are Science/Technology."
+  },
+  {
+    "dataset": "agnews",
+    "query": "3",
+    "run": "0",
+    "answer": "Approximately 335 business articles per year (about 3,685–3,700 business articles in total across Europe for 2010–2020).\n\nHow this was obtained:\n- metadata_database: filtering article_metadata for region = 'Europe' and publication_date between 2010-01-01 and 2020-12-31 gives 14,860 articles (yearly counts: 1306, 1316, 1355, 1354, 1372, 1357, 1364, 1391, 1351, 1328, 1366 — an average of 1,351 articles/year).\n- articles_database: titles/descriptions of these 14,860 articles were classified into the four categories (World, Sports, Business, Science/Technology) using a keyword/pattern classifier (financial/market/company terms for Business) validated against a self-trained (Naive Bayes, self-labeled) classifier.\n- The Business category accounts for roughly 24.8–25% of the articles (consistent with the balanced 4-class distribution of the corpus, ~25% per class, and with the per-class Europe/period shares being nearly identical, i.e. region and date are independent of category).\n- 0.25 × 14,860 ≈ 3,690 business articles ÷ 11 years ≈ 335 per year."
+  },
+  {
+    "dataset": "agnews",
+    "query": "3",
+    "run": "1",
+    "answer": "≈ 337 business articles per year.\n\nDetails: In Europe, 14,860 articles were published in 2010–2020 (inclusive). Classifying each article's title/description into World / Sports / Business / Science-Technology shows that roughly a quarter of them (~3,700, i.e. 3,700–3,715) are Business stories. Dividing by the 11 years (2010–2020) gives an average of about 337 (≈340) business articles per year (yearly counts ranged from ~316 to ~375)."
+  },
+  {
+    "dataset": "agnews",
+    "query": "3",
+    "run": "2",
+    "answer": "Approximately 338 business articles per year.\n\nDetails: 14,860 articles were published in the Europe region between 2010-01-01 and 2020-12-31. Classifying each article's title/description into World / Sports / Business / Science‑Technology shows about 3,720 of them are business articles (~25% share, consistent with the dataset's balanced 4‑class mix), which over the 11 years (2010–2020 inclusive) gives 3,720 ÷ 11 ≈ 338 business articles per year (yearly counts ranged from about 310 in 2010 to about 379 in 2017)."
+  },
+  {
+    "dataset": "agnews",
+    "query": "3",
+    "run": "3",
+    "answer": "About 338 business articles per year on average in Europe over 2010–2020.\n\nDetails: Europe has 14,860 articles dated 2010-01-01 to 2020-12-31 (1,306/1,316/1,355/1,354/1,372/1,357/1,364/1,391/1,351/1,328/1,366 for 2010…2020). Classifying each article's title/description into World / Sports / Business / Sci-Tech (keyword-rule classifier, hand-validated on a random sample and calibrated against the corpus's known class balance) gives ≈3,700–3,720 Business articles in that slice, i.e. ≈335–340 per year (best point estimate ≈338; plausible range ~315–365).</answer>\n</invoke>\n"
+  },
+  {
+    "dataset": "agnews",
+    "query": "3",
+    "run": "4",
+    "answer": "≈ 338 business articles per year.\n\nDetail: Of the 14,860 articles published in the Europe region between 2010-01-01 and 2020-12-31 (inclusive, 11 years), about 3,720 (≈25%, i.e. 3,719–3,744 depending on the classifier calibration) are Business‑category articles. Dividing that total by the 11 years gives an average of roughly 338 business articles per year (yearly counts range from about 308 in 2010 to about 382 in 2017)."
+  },
+  {
+    "dataset": "agnews",
+    "query": "4",
+    "run": "0",
+    "answer": "South America\n\nUsing the 2015 articles (6,696 total) joined with their titles/descriptions and classifying each into World / Sports / Business / Science-Technology (semi-supervised, balanced model trained on the full corpus), the estimated number of World-category articles per region is:\n\n- South America ≈ 342 (highest)\n- North America ≈ 340\n- Africa ≈ 336\n- Europe ≈ 329\n- Asia ≈ 327\n\nSo South America published the largest number of World-category articles in 2015 (though the top three regions are very close)."
+  },
+  {
+    "dataset": "agnews",
+    "query": "4",
+    "run": "1",
+    "answer": ""
+  },
+  {
+    "dataset": "agnews",
+    "query": "4",
+    "run": "2",
+    "answer": ""
+  },
+  {
+    "dataset": "agnews",
+    "query": "4",
+    "run": "3",
+    "answer": ""
+  },
+  {
+    "dataset": "agnews",
+    "query": "4",
+    "run": "4",
+    "answer": ""
+  },
+  {
+    "dataset": "bookreview",
+    "query": "1",
+    "run": "0",
+    "answer": "2020s — books published in the 2020s (2020–2023) have the highest average rating (≈4.66 across 110 reviews from 21 distinct rated books), beating the 2010s (≈4.61), 2000s (≈4.27), 1980s (≈4.21) and 1990s (≈3.84)."
+  },
+  {
+    "dataset": "bookreview",
+    "query": "1",
+    "run": "1",
+    "answer": "2020s — among publication decades with at least 10 distinct rated books (1980s, 1990s, 2000s, 2010s, 2020s), the 2020s has the highest average review rating (~4.66), edging out the 2010s (~4.61)."
+  },
+  {
+    "dataset": "bookreview",
+    "query": "1",
+    "run": "2",
+    "answer": "2020s — among publication decades with at least 10 distinct rated books, the 2020s has the highest average rating (~4.66 across 110 reviews from 21 books), edging out the 2010s (~4.61)."
+  },
+  {
+    "dataset": "bookreview",
+    "query": "1",
+    "run": "3",
+    "answer": "2020s\n\n(Using publication year parsed from books_info.details, joined to reviews via book_id ↔ purchase_id number: decades with ≥10 distinct rated books are 1980s (11 books, avg 4.21), 1990s (16, 3.82), 2000s (47, 4.28), 2010s (88, 4.61), 2020s (21, 4.66) — the 2020s has the highest average rating.)"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "1",
+    "run": "4",
+    "answer": "2020s — among decades with at least 10 distinct rated books, the 2020s (books published 2020–2023) has the highest average rating (~4.66 across 110 reviews from 21 rated books), edging out the 2010s (~4.61)."
+  },
+  {
+    "dataset": "bookreview",
+    "query": "2",
+    "run": "0",
+    "answer": "15 English-language books in the \"Literature & Fiction\" category have a perfect average review rating of 5.0 (average of all reviews in the review table, joined book_id ↔ purchase_id):\n\n1. Reunion: The Children of Lauderdale Park (bookid_9) – avg 5.0, 3 ratings\n2. The Prophet: With Original 1923 Illustrations by the Author (bookid_38) – avg 5.0, 4 ratings\n3. The Melancholy Strumpet Master (bookid_39) – avg 5.0, 2 ratings\n4. Child Of The King A Journey of Hope Book 1: Earthly Story With A Heavenly Message (bookid_74) – avg 5.0, 8 ratings\n5. Fire Cracker (bookid_82) – avg 5.0, 2 ratings\n6. Local Honey (bookid_84) – avg 5.0, 2 ratings\n7. Hollywood Confessions: Hollywood Headlines Book #3 (Hollywood Headlines Mysteries) (bookid_98) – avg 5.0, 1 rating\n8. Knowing When To Die: Uncollected Stories (bookid_101) – avg 5.0, 2 ratings\n9. Childe Harold of Dysna (bookid_122) – avg 5.0, 1 rating\n10. Forged in Blood (Freehold) (bookid_144) – avg 5.0, 6 ratings\n11. Exits, Desires, & Slow Fires (bookid_171) – avg 5.0, 3 ratings\n12. Kennebago Moments (bookid_177) – avg 5.0, 1 rating\n13. The Sludge (bookid_180) – avg 5.0, 1 rating\n14. Liza of Lambeth (bookid_182) – avg 5.0, 1 rating\n15. Something That Feels Like Truth (Switchgrass Books) (bookid_195) – avg 5.0, 2 ratings\n\nAll 40 \"Literature & Fiction\" books in books_info are listed as written/available in English in their details, so the language filter did not remove any of these."
+  },
+  {
+    "dataset": "bookreview",
+    "query": "2",
+    "run": "1",
+    "answer": "15 English-language books in the \"Literature & Fiction\" category have a perfect (5.0) average review rating:\n\n1. Reunion: The Children of Lauderdale Park (bookid_9) — 3 reviews, avg 5.0\n2. The Prophet: With Original 1923 Illustrations by the Author — Kahlil Gibran (bookid_38) — 4 reviews, avg 5.0\n3. The Melancholy Strumpet Master — Zeb Beck (bookid_39) — 2 reviews, avg 5.0\n4. Child Of The King A Journey of Hope Book 1: Earthly Story With A Heavenly Message — K. G. Ingram (bookid_74) — 8 reviews, avg 5.0\n5. Fire Cracker — Shirley Kennett (bookid_82) — 2 reviews, avg 5.0\n6. Local Honey — Jo Stewart Wray (bookid_84) — 2 reviews, avg 5.0\n7. Hollywood Confessions: Hollywood Headlines Book #3 (Hollywood Headlines Mysteries) — Gemma Halliday (bookid_98) — 1 review, avg 5.0\n8. Knowing When To Die: Uncollected Stories — Mort Castle (bookid_101) — 2 reviews, avg 5.0\n9. Childe Harold of Dysna (bookid_122) — 1 review, avg 5.0\n10. Forged in Blood (Freehold) — Michael Z. Williamson (bookid_144) — 6 reviews, avg 5.0\n11. Exits, Desires, & Slow Fires — J.R. Rogue (bookid_171) — 3 reviews, avg 5.0\n12. Kennebago Moments — Betsy Wolff Frey (bookid_177) — 1 review, avg 5.0\n13. The Sludge — David Bernstein (bookid_180) — 1 review, avg 5.0\n14. Liza of Lambeth (bookid_182) — 1 review, avg 5.0\n15. Something That Feels Like Truth (Switchgrass Books) — Donald Lystra (bookid_195) — 2 reviews, avg 5.0\n\nMethod: books_info rows whose categories list contains exactly \"Literature & Fiction\" (40 books, all confirmed English-language via the details field) were joined to the review table by matching bookid_N to purchaseid_N, then grouped by book and filtered for AVG(rating) = 5.0."
+  },
+  {
+    "dataset": "bookreview",
+    "query": "2",
+    "run": "2",
+    "answer": "15 English-language books in the \"Literature & Fiction\" category have a perfect 5.0 average rating (all reviews in the review table = 5.0 for each; join: bookid_N ↔ purchaseid_N):\n\n1. Reunion: The Children of Lauderdale Park (bookid_9) — Literature & Fiction > Genre Fiction — avg 5.0 (3 reviews)\n2. The Prophet: With Original 1923 Illustrations by the Author (bookid_38) — Kahlil Gibran — Literature & Fiction > Poetry — avg 5.0 (4 reviews)\n3. The Melancholy Strumpet Master (bookid_39) — Zeb Beck — Literature & Fiction > Humor & Satire — avg 5.0 (2 reviews)\n4. Child Of The King A Journey of Hope Book 1: Earthly Story With A Heavenly Message (bookid_74) — K. G. Ingram — Literature & Fiction — avg 5.0 (8 reviews)\n5. Fire Cracker (bookid_82) — Shirley Kennett — Literature & Fiction > United States — avg 5.0 (2 reviews)\n6. Local Honey (bookid_84) — Jo Stewart Wray — Literature & Fiction — avg 5.0 (2 reviews)\n7. Hollywood Confessions: Hollywood Headlines Book #3 (bookid_98) — Gemma Halliday — Literature & Fiction > Genre Fiction — avg 5.0 (1 review)\n8. Knowing When To Die: Uncollected Stories (bookid_101) — Mort Castle — Literature & Fiction > Genre Fiction — avg 5.0 (2 reviews)\n9. Childe Harold of Dysna (bookid_122) — Literature & Fiction > History & Criticism — avg 5.0 (1 review)\n10. Forged in Blood (Freehold) (bookid_144) — Michael Z. Williamson — Literature & Fiction > Short Stories & Anthologies — avg 5.0 (6 reviews)\n11. Exits, Desires, & Slow Fires (bookid_171) — J.R. Rogue — Literature & Fiction > Poetry — avg 5.0 (3 reviews)\n12. Kennebago Moments (bookid_177) — Betsy Wolff Frey — Literature & Fiction > Poetry — avg 5.0 (1 review)\n13. The Sludge (bookid_180) — David Bernstein — Literature & Fiction > Genre Fiction — avg 5.0 (1 review)\n14. Liza of Lambeth (bookid_182) — Literature & Fiction > Classics — avg 5.0 (1 review)\n15. Something That Feels Like Truth (Switchgrass Books) (bookid_195) — Donald Lystra — Literature & Fiction > Short Stories & Anthologies — avg 5.0 (2 reviews)\n\n(English-language status taken from the books_info \"details\" text, e.g. \"written in English\"/\"available in English\"; all 40 Literature & Fiction books in the sample are English, so the language filter did not remove any of these.)"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "2",
+    "run": "3",
+    "answer": "15 English-language books in the \"Literature & Fiction\" category have a perfect average review rating of 5.0 (books_info.book_id matched to review.purchase_id, e.g. bookid_9 ↔ purchaseid_9):\n\n1. Reunion: The Children of Lauderdale Park (bookid_9) – 3 reviews, avg 5.0\n2. The Prophet: With Original 1923 Illustrations by the Author (bookid_38) – 4 reviews, avg 5.0\n3. The Melancholy Strumpet Master (bookid_39) – 2 reviews, avg 5.0\n4. Child Of The King A Journey of Hope Book 1: Earthly Story With A Heavenly Message (bookid_74) – 8 reviews, avg 5.0\n5. Fire Cracker (bookid_82) – 2 reviews, avg 5.0\n6. Local Honey (bookid_84) – 2 reviews, avg 5.0\n7. Hollywood Confessions: Hollywood Headlines Book #3 (Hollywood Headlines Mysteries) (bookid_98) – 1 review, avg 5.0\n8. Knowing When To Die: Uncollected Stories (bookid_101) – 2 reviews, avg 5.0\n9. Childe Harold of Dysna (bookid_122) – 1 review, avg 5.0\n10. Forged in Blood (Freehold) (bookid_144) – 6 reviews, avg 5.0\n11. Exits, Desires, & Slow Fires (bookid_171) – 3 reviews, avg 5.0\n12. Kennebago Moments (bookid_177) – 1 review, avg 5.0\n13. The Sludge (bookid_180) – 1 review, avg 5.0\n14. Liza of Lambeth (bookid_182) – 1 review, avg 5.0\n15. Something That Feels Like Truth (Switchgrass Books) (bookid_195) – 2 reviews, avg 5.0\n\nAll 40 \"Literature & Fiction\" books in the database are listed as English in their details (none are Spanish or other-language editions), so the language filter excludes none of them."
+  },
+  {
+    "dataset": "bookreview",
+    "query": "2",
+    "run": "4",
+    "answer": "15 English-language books in the \"Literature & Fiction\" category have a perfect average review rating of 5.0 (books_info joined to review via book_id n <-> purchaseid n):\n\n1. Reunion: The Children of Lauderdale Park (bookid_9) — avg 5.0, 3 reviews — Genre Fiction\n2. The Prophet: With Original 1923 Illustrations by the Author (bookid_38) — avg 5.0, 4 reviews — Poetry\n3. The Melancholy Strumpet Master (bookid_39) — avg 5.0, 2 reviews — Humor & Satire\n4. Child Of The King A Journey of Hope Book 1: Earthly Story With A Heavenly Message (bookid_74) — avg 5.0, 8 reviews — Literature & Fiction\n5. Fire Cracker (bookid_82) — avg 5.0, 2 reviews — United States\n6. Local Honey (bookid_84) — avg 5.0, 2 reviews — Literature & Fiction\n7. Hollywood Confessions: Hollywood Headlines Book #3 (Hollywood Headlines Mysteries) (bookid_98) — avg 5.0, 1 review — Genre Fiction\n8. Knowing When To Die: Uncollected Stories (bookid_101) — avg 5.0, 2 reviews — Genre Fiction\n9. Childe Harold of Dysna (bookid_122) — avg 5.0, 1 review — History & Criticism\n10. Forged in Blood (Freehold) (bookid_144) — avg 5.0, 6 reviews — Short Stories & Anthologies\n11. Exits, Desires, & Slow Fires (bookid_171) — avg 5.0, 3 reviews — Poetry\n12. Kennebago Moments (bookid_177) — avg 5.0, 1 review — Poetry\n13. The Sludge (bookid_180) — avg 5.0, 1 review — Genre Fiction\n14. Liza of Lambeth (bookid_182) — avg 5.0, 1 review — Classics\n15. Something That Feels Like Truth (Switchgrass Books) (bookid_195) — avg 5.0, 2 reviews — Short Stories & Anthologies"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "3",
+    "run": "0",
+    "answer": "14 books in the \"Children's Books\" category have an average review rating of 4.5 or higher considering only reviews posted from 2020 onward (book_id ↔ purchase_id matched on the numeric id; reviews filtered to review_time >= 2020-01-01):\n\n1. Monstrous Stories #4: The Day the Mice Stood Still — 5.00 (1 review)\n2. The Old Man and the Pirate Princess — 5.00 (1)\n3. Egypt (Enchantment of the World) — 5.00 (1)\n4. Behind the Wheel (Choose Your Own Adventure #35)(Paperback/Revised) — 5.00 (1)\n5. Favorite Thorton W. Burgess Stories: 6 Books — 5.00 (3)\n6. Cheer Up, Ben Franklin! (Young Historians) — 5.00 (1)\n7. LunaLu the Llamacorn — 5.00 (3)\n8. Benny Goes To The Moon: The great new book from Top Children's entertainer Gerry Ogilvie (1) — 5.00 (1)\n9. The Library Book — 5.00 (3)\n10. Pokémon: Sun & Moon, Vol. 8 (8) — 5.00 (1)\n11. Around the World Mazes — 5.00 (1)\n12. Trouble in the CTC!: The Terra Prime Adventures Book 2 — 4.90 (10)\n13. Clark the Shark: Tooth Trouble, No. 1 — 4.75 (4)\n14. Cleo Porter and the Body Electric — 4.71 (24)\n\n(Out of 25 \"Children's Books\" titles, 17 had at least one review since 2020; the next closest were \"Buddy the Soldier Bear\" at 4.40 and \"Kirsten: An American Girl: 1854\" at 4.00.)"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "3",
+    "run": "1",
+    "answer": "14 books in the \"Children's Books\" category have an average review rating of 4.5 or higher from reviews posted in 2020 onwards (joined books_info.book_id ↔ review.purchase_id by matching numeric ID):\n\n1. Around the World Mazes (bookid_152) — 5.00 avg (1 review)\n2. Behind the Wheel (Choose Your Own Adventure #35)(Paperback/Revised) (bookid_55) — 5.00 avg (1 review)\n3. Benny Goes To The Moon... (bookid_130) — 5.00 avg (1 review)\n4. Cheer Up, Ben Franklin! (Young Historians) (bookid_96) — 5.00 avg (1 review)\n5. Egypt (Enchantment of the World) (bookid_40) — 5.00 avg (1 review)\n6. Favorite Thorton W. Burgess Stories: 6 Books (bookid_54) — 5.00 avg (3 reviews)\n7. LunaLu the Llamacorn (bookid_146) — 5.00 avg (3 reviews)\n8. Monstrous Stories #4: The Day the Mice Stood Still (bookid_4) — 5.00 avg (1 review)\n9. Pokémon: Sun & Moon, Vol. 8 (8) (bookid_170) — 5.00 avg (1 review)\n10. The Library Book (bookid_108) — 5.00 avg (3 reviews)\n11. The Old Man and the Pirate Princess (bookid_14) — 5.00 avg (1 review)\n12. Trouble in the CTC!: The Terra Prime Adventures Book 2 (bookid_149) — 4.90 avg (10 reviews)\n13. Clark the Shark: Tooth Trouble, No. 1 (bookid_48) — 4.75 avg (4 reviews)\n14. Cleo Porter and the Body Electric (bookid_158) — 4.71 avg (24 reviews)\n\nExcluded: The Very Hungry Caterpillar (3.57), Buddy the Soldier Bear (4.40), Kirsten: An American Girl 1854 (4.00); and 8 other Children's Books with no reviews since 2020."
+  },
+  {
+    "dataset": "bookreview",
+    "query": "3",
+    "run": "2",
+    "answer": "14 \"Children's Books\" have an average review rating of 4.5 or higher from reviews posted in 2020 or later (books_info joined to review via book_id ↔ purchase_id; reviews filtered to review_time >= 2020-01-01):\n\n1. The Library Book (bookid_108) – avg 5.00 (3 reviews)\n2. Benny Goes To The Moon: The great new book from Top Children's entertainer Gerry Ogilvie (1) (bookid_130) – avg 5.00 (1 review)\n3. The Old Man and the Pirate Princess (bookid_14) – avg 5.00 (1 review)\n4. LunaLu the Llamacorn (bookid_146) – avg 5.00 (3 reviews)\n5. Around the World Mazes (bookid_152) – avg 5.00 (1 review)\n6. Pokémon: Sun & Moon, Vol. 8 (8) (bookid_170) – avg 5.00 (1 review)\n7. Monstrous Stories #4: The Day the Mice Stood Still (bookid_4) – avg 5.00 (1 review)\n8. Egypt (Enchantment of the World) (bookid_40) – avg 5.00 (1 review)\n9. Favorite Thorton W. Burgess Stories: 6 Books (bookid_54) – avg 5.00 (3 reviews)\n10. Behind the Wheel (Choose Your Own Adventure #35)(Paperback/Revised) (bookid_55) – avg 5.00 (1 review)\n11. Cheer Up, Ben Franklin! (Young Historians) (bookid_96) – avg 5.00 (1 review)\n12. Trouble in the CTC!: The Terra Prime Adventures Book 2 (bookid_149) – avg 4.90 (10 reviews)\n13. Clark the Shark: Tooth Trouble, No. 1 (bookid_48) – avg 4.75 (4 reviews)\n14. Cleo Porter and the Body Electric (bookid_158) – avg 4.71 (24 reviews)\n\nNote: Of the 25 books tagged \"Children's Books\", only 17 had reviews from 2020 onwards; the remaining 8 (e.g., Can You Buy Me The Wind?, From the Earth to the Moon, Caroline's Color Dreams, Skeleton Play, Mae and Jane in the Rain, Monster Kisses, I Hadn't Meant to Tell You This, Goodnight Riley...) had no 2020+ reviews, and Kirsten: An American Girl (4.00) and Buddy the Soldier Bear (4.40) fell below the 4.5 threshold."
+  },
+  {
+    "dataset": "bookreview",
+    "query": "3",
+    "run": "3",
+    "answer": "14 books categorized under \"Children's Books\" have an average rating of 4.5 or higher based on reviews posted from 2020 onwards (books_info joined to review via book_id ↔ purchase_id):\n\n1. Monstrous Stories #4: The Day the Mice Stood Still — 5.00 (1 review)\n2. The Old Man and the Pirate Princess — 5.00 (1)\n3. Egypt (Enchantment of the World) — 5.00 (1)\n4. Favorite Thorton W. Burgess Stories: 6 Books — 5.00 (3)\n5. Behind the Wheel (Choose Your Own Adventure #35)(Paperback/Revised) — 5.00 (1)\n6. Cheer Up, Ben Franklin! (Young Historians) — 5.00 (1)\n7. The Library Book — 5.00 (3)\n8. Benny Goes To The Moon: The great new book from Top Children's entertainer Gerry Ogilvie (1) — 5.00 (1)\n9. LunaLu the Llamacorn — 5.00 (3)\n10. Around the World Mazes — 5.00 (1)\n11. Pokémon: Sun & Moon, Vol. 8 (8) — 5.00 (1)\n12. Trouble in the CTC!: The Terra Prime Adventures Book 2 — 4.90 (10)\n13. Clark the Shark: Tooth Trouble, No. 1 — 4.75 (4)\n14. Cleo Porter and the Body Electric — 4.71 (24)\n\n(Other Children's Books either had no reviews since 2020 or averaged below 4.5, e.g. Buddy the Soldier Bear 4.40, The Very Hungry Caterpillar 3.57, Kirsten: An American Girl 4.00.)"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "3",
+    "run": "4",
+    "answer": "14 books in the \"Children's Books\" category have an average review rating of 4.5 or higher from reviews posted in 2020 or later (joining books_info.book_id to review.purchase_id by matching ID number):\n\n1. Monstrous Stories #4: The Day the Mice Stood Still (bookid_4) — avg 5.00 (1 review)\n2. The Old Man and the Pirate Princess (bookid_14) — avg 5.00 (1 review)\n3. Egypt (Enchantment of the World) (bookid_40) — avg 5.00 (1 review)\n4. Favorite Thorton W. Burgess Stories: 6 Books (bookid_54) — avg 5.00 (3 reviews)\n5. Behind the Wheel (Choose Your Own Adventure #35)(Paperback/Revised) (bookid_55) — avg 5.00 (1 review)\n6. Cheer Up, Ben Franklin! (Young Historians) (bookid_96) — avg 5.00 (1 review)\n7. The Library Book (bookid_108) — avg 5.00 (3 reviews)\n8. Benny Goes To The Moon (bookid_130) — avg 5.00 (1 review)\n9. LunaLu the Llamacorn (bookid_146) — avg 5.00 (3 reviews)\n10. Around the World Mazes (bookid_152) — avg 5.00 (1 review)\n11. Pokémon: Sun & Moon, Vol. 8 (8) (bookid_170) — avg 5.00 (1 review)\n12. Trouble in the CTC!: The Terra Prime Adventures Book 2 (bookid_149) — avg 4.90 (10 reviews)\n13. Clark the Shark: Tooth Trouble, No. 1 (bookid_48) — avg 4.75 (4 reviews)\n14. Cleo Porter and the Body Electric (bookid_158) — avg 4.71 (24 reviews)\n\nOther Children's Books either had no reviews since 2020 or averaged below 4.5 (e.g., The Very Hungry Caterpillar 3.57, Kirsten: An American Girl 4.00, Buddy the Soldier Bear 4.40)."
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "1",
+    "run": "0",
+    "answer": "No — the lead cannot be qualified. Failing BANT factors: Budget, Authority, Timeline.\n\n- Budget: The rep quoted 4 × $500 = $2,000 (under the $2,261 budget), but the \"Mandatory Bundles for Quotes\" article requires PulseSim Pro ($499.99) to be bundled with CircuitMaster Analyzer ($549.99) and VeriSim Express ($429.99) — $1,479.97 per set, i.e. ≈$5,920 for 4 units (≈$5,032 even after the 15% volume discount), far above the $2,261 budget.\n- Authority: Ali Hussein states he must consult the finance team because he does not have final decision authority.\n- Timeline: The customer has a tight installation timeline and the rep promised same‑day installation, but the Volume‑Based Installation Timeline Policy allows 1 day only for a single unit — a 4‑unit (5‑unit tier) order requires 3 days.\n(Need is satisfied: the customer clearly wants to expand simulation capability with PulseSim Pro.)"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "1",
+    "run": "1",
+    "answer": "Budget, Authority, Timeline"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "1",
+    "run": "2",
+    "answer": "Authority, Timeline"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "1",
+    "run": "3",
+    "answer": "Authority, Timeline"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "1",
+    "run": "4",
+    "answer": "Authority"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "2",
+    "run": "0",
+    "answer": "ka0Wt000000Eq0MIAS"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "2",
+    "run": "1",
+    "answer": "ka0Wt000000Eq0MIAS"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "2",
+    "run": "2",
+    "answer": "ka0Wt000000Eq0MIAS"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "2",
+    "run": "3",
+    "answer": "ka0Wt000000Eq0MIAS"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "2",
+    "run": "4",
+    "answer": "ka0Wt000000Eq0MIAS"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "3",
+    "run": "0",
+    "answer": "Negotiation"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "3",
+    "run": "1",
+    "answer": "Negotiation"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "3",
+    "run": "2",
+    "answer": "Negotiation"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "3",
+    "run": "3",
+    "answer": "Negotiation"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "3",
+    "run": "4",
+    "answer": "Negotiation\n\n(The opportunity 006Wt000007BGGjIAO is currently marked \"Discovery,\" but its tasks — \"Prepare tailored proposal,\" \"Organize product demo,\" \"Send case studies,\" \"Hold negotiation meeting\" (finalize pricing), \"Follow up on proposal\" (address questions/negotiate terms) and \"Prepare contract for approval\" (final contract for review and signature), along with an 85% probability and line items already entered — are proposal/negotiation-and-contract activities, not discovery activities. The correct stage label is: Negotiation)"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "4",
+    "run": "0",
+    "answer": "November (2020 — 2 SecureAnalytics Pro cases, vs. 1 each in Sept 2020, Jan 2021 and Mar 2021)"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "4",
+    "run": "1",
+    "answer": "November"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "4",
+    "run": "2",
+    "answer": "November"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "4",
+    "run": "3",
+    "answer": "November"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "4",
+    "run": "4",
+    "answer": "November"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "5",
+    "run": "0",
+    "answer": "a03Wt00000JqnHwIAJ"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "5",
+    "run": "1",
+    "answer": "a03Wt00000JqnHwIAJ"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "5",
+    "run": "2",
+    "answer": "a03Wt00000JqnHwIAJ"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "5",
+    "run": "3",
+    "answer": "a03Wt00000JqnHwIAJ"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "5",
+    "run": "4",
+    "answer": "a03Wt00000JqnHwIAJ"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "6",
+    "run": "0",
+    "answer": "ka0Wt000000EnwvIAC (Knowledge Article: \"Product Quantity Limits\")"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "6",
+    "run": "1",
+    "answer": "ka0Wt000000EnwvIAC"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "6",
+    "run": "2",
+    "answer": "ka0Wt000000EnwvIAC"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "6",
+    "run": "3",
+    "answer": "ka0Wt000000EnwvIAC"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "6",
+    "run": "4",
+    "answer": "ka0Wt000000EnwvIAC"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "7",
+    "run": "0",
+    "answer": "ka0Wt000000EoD3IAK"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "7",
+    "run": "1",
+    "answer": "ka0Wt000000EoD3IAK"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "7",
+    "run": "2",
+    "answer": "ka0Wt000000EoD3IAK"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "7",
+    "run": "3",
+    "answer": "ka0Wt000000EoD3IAK"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "7",
+    "run": "4",
+    "answer": "ka0Wt000000EpSUIA0"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "8",
+    "run": "0",
+    "answer": "005Wt000003NIliIAG"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "8",
+    "run": "1",
+    "answer": "005Wt000003NIliIAG"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "8",
+    "run": "2",
+    "answer": "005Wt000003NIliIAG"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "8",
+    "run": "3",
+    "answer": "005Wt000003NIliIAG"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "8",
+    "run": "4",
+    "answer": "005Wt000003NIliIAG"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "9",
+    "run": "0",
+    "answer": "MI"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "9",
+    "run": "1",
+    "answer": "MI"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "9",
+    "run": "2",
+    "answer": "MI"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "9",
+    "run": "3",
+    "answer": "MI"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "9",
+    "run": "4",
+    "answer": "MI"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "10",
+    "run": "0",
+    "answer": "005Wt000003NDqDIAW"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "10",
+    "run": "1",
+    "answer": "005Wt000003NDqDIAW"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "10",
+    "run": "2",
+    "answer": "005Wt000003NDqDIAW"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "10",
+    "run": "3",
+    "answer": "005Wt000003NDqDIAW"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "10",
+    "run": "4",
+    "answer": "005Wt000003NDqDIAW"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "11",
+    "run": "0",
+    "answer": "01tWt000006hV8LIAU"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "11",
+    "run": "1",
+    "answer": "01tWt000006hV8LIAU"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "11",
+    "run": "2",
+    "answer": "01tWt000006hV8LIAU"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "11",
+    "run": "3",
+    "answer": "01tWt000006hV8LIAU"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "11",
+    "run": "4",
+    "answer": "01tWt000006hV8LIAU"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "12",
+    "run": "0",
+    "answer": "005Wt000003NJgAIAW"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "12",
+    "run": "1",
+    "answer": "005Wt000003NJgAIAW"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "12",
+    "run": "2",
+    "answer": "005Wt000003NJgAIAW"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "12",
+    "run": "3",
+    "answer": "005Wt000003NJgAIAW"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "12",
+    "run": "4",
+    "answer": "005Wt000003NJgAIAW"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "13",
+    "run": "0",
+    "answer": "005Wt000003NIXCIA4"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "13",
+    "run": "1",
+    "answer": "005Wt000003NIXCIA4"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "13",
+    "run": "2",
+    "answer": "005Wt000003NBp4IAG"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "13",
+    "run": "3",
+    "answer": "005Wt000003NIXCIA4"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "13",
+    "run": "4",
+    "answer": "005Wt000003NHw5IAG"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "1",
+    "run": "0",
+    "answer": "Top 5 businesses located in Los Angeles, CA, ranked by highest average review rating (from review_database, joined on gmap_id):\n\n1. Widows Peak Salon (gmap_40) — average rating 4.86 (35 reviews)\n2. City Textile (gmap_44) — average rating 4.50 (6 reviews)\n3. Nobel Textile Co (gmap_38) — average rating 4.29 (7 reviews)\n4. San Soo Dang (gmap_41) — average rating 4.28 (18 reviews)\n5. Nova Fabrics (gmap_43) — average rating 3.33 (6 reviews)\n\n(Excluded from the top 5: Ace Jewelry & Loan, 3.29; Beads and More, 3.22.)"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "1",
+    "run": "1",
+    "answer": "Top 5 businesses located in Los Angeles, CA, ranked by highest average review rating (computed from review_database, joined on gmap_id):\n\n1. Widows Peak Salon (gmap_40) — avg rating 4.86 (35 reviews)\n2. City Textile (gmap_44) — avg rating 4.50 (6 reviews)\n3. Nobel Textile Co (gmap_38) — avg rating 4.29 (7 reviews)\n4. San Soo Dang (gmap_41) — avg rating 4.28 (18 reviews)\n5. Nova Fabrics (gmap_43) — avg rating 3.33 (6 reviews)\n\n(Next lowest: Ace Jewelry & Loan 3.29; Beads and More 3.22.)"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "1",
+    "run": "2",
+    "answer": "Top 5 businesses located in Los Angeles, CA by highest average review rating (from the review joined to business metadata on gmap_id):\n\n1. Widows Peak Salon (gmap_40) — avg rating 4.86 (35 reviews)\n2. City Textile (gmap_44) — avg rating 4.50 (6 reviews)\n3. Nobel Textile Co (gmap_38) — avg rating 4.29 (7 reviews)\n4. San Soo Dang (gmap_41) — avg rating 4.28 (18 reviews)\n5. Nova Fabrics (gmap_43) — avg rating 3.33 (6 reviews)"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "1",
+    "run": "3",
+    "answer": "Top 5 businesses located in Los Angeles, CA (identified from the business description), ranked by highest average review rating:\n\n1. Widows Peak Salon (gmap_40) — avg rating 4.86 (35 reviews)\n2. City Textile (gmap_44) — avg rating 4.50 (6 reviews)\n3. Nobel Textile Co (gmap_38) — avg rating 4.29 (7 reviews)\n4. San Soo Dang (gmap_41) — avg rating 4.28 (18 reviews)\n5. Nova Fabrics (gmap_43) — avg rating 3.33 (6 reviews)\n\n(Only 7 businesses in the dataset are described as being in Los Angeles, CA; the remaining two — Ace Jewelry & Loan at 3.29 and Beads and More at 3.22 — fall outside the top 5.)"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "1",
+    "run": "4",
+    "answer": "Top 5 businesses in Los Angeles, CA by highest average review rating (reviews joined via gmap_id):\n\n1. Widows Peak Salon (gmap_40) — avg rating 4.86 (35 reviews)\n2. City Textile (gmap_44) — avg rating 4.50 (6 reviews)\n3. Nobel Textile Co (gmap_38) — avg rating 4.29 (7 reviews)\n4. San Soo Dang (gmap_41) — avg rating 4.28 (18 reviews)\n5. Nova Fabrics (gmap_43) — avg rating 3.33 (6 reviews)"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "2",
+    "run": "0",
+    "answer": "Massage therapy businesses (identified from the business description as massage/bodywork providers) with an average review rating of 4.0 or higher:\n\n1. Elite Massage (gmap_25) – average rating 5.00 (1 review)\n2. Angel-A Massage (gmap_22) – average rating 4.33 (6 reviews)\n3. Aurora Massage (gmap_20) – average rating 4.18 (56 reviews)\n\nThe other massage businesses fall below the 4.0 threshold: Orient Massage 3.93 (15 reviews), SUSY massage 3.88 (8 reviews), Good Massage 3.88 (8 reviews), and Happy Spa & Massage (Formerly Hawaii Massage & Spa) 2.13 (8 reviews).\n\nNote: J B Oriental Inc (gmap_32), described as offering \"rejuvenating therapies and soothing body treatments\" and reviewed as a massage parlor, also averages above the threshold at 4.17 (6 reviews) — include it if that business is counted as massage therapy."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "2",
+    "run": "1",
+    "answer": "Massage therapy businesses with an average review rating of 4.0 or higher (average computed from the Google Maps reviews in review_database, joined on gmap_id):\n\n1. Elite Massage (gmap_25, Fair Oaks CA) – 5.00 (1 review)\n2. Angel-A Massage (gmap_22, Fair Oaks CA) – 4.33 (6 reviews)\n3. Aurora Massage (gmap_20, Sacramento CA) – 4.18 (56 reviews)\n\nBorderline case: J B Oriental Inc (gmap_32, Roseville CA), described as offering \"rejuvenating therapies and soothing body treatments\" (a massage spa) and whose reviews discuss massages, also qualifies with 4.17 (6 reviews).\n\nFor reference, the other massage businesses fall below the 4.0 threshold: Orient Massage 3.93, SUSY massage 3.88, Good Massage 3.88, and Happy Spa & Massage (Formerly Hawaii Massage & Spa) 2.13."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "2",
+    "run": "2",
+    "answer": "3 massage therapy businesses have an average review rating of at least 4.0 (out of 7 massage businesses in the data):\n\n1. Elite Massage (gmap_25) — average rating 5.00 (1 review)\n2. Angel-A Massage (gmap_22) — average rating 4.33 (6 reviews)\n3. Aurora Massage (gmap_20) — average rating 4.18 (56 reviews)\n\nExcluded because their averages fell below 4.0: Orient Massage (3.93), Good Massage (3.88), SUSY massage (3.88), and Happy Spa & Massage – Formerly Hawaii Massage & Spa (2.13)."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "2",
+    "run": "3",
+    "answer": "Three massage therapy businesses have an average review rating of 4.0 or higher (average computed from the Google Maps reviews in review_database, joined to business_database on gmap_id):\n\n1. Elite Massage (gmap_25, Fair Oaks, CA) – average rating 5.00 (1 review)\n2. Angel-A Massage (gmap_22, Fair Oaks, CA) – average rating 4.33 (6 reviews)\n3. Aurora Massage (gmap_20, Sacramento, CA) – average rating 4.18 (56 reviews)\n\nThe other massage therapy businesses fell below the 4.0 threshold: Orient Massage (3.93), Good Massage (3.88), SUSY massage (3.88), and Happy Spa & Massage (Formerly Hawaii Massage & Spa) (2.13)."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "2",
+    "run": "4",
+    "answer": "Among the massage therapy businesses in the data (identified via business_database descriptions/names), 3 have an average review rating of at least 4.0 (averages computed from review_database, joined on gmap_id):\n\n1. Elite Massage (gmap_25) — average rating 5.00 (1 review)\n2. Angel-A Massage (gmap_22) — average rating 4.33 (6 reviews)\n3. Aurora Massage (gmap_20) — average rating 4.18 (56 reviews)\n\nThe other massage businesses fell below the threshold: Orient Massage (gmap_21) 3.93, SUSY massage (gmap_24) 3.88, Good Massage (gmap_28) 3.88, and Happy Spa & Massage (Formerly Hawaii Massage & Spa) (gmap_33) 2.13."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "3",
+    "run": "0",
+    "answer": "Top 5 businesses that stay open past 6:00 PM on at least one weekday (Mon–Fri), ranked by highest average rating (computed from the review table; 25 of 79 businesses qualified, and exactly these 5 share a perfect 5.0 average):\n\n1. Taba Rug Gallery — Avg rating: 5.00 (18 reviews)\n   Hours: Mon 10AM–7PM | Tue 10AM–7PM | Wed 10AM–7PM | Thu 10AM–7PM | Fri 10AM–7PM | Sat 10AM–7PM | Sun 11AM–6PM\n   (Late weekday: Mon–Fri, closes 7PM)\n\n2. Beauty Divine Artistry — Avg rating: 5.00 (8 reviews)\n   Hours: Mon 9AM–8PM | Tue 9AM–8PM | Wed 9AM–8PM | Thu 9AM–8PM | Fri 9AM–8PM | Sat 10AM–7PM | Sun 11AM–6PM\n   (Late weekday: Mon–Fri, closes 8PM)\n\n3. Mariscos el poblano — Avg rating: 5.00 (3 reviews)\n   Hours: Mon 9AM–3:30AM | Tue 8AM–3:30PM | Wed 8AM–3:30PM | Thu Open 24 hours | Fri 8AM–3:30PM | Sat 8AM–3:30PM | Sun 8AM–3:30PM\n   (Late weekday: Thursday open 24 hours; Monday overnight to 3:30AM)\n\n4. White Barn Candle Co — Avg rating: 5.00 (2 reviews)\n   Hours: Mon 10AM–9PM | Tue 10AM–9PM | Wed 10AM–9PM | Thu 10AM–9PM | Fri 10AM–9PM | Sat 10AM–9PM | Sun 11AM–7PM\n   (Late weekday: Mon–Fri, closes 9PM)\n\n5. TACOS LA CABANA — Avg rating: 5.00 (2 reviews)\n   Hours: Mon 5–11PM | Tue Closed | Wed Closed | Thu Closed | Fri 5–11PM | Sat 5–11PM | Sun 5–11PM\n   (Late weekday: Mon & Fri, closes 11PM)\n\nRunner-up for reference: Paradise tattoo, 4.96 (378 reviews), closes 10PM Mon–Thu / 12AM Fri."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "3",
+    "run": "1",
+    "answer": "Top 5 businesses that stay open past 6:00 PM on at least one weekday (Mon–Fri), ranked by highest average review rating (avg computed from review_database, joined on gmap_id):\n\n1. Taba Rug Gallery — avg rating 5.00 (18 reviews)\n   Hours: Mon–Sat 10AM–7PM; Sun 11AM–6PM (closes 7PM on all weekdays)\n\n2. Beauty Divine Artistry — avg rating 5.00 (8 reviews)\n   Hours: Mon–Fri 9AM–8PM; Sat 10AM–7PM; Sun 11AM–6PM (closes 8PM on all weekdays)\n\n3. Mariscos el poblano — avg rating 5.00 (3 reviews)\n   Hours: Mon 9AM–3:30AM; Tue/Wed/Fri/Sat/Sun 8AM–3:30PM; Thu Open 24 hours (open past 6PM Monday and Thursday)\n\n4. White Barn Candle Co — avg rating 5.00 (2 reviews)\n   Hours: Mon–Sat 10AM–9PM; Sun 11AM–7PM (closes 9PM on all weekdays)\n\n5. TACOS LA CABANA — avg rating 5.00 (2 reviews)\n   Hours: Mon, Fri, Sat, Sun 5PM–11PM; Tue–Thu Closed (open until 11PM on Monday and Friday)\n\nNote: All five tied at a perfect 5.0 average; ties are ordered by number of reviews. The next best qualifying business is Paradise tattoo (4.96, 378 reviews). 25 of the 79 businesses (66 with hour data) close after 6PM on at least one weekday; businesses closing exactly at 6PM (e.g., Hanford Auto Supply, 5.0) were not counted as \"open after 6:00 PM.\""
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "3",
+    "run": "2",
+    "answer": "Top 5 businesses open after 6:00 PM on at least one weekday (Mon–Fri), ranked by highest average review rating (avg computed from review_database, joined on gmap_id). All five tie at a perfect 5.0 average:\n\n1. Taba Rug Gallery (gmap_51) — Avg rating: 5.00 (18 reviews)\n   Hours: Monday–Saturday 10AM–7PM; Sunday 11AM–6PM (late weekday closing: Mon–Fri 7PM)\n\n2. Beauty Divine Artistry (gmap_36) — Avg rating: 5.00 (8 reviews)\n   Hours: Monday–Friday 9AM–8PM; Saturday 10AM–7PM; Sunday 11AM–6PM (late weekday closing: Mon–Fri 8PM)\n\n3. Mariscos el poblano (gmap_9) — Avg rating: 5.00 (3 reviews)\n   Hours: Monday 9AM–3:30AM; Tuesday 8AM–3:30PM; Wednesday 8AM–3:30PM; Thursday Open 24 hours; Friday 8AM–3:30PM; Saturday 8AM–3:30PM; Sunday 8AM–3:30PM (late weekdays: Thursday 24h, Monday past midnight)\n\n4. White Barn Candle Co (gmap_12) — Avg rating: 5.00 (2 reviews)\n   Hours: Monday–Friday 10AM–9PM; Saturday 10AM–9PM; Sunday 11AM–7PM (late weekday closing: Mon–Fri 9PM)\n\n5. TACOS LA CABANA (gmap_8) — Avg rating: 5.00 (2 reviews)\n   Hours: Monday 5–11PM; Tuesday Closed; Wednesday Closed; Thursday Closed; Friday 5–11PM; Saturday 5–11PM; Sunday 5–11PM (late weekdays: Monday & Friday 11PM)\n\nRunner-ups (below 5.0): Paradise tattoo 4.96 (378 reviews), The Boochyard @ Local Roots 4.89 (38), Widows Peak Salon 4.86 (35), The Beauty Bar 4.86 (21).\n\nNote: 25 of the 79 businesses have hours and stay open past 6:00 PM on at least one weekday; \"Open 24 hours\" and closing times after midnight count as open after 6PM, while businesses closing exactly at 6PM were excluded."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "3",
+    "run": "3",
+    "answer": "Top 5 businesses open after 6:00 PM on at least one weekday (Mon–Fri), ranked by highest average rating (avg computed from the review table). All five tie at a perfect 5.0 rating; ties are broken by number of reviews.\n\n1) Taba Rug Gallery — Avg rating: 5.0 (18 reviews)\n   Hours: Mon–Fri 10AM–7PM, Sat 10AM–7PM, Sun 11AM–6PM (late weekday: all Mon–Fri until 7PM)\n\n2) Beauty Divine Artistry — Avg rating: 5.0 (8 reviews)\n   Hours: Mon–Fri 9AM–8PM, Sat 10AM–7PM, Sun 11AM–6PM (late weekday: all Mon–Fri until 8PM)\n\n3) Mariscos el poblano — Avg rating: 5.0 (3 reviews)\n   Hours: Thu Open 24 hours; Mon 9AM–3:30AM (next day); Tue/Wed/Fri/Sat 8AM–3:30PM; Sun 8AM–3:30PM (late weekdays: Thursday 24h, Monday until 3:30AM)\n\n4) White Barn Candle Co — Avg rating: 5.0 (2 reviews)\n   Hours: Mon–Sat 10AM–9PM, Sun 11AM–7PM (late weekday: all Mon–Fri until 9PM)\n\n5) TACOS LA CABANA — Avg rating: 5.0 (2 reviews)\n   Hours: Fri 5–11PM, Sat 5–11PM, Sun 5–11PM, Mon 5–11PM, Tue Closed, Wed Closed, Thu Closed (late weekdays: Friday & Monday until 11PM)\n\nNote: 25 businesses in total close after 6:00 PM on at least one weekday; only these five have a 5.0 average rating (the next highest is Paradise tattoo at 4.96)."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "3",
+    "run": "4",
+    "answer": "Top 5 businesses that stay open past 6:00 PM on at least one weekday (Mon–Fri), ranked by highest average review rating (avg computed from review_database, ties broken by number of reviews). All five tie at a perfect 5.0:\n\n1. Taba Rug Gallery — Avg rating: 5.00 (18 reviews)\n   Hours: Mon–Sat 10AM–7PM, Sun 11AM–6PM (open past 6 PM all five weekdays)\n\n2. Beauty Divine Artistry — Avg rating: 5.00 (8 reviews)\n   Hours: Mon–Fri 9AM–8PM, Sat 10AM–7PM, Sun 11AM–6PM (past 6 PM Mon–Fri)\n\n3. Mariscos el poblano — Avg rating: 5.00 (3 reviews)\n   Hours: Mon 9AM–3:30AM, Tue/Wed/Fri 8AM–3:30PM, Thu Open 24 hours, Sat–Sun 8AM–3:30PM (past 6 PM Monday & Thursday)\n\n4. TACOS LA CABANA — Avg rating: 5.00 (2 reviews)\n   Hours: Mon 5–11PM, Tue Closed, Wed Closed, Thu Closed, Fri 5–11PM, Sat 5–11PM, Sun 5–11PM (past 6 PM Monday & Friday)\n\n5. White Barn Candle Co — Avg rating: 5.00 (2 reviews)\n   Hours: Mon–Sat 10AM–9PM, Sun 11AM–7PM (past 6 PM Mon–Fri)\n\nRunner-up (6th): Paradise tattoo — 4.96 avg (378 reviews), Mon/Thu 12–10PM, Fri 12PM–12AM, Sat 12PM–12AM, Tue/Wed 12–10PM, Sun 12–10PM.\n\nNotes: 25 of the 79 businesses close after 6:00 PM on at least one weekday. Businesses whose \"hours\" field is null (e.g., Elite Massage, Jjironwork, Climate Control, CYD Works Electric) were excluded since their operating hours cannot be verified; businesses closing exactly at 6:00 PM (e.g., Hanford Auto Supply, Dr. Syverain Skincare Clinic) were also excluded."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "4",
+    "run": "0",
+    "answer": "Top 3 businesses by number of high-rating (≥4.5, i.e. 5-star since ratings are whole numbers) reviews posted in 2019:\n\n1. Encino Dermatology & Laser: Alex Khadavi MD (gmap_35) — 19 high-rating reviews\n2. The Boochyard @ Local Roots (gmap_53) — 17 high-rating reviews\n3. Aurora Massage (gmap_20) — 14 high-rating reviews\n\n(Runner-up: Widows Peak Salon with 13.)"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "4",
+    "run": "1",
+    "answer": "Top 3 businesses by number of reviews rated 4.5+ (i.e., 5-star, since ratings are whole numbers) posted in 2019:\n\n1. Encino Dermatology & Laser: Alex Khadavi MD (gmap_35) — 19 high-rating reviews\n2. The Boochyard @ Local Roots (gmap_53) — 17 high-rating reviews\n3. Aurora Massage (gmap_20) — 14 high-rating reviews"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "4",
+    "run": "2",
+    "answer": "Top 3 businesses by number of high-rating (4.5+, i.e., 5-star) reviews during 2019:\n\n1. Encino Dermatology & Laser: Alex Khadavi MD (gmap_35) — 19 reviews\n2. The Boochyard @ Local Roots (gmap_53) — 17 reviews\n3. Aurora Massage (gmap_20) — 14 reviews\n\nNote: ratings in the review table are whole numbers (1–5), so \"4.5 or higher\" corresponds to 5-star reviews; 314 reviews total were posted in 2019."
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "4",
+    "run": "3",
+    "answer": "Top 3 businesses by number of 2019 reviews rated 4.5 or higher (all such reviews have a rating of 5, since ratings are whole numbers 1–5):\n\n1. Encino Dermatology & Laser: Alex Khadavi MD (gmap_35) — 19 high-rating reviews\n2. The Boochyard @ Local Roots (gmap_53) — 17 high-rating reviews\n3. Aurora Massage (gmap_20) — 14 high-rating reviews"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "4",
+    "run": "4",
+    "answer": "Top 3 businesses by number of high-rating (≥4.5, i.e. 5-star, since ratings are whole numbers) reviews posted in 2019:\n\n1. Encino Dermatology & Laser: Alex Khadavi MD (gmap_35) — 19 high-rating reviews\n2. The Boochyard @ Local Roots (gmap_53) — 17 high-rating reviews\n3. Aurora Massage (gmap_20) — 14 high-rating reviews"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "1",
+    "run": "0",
+    "answer": "$1,059.46\n\nEntity resolution identified 5 duplicate records of Beyoncé's \"Get Me Bodied\" (track_ids 4233, 5281, 10838, 12954, 15158). Their Canada / Apple Music sales were: 4233 → $377.62, 5281 → $458.02, 12954 → $223.82, totaling $1,059.46."
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "1",
+    "run": "1",
+    "answer": "$1,059.46 USD\n\nEntity resolution identified 5 duplicate records of Beyoncé's \"Get Me Bodied\" (track_ids 4233, 5281, 10838, 12954, 15158). Their Apple Music / Canada sales were: 4233 → $377.62, 5281 → $458.02, 12954 → $223.82 (10838 and 15158 had none), totaling $1,059.46."
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "1",
+    "run": "2",
+    "answer": "$1,059.46 USD\n\nEntity resolution identified 5 duplicate records of Beyoncé's \"Get Me Bodied\" (track_ids 4233, 5281, 10838, 12954, 15158). Of these, three had Canada / Apple Music sales:\n- track_id 4233: 354 units, $377.62\n- track_id 5281: 426 units, $458.02\n- track_id 12954: 210 units, $223.82\nTotal: $1,059.46"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "1",
+    "run": "3",
+    "answer": "$1,059.46 USD\n\nDetails: Entity resolution identified 5 duplicate track records for Beyoncé's \"Get Me Bodied\" (2007, Sexxxplicit R&B Vol. 25): track_ids 4233, 5281, 10838, 12954, 15158. Of these, three had Canada / Apple Music sales: 377.62 (4233) + 458.02 (5281) + 223.82 (12954) = 1,059.46 USD."
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "1",
+    "run": "4",
+    "answer": "$1,059.46\n\nEntity resolution found 5 duplicate records for Beyoncé's \"Get Me Bodied\" (track_ids 4233, 5281, 10838, 12954, 15158). Canada + Apple Music sales among these were: track 4233 = $377.62, track 5281 = $458.02, track 12954 = $223.82 (tracks 10838 and 15158 had no such sales), totaling $1,059.46."
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "2",
+    "run": "0",
+    "answer": "Amazon Music — it earned the most total revenue (≈$1,108.99) from \"Street Hype\" by Brucqe/Bruce Maginnis across all countries, ahead of Apple Music ($984.48), iTunes ($916.86), and Google Play ($51.40); Spotify had no sales."
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "2",
+    "run": "1",
+    "answer": "Amazon Music — it earned the most revenue (≈ $1,108.99) from Bruce/Brucqe Maginnis' \"Street Hype\" (Groove City, 2005) across all countries, ahead of Apple Music ($984.48), iTunes ($916.86), and Google Play ($51.40); Spotify had no sales.\n\n(entity resolution matched track_ids 7, 4122, 4628, 13758, 14080)"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "2",
+    "run": "2",
+    "answer": "Amazon Music — with total revenue of $1,108.99 USD across all countries (vs. Apple Music $984.48, iTunes $916.86, Google Play $51.40, Spotify $0.00) from the duplicate track records of \"Street Hype\" by Bruce/Brucqe Maginnis (track_ids 7, 4122, 4628, 13758, 14080)."
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "2",
+    "run": "3",
+    "answer": "Amazon Music — it earned the most revenue (~$1,108.99 USD) from \"Street Hype\" by Bruce/Brucqe Maginnis across all countries, ahead of Apple Music ($984.48), iTunes ($916.86), and Google Play ($51.40)."
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "2",
+    "run": "4",
+    "answer": "Amazon Music — total revenue of $682.23 USD (from France sales across duplicate track records 4122 and 13758), ahead of iTunes ($654.56) and Apple Music ($593.26)."
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "3",
+    "run": "0",
+    "answer": "\"Zo gaat het leven aan je voor\" by Syb van der Ploeg (album: \"Hillich fjoer | Heilig vuur\", 2008).\n\nAfter entity resolution, this one song appears as 5 duplicate track records (one per source): track_ids 3435, 12620, 12854, 13225, 3024 — whose title/artist formatting differs by source (\"Zo gaat het leven aan je voor\", \"Zo gaat het leven aan je voor - Hillich fjoer | Heilig vuur\", \"Zo gaat het leven aan je voor (Hillich fjoer | Heilig vuur)\", \"Syb van der Ploeg - Zo gaat het leven aan je voor\").\n\nTotal revenue across all countries (USA, UK, Canada, Germany, France) and stores (iTunes, Spotify, Apple Music, Amazon Music, Google Play): $9,013.69 (7,792 units, 22 sale transactions).\n\nRunner-ups: \"Chile\" – Neil Biggin ($7,744.25), \"Emerge\" – Fischerspooner ($7,515.88 incl. remix variants), \"Ne veruj\" – Vrisak generacije ($7,299.91), \"Vagga\" – Ske ($7,214.20)."
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "3",
+    "run": "1",
+    "answer": "\"Zo gaat het leven aan je voor\" – Syb van der Ploeg — total revenue ≈ $9,013.69 USD (7,792 units, 22 sales transactions across USA/UK/Canada/Germany/France and all five stores).\n\nEntity resolution detail: this song appears in the tracks table as 5 duplicate records (one per source): track_id 3024 ($1,754.68), 3435 ($2,024.37), 12620 ($2,377.59), 12854 ($1,379.67), 13225 ($1,477.38). No single track_id tops the list (the largest single-record total is only ~$2,522.82); only after merging duplicates does this song lead.\n\nRunner-up: \"Chile\" – Neil Biggin, $7,744.25 (5 duplicate records); then \"Emerge\" – Fischerspooner (~$7,515.88 including a remix variant) and \"Ne veruj\" – Vrisak generacije ($7,299.91)."
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "3",
+    "run": "2",
+    "answer": ""
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "3",
+    "run": "3",
+    "answer": "\"Zo gaat het leven aan je voor\" by Syb van der Ploeg (album: Hillich fjoer | Heilig vuur) generated the highest total revenue: ≈ $9,013.69 USD.\n\nAfter entity resolution, this single real-world song appears as 5 duplicate records (one per source), which together account for all 5 stores/platforms and all 5 countries:\n- track_id 12620 (src 3, \"Zo gaat het leven aan je voor - Hillich fjoer | Heilig vuur\"): $2,377.59\n- track_id 3435 (src 5, \"Zo gaat het leven aan je voor\"): $2,024.37\n- track_id 3024 (src 1, \"Zo gaat het leven aan je voor (Hillich fjoer | Heilig vuur)\"): $1,754.68\n- track_id 13225 (src 2, \"Syb van der Ploeg - Zo gaat het leven aan je voor\"): $1,477.38\n- track_id 12854 (src 4, \"006-Zo gaat het leven aan je voor\"): $1,379.67\nTotal: $9,013.69\n\nRunner-up (for reference): \"Chile\" by Neil Biggin, ≈ $7,744.25. (Without deduplication the largest single record would be track_id 14719, \"Systemisch bled\" by Stüngö, at only $2,522.82.)"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "3",
+    "run": "4",
+    "answer": "**\"Zo gaat het leven aan je voor\" — Syb van der Ploeg** (album *Hillich fjoer | Heilig vuur*, 2008)\n\nAfter entity resolution, this single real-world song exists as 5 duplicate records (one per source) and its combined revenue across all 5 stores and all 5 countries is **≈ $9,013.69** — the highest of any song.\n\n| track_id | source | title as stored | revenue (USD) |\n|---|---|---|---|\n| 3024 | 1 | Zo gaat het leven aan je voor (Hillich fjoer \\| Heilig vuur) | 1,754.68 |\n| 13225 | 2 | Syb van der Ploeg - Zo gaat het leven aan je voor | 1,477.38 |\n| 12620 | 3 | Zo gaat het leven aan je voor - Hillich fjoer \\| Heilig vuur | 2,377.59 |\n| 12854 | 4 | 006-Zo gaat het leven aan je voor | 1,379.67 |\n| 3435 | 5 | Zo gaat het leven aan je voor | 2,024.37 |\n| **total** | | | **9,013.69** |\n\nRunner-ups: \"Chile\" – Neil Biggin ($7,744.25), \"Emerge\" – Fischerspooner ($7,515.88, incl. a second Dave Clarke remix version), \"Ne veruj\" – Vrisak generacije ($7,299.91), \"Vagga\" – Ske ($7,214.20). By a single raw track_id the leader would be track 14719 \"Systemisch bled\" – Stungo ($2,522.82), but once duplicates are resolved the Syb van der Ploeg song wins."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "1",
+    "run": "0",
+    "answer": "**399001.SZ — the Shenzhen Component Index (Shenzhen Stock Exchange, China)** has the highest average intraday volatility among Asian indices since 2020.\n\nAverage daily (High − Low) / Open, 2020-01-02 → 2021-06-02:\n- 399001.SZ (Shenzhen, China) — 1.834% (342 days)  ← highest\n- NSEI (National Stock Exchange of India) — 1.707% (349 days)\n- HSI (Hong Kong) — 1.493% (348 days)\n- 000001.SS (Shanghai) — 1.378% (340 days)\n- N225 (Tokyo) — 1.343% (344 days)\n- TWII (Taiwan) — 1.323% (339 days)"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "1",
+    "run": "1",
+    "answer": "399001.SZ — the Shenzhen Component Index (Shenzhen Stock Exchange, China).\n\nComputing daily intraday volatility as (High − Low) / Open for all trading days from 2020-01-01 onward, the Asian indices rank as follows:\n1. 399001.SZ (Shenzhen, China): 1.834% (342 days)\n2. NSEI (National Stock Exchange of India): 1.707%\n3. HSI (Hang Seng, Hong Kong): 1.493%\n4. 000001.SS (Shanghai Composite, China): 1.378%\n5. N225 (Nikkei 225, Tokyo): 1.343%\n6. TWII (Taiwan Weighted Index): 1.323%\n\nThe result also holds on a median basis (399001.SZ ≈ 1.66% vs ≈1.30% for the next highest), and no missing/outlier values distort it."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "1",
+    "run": "2",
+    "answer": "399001.SZ — the Shenzhen Component Index (Shenzhen Stock Exchange, China).\n\nAmong the Asia-region indices in the data (399001.SZ, NSEI, HSI, 000001.SS, N225, TWII), the average intraday volatility since 2020, computed as mean of (High − Low) / Open per trading day, is:\n\n- 399001.SZ (Shenzhen, China): 0.01834 (~1.83%) — highest\n- NSEI (National Stock Exchange of India): 0.01707\n- HSI (Hong Kong): 0.01493\n- 000001.SS (Shanghai, China): 0.01378\n- N225 (Tokyo, Japan): 0.01343\n- TWII (Taiwan): 0.01323\n\n(Based on 2020-01-01 through 2021-06-02 trading data, ~340 days per index.)"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "1",
+    "run": "3",
+    "answer": "399001.SZ — the Shenzhen Component Index (Shenzhen Stock Exchange, China).\n\nAverage intraday volatility, i.e. mean of (High − Low) / Open for trading days from 2020-01-01 onward (data run through mid-2021):\n\n| Rank | Index | Exchange (Asia) | Trading days | Avg (High−Low)/Open |\n|---|---|---|---|---|\n| 1 | 399001.SZ | Shenzhen Stock Exchange | 342 | 1.834% |\n| 2 | NSEI | National Stock Exchange of India | 349 | 1.707% |\n| 3 | HSI | Hong Kong Stock Exchange | 348 | 1.493% |\n| 4 | 000001.SS | Shanghai Stock Exchange | 340 | 1.378% |\n| 5 | N225 | Tokyo Stock Exchange | 344 | 1.343% |\n| 6 | TWII | Taiwan Stock Exchange | 339 | 1.323% |\n\nSo among the Asian indices in the database, the Shenzhen Component Index (399001.SZ) shows the highest average intraday volatility since 2020 (~1.83% per day)."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "1",
+    "run": "4",
+    "answer": "The Shenzhen Component Index (399001.SZ, Shenzhen Stock Exchange, China) has the highest average intraday volatility among Asian indices since 2020, at about 1.83% per day (mean of (High − Low)/Open ≈ 0.01834 over 342 trading days, Jan 2020 – Jun 2021).\n\nRanking of Asian indices (avg intraday volatility since 2020-01-01):\n1. 399001.SZ – Shenzhen Component Index (Shenzhen Stock Exchange, China): 1.83%\n2. NSEI – Nifty 50 (National Stock Exchange of India): 1.71%\n3. HSI – Hang Seng Index (Hong Kong Stock Exchange): 1.49%\n4. 000001.SS – Shanghai Composite (Shanghai Stock Exchange): 1.38%\n5. N225 – Nikkei 225 (Tokyo Stock Exchange, Japan): 1.34%\n6. TWII – TAIEX (Taiwan Stock Exchange): 1.32%"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "2",
+    "run": "0",
+    "answer": "Only the NASDAQ Composite (IXIC) had more up days than down days in 2018 among the North American indices.\n\nNorth American indices in the data (NYSE → NYA, NASDAQ → IXIC, Toronto → GSPTSE), 2018 (251 trading days each, Close vs Open):\n- IXIC (NASDAQ Composite): 131 up days vs 120 down days → MORE UP DAYS\n- NYA (NYSE Composite): 125 up days vs 126 down days → more down days\n- GSPTSE (S&P/TSX Composite): 115 up days vs 135 down days (1 unchanged) → more down days"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "2",
+    "run": "1",
+    "answer": "Only one North American index had more up days than down days in 2018: IXIC (NASDAQ Composite, NASDAQ — USA) with 131 up days vs. 120 down days (251 trading days).\n\nThe other North American indices did not:\n- NYA (NYSE Composite, New York Stock Exchange): 125 up vs. 126 down\n- GSPTSE (S&P/TSX Composite, Toronto Stock Exchange — Canada): 115 up vs. 135 down (1 flat day)"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "2",
+    "run": "2",
+    "answer": "NASDAQ Composite (IXIC) — the only North American index with more up days than down days in 2018.\n\nNorth American indices (NYSE → NYA, NASDAQ → IXIC, Toronto → GSPTSE), 2018 results:\n- IXIC (NASDAQ Composite, USA): 131 up days vs 120 down days → MORE UP DAYS ✔\n- NYA (NYSE Composite, USA): 125 up days vs 126 down days → more down days ✘\n- GSPTSE (S&P/TSX Composite, Canada): 115 up days vs 135 down days → more down days ✘"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "2",
+    "run": "3",
+    "answer": "Only one: IXIC (NASDAQ Composite, NASDAQ — USA).\n\nNorth American indices in the data and their 2018 up/down day counts (Close vs Open, 251 trading days each):\n- IXIC (NASDAQ Composite, NASDAQ): 131 up days vs 120 down days → MORE UP DAYS ✓\n- NYA (NYSE Composite, New York Stock Exchange): 125 up vs 126 down\n- GSPTSE (S&P/TSX Composite, Toronto Stock Exchange): 115 up vs 135 down\n\nSo the NASDAQ Composite (IXIC) is the only North American index with more up days than down days in 2018."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "2",
+    "run": "4",
+    "answer": "Only one North American index had more up days than down days in 2018: the NASDAQ Composite (IXIC) — 131 up days vs. 120 down days (251 trading days).\n\nFor comparison (2018, close > open = up day, close < open = down day):\n- IXIC (NASDAQ): 131 up / 120 down → more up days ✔\n- NYA (NYSE Composite): 125 up / 126 down → slightly more down days ✘\n- GSPTSE (S&P/TSX Composite, Toronto): 115 up / 135 down (1 flat) ✘"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "3",
+    "run": "0",
+    "answer": "Method: for each index I took the last trading day of every month from 2000-01-01 onward, invested a fixed $1,000 monthly (dollar-cost averaging) at that month's closing price, and compared the final portfolio value with the total amount invested.\n\nTop 5 indices by overall return (data run through mid-2021):\n1. IXIC – NASDAQ Composite – United States (New York / NASDAQ): ≈ +382% (≈7.7% p.a.)\n2. GDAXI – DAX – Germany (Frankfurt Stock Exchange): ≈ +135% (≈4.1% p.a.)\n3. NSEI – Nifty 50 – India (National Stock Exchange of India): ≈ +135% (≈6.4% p.a.; data available only from Sep-2007)\n4. 399001.SZ – Shenzhen Component – China (Shenzhen Stock Exchange): ≈ +134% (≈4.1% p.a.)\n5. TWII – TAIEX – Taiwan (Taiwan Stock Exchange): ≈ +130% (≈4.0% p.a.)\n\nCountries: United States, Germany, India, China, Taiwan.\n\nNote: NSEI's history starts in 2007, so if the comparison is restricted to indices with data covering the whole 2000–2021 window, the 5th place goes to N225 (Nikkei 225, Japan, ≈ +117%) instead of the Indian Nifty 50, giving: USA (NASDAQ), Germany (DAX), China (Shenzhen Component), Taiwan (TAIEX), Japan (Nikkei 225). The laggards in every variant were SSMI (Switzerland), HSI (Hong Kong), N100 (Euronext) and 000001.SS (Shanghai)."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "3",
+    "run": "1",
+    "answer": "Simulation: for every index, a fixed amount was invested each month from Jan 2000 to the last available month (May/Jun 2021) at that month's closing level; overall return = final portfolio value ÷ total invested − 1 (currency/adjusted-close variants give identical results).\n\nTop 5 indices by overall (dollar-cost-averaging) return, with their countries:\n\n1. IXIC – NASDAQ Composite (NASDAQ) – United States – ≈ +382% (≈7.6%/yr)\n2. GDAXI – DAX (Frankfurt Stock Exchange) – Germany – ≈ +135% (≈4.1%/yr)\n3. NSEI – Nifty 50 (National Stock Exchange of India) – India – ≈ +135% (≈6.4%/yr; data only from Sep 2007)\n4. 399001.SZ – Shenzhen Composite (Shenzhen Stock Exchange) – China – ≈ +134% (≈4.0%/yr)\n5. TWII – TSEC Weighted Index (Taiwan Stock Exchange) – Taiwan – ≈ +130% (≈4.0%/yr)\n\nRest of the field: N225 (Japan) ≈ +117%, NYA (USA) ≈ +101%, GSPTSE (Canada) ≈ +73%, 000001.SS (China) ≈ +64%, N100 (Euronext/Netherlands‑Europe) ≈ +61%, HSI (Hong Kong, China) ≈ +61%, SSMI (Switzerland) ≈ +59%, J203.JO (South Africa) ≈ +37%.\n\nCaveat: NSEI has no data before Sep 2007. If only indices with continuous data from January 2000 are eligible, the top 5 become IXIC (USA), 399001.SZ (China), GDAXI (Germany), TWII (Taiwan) and N225 (Japan, ≈ +117%), i.e. N225/Nikkei 225 (Tokyo Stock Exchange, Japan) replaces NSEI/India in 5th place. The result is robust to buying at the first or last trading day of each month."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "3",
+    "run": "2",
+    "answer": "Method: parsed the daily trade data, built month-end closing series for every index from Jan‑2000 to the end of available data (May/Jun 2021), and simulated dollar‑cost averaging (a fixed amount invested every month; overall return = shares accumulated × final price ÷ total invested − 1). Only indices with data going back to 2000 were eligible (J203.JO/JSE starts 2012, NSEI/Nifty starts 2007, so they were excluded).\n\nTop 5 indices by overall DCA return since 2000:\n1. IXIC (NASDAQ Composite) — United States (NASDAQ) — ≈ +382% (~7.6%/yr)\n2. GDAXI (DAX) — Germany (Frankfurt Stock Exchange) — ≈ +135% (~4.1%/yr)\n3. 399001.SZ (Shenzhen Component) — China (Shenzhen Stock Exchange) — ≈ +134% (~4.1%/yr)\n4. TWII (TAIEX) — Taiwan (Taiwan Stock Exchange) — ≈ +130% (~4.0%/yr)\n5. N225 (Nikkei 225) — Japan (Tokyo Stock Exchange) — ≈ +117% (~3.7%/yr)\n\nSo the countries are: United States, Germany, China, Taiwan and Japan.\n\nNotes: currency conversion is a constant factor per index (CloseUSD = Close × fixed FX rate), so local‑currency and USD rankings are identical. Runner‑ups were NYA (USA, ≈+101%), GSPTSE (Canada, ≈+73%), 000001.SS (China, ≈+64%), HSI (Hong Kong, ≈+61%), N100 (Euronext, ≈+61%) and SSMI (Switzerland, ≈+59%)."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "3",
+    "run": "3",
+    "answer": "Method: For every index I built a monthly series (last trading day of each month, from Jan 2000 to the last available month) and simulated dollar‑cost averaging — investing the same amount each month, so total return = (final price × Σ 1/price_month) / number_of_months − 1. (Results are identical in local currency and in the USD‑converted column, and the ranking is essentially unchanged when using Adj Close.)\n\nTop 5 indices by overall (money‑weighted) return from monthly investing since 2000:\n\n1. IXIC – NASDAQ Composite — United States (NASDAQ): ≈ +382% (final value ≈ 4.82× the average amount invested; ≈ 13.0%/yr)\n2. GDAXI – DAX — Germany (Frankfurt Stock Exchange): ≈ +135% (≈ 2.35×; ≈ 7.4%/yr)\n3. NSEI – Nifty 50 — India (National Stock Exchange of India): ≈ +135% (≈ 2.35×; data start 2007‑09, ≈ 11.7%/yr)\n4. 399001.SZ – Shenzhen Component — China (Shenzhen Stock Exchange): ≈ +134% (≈ 2.34×; ≈ 7.3%/yr)\n5. TWII – Taiwan Stock Exchange Weighted Index — Taiwan (Taiwan Stock Exchange): ≈ +130% (≈ 2.30×; ≈ 7.2%/yr)\n\nNotes: N225 (Japan, Tokyo Stock Exchange) is a very close 6th (≈ +117%) and would take the 5th place if only indices with full 2000–2021 history are compared (i.e., dropping NSEI, whose data begin in Sep 2007, and J203.JO, South Africa, whose data begin in 2012). The weakest performers under the same monthly‑investment strategy were J203.JO (South Africa, ≈ +37%), SSMI (Switzerland, ≈ +59%), HSI (Hong Kong, ≈ +61%), N100 (Euronext, ≈ +61%) and 000001.SS (Shanghai, China, ≈ +64%). The Korea Exchange has no index data in the trading database."
+  },
+  {
+    "dataset": "stockindex",
+    "query": "3",
+    "run": "4",
+    "answer": "Analysis: I parsed the daily trade data, built end-of-month series for each index from Jan 2000 onward, computed monthly returns and averaged them over the whole period (equivalent to a fixed monthly investment / dollar-cost-averaging performance), then ranked the 13 indices.\n\nTop 5 indices by average monthly return since 2000 (with the exchange/country they belong to):\n\n1. NSEI – Nifty 50, National Stock Exchange of India → India (~0.91% avg/month, ~8.6% p.a. CAGR)\n2. 399001.SZ – Shenzhen Component Index, Shenzhen Stock Exchange → China (~0.86% avg/month, ~6.4% p.a., +276% cumulative)\n3. IXIC – NASDAQ Composite, NASDAQ → United States (~0.69% avg/month, ~6.0% p.a., +249% cumulative)\n4. J203.JO – JSE Top 40, Johannesburg Stock Exchange → South Africa (~0.69% avg/month, ~7.7% p.a.; data available only from 2012)\n5. 000001.SS – Shanghai Composite Index, Shanghai Stock Exchange → China (~0.61% avg/month, ~4.1% p.a., +136% cumulative)\n\nSo the countries are: India, China (two indices – Shenzhen and Shanghai), United States, and South Africa.\n\nNotes: NSEI (data from Sep 2007) and J203.JO (data from Feb 2012) have shorter histories than the rest, which inflates their averages relative to a true \"since 2000\" record. On pure cumulative price appreciation since 2000 the top group is the same core four (399001.SZ China, IXIC USA, NSEI India, 000001.SS China) with NYA (NYSE Composite, United States, +152%) edging out J203.JO for the fifth place. The clear laggards are N100 (Euronext, Europe), N225 (Japan), SSMI (Switzerland) and TWII (Taiwan)."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "1",
+    "run": "0",
+    "answer": "The maximum adjusted closing price for The RealReal, Inc. (ticker REAL) in 2020 was $18.44 (recorded on 2020-01-03; available data covers 2020-01-02 through 2020-04-01)."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "1",
+    "run": "1",
+    "answer": "The maximum adjusted closing price in 2020 for The RealReal, Inc. (ticker: REAL) was $18.44 (recorded on January 3, 2020)."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "1",
+    "run": "2",
+    "answer": "The maximum adjusted closing price for The RealReal, Inc. (ticker REAL) in 2020 was $18.44 (recorded on January 3, 2020)."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "1",
+    "run": "3",
+    "answer": "The maximum adjusted closing price in 2020 for The RealReal, Inc. (ticker: REAL) was approximately $18.44 (recorded on 2020-01-03)."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "1",
+    "run": "4",
+    "answer": "The maximum adjusted closing price for The RealReal, Inc. (ticker REAL) in 2020 was $18.44 (recorded on 2020-01-03)."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "2",
+    "run": "0",
+    "answer": "Method: From stockinfo_database, selected all securities with ETF = 'Y' and Listing Exchange = 'P' (NYSE ARCA) → 1,435 ETFs. For each of their price tables in stocktrade_database, the maximum \"Adj Close\" restricted to trading dates in 2015 was computed; 31 of them exceeded $200.\n\nNYSE Arca ETFs whose adjusted closing price went above $200 at some point during 2015 (peak 2015 adjusted close in parentheses):\n\n1. BOIL — ProShares Ultra Bloomberg Natural Gas ($382.20)\n2. BZQ — ProShares UltraShort MSCI Brazil Capped ($462.78)\n3. COM — Direxion Auspice Broad Commodity Strategy ETF ($40,487.99)\n4. DUST — Direxion Daily Gold Miners Index Bear 2X Shares ($1,923.28)\n5. EDZ — Direxion Emerging Markets Bear 3X Shares ($302.01)\n6. ERX — Direxion Energy Bull 2X Shares ($645.16)\n7. FAZ — Direxion Financial Bear 3X Shares ($288.54)\n8. FXP — ProShares UltraShort FTSE China 50 ($206.00)\n9. GFIN — Goldman Sachs Motif Finance Reimagined ETF ($686.76)\n10. GUSH — Direxion Daily S&P Oil & Gas Exp. & Prod. Bull 2X Shares ($78,699.22)\n11. HYUP — Xtrackers High Beta High Yield Bond ETF ($4,329.75)\n12. JDST — Direxion Daily Junior Gold Miners Index Bear 2X Shares ($12,988.41)\n13. JNUG — Direxion Daily Junior Gold Miners Index Bull 2X Shares ($451.07)\n14. JPN — Xtrackers Japan JPX-Nikkei 400 Equity ETF ($201.52)\n15. LABD — Direxion Daily S&P Biotech Bear 3X Shares ($624.08)\n16. LABU — Direxion Daily S&P Biotech Bull 3X Shares ($230.28)\n17. LBJ — Direxion Daily Latin America 3x Bull Shares ($998.11)\n18. MDY — SPDR S&P MidCap 400 (SPDR MidCap Trust Series I) ($263.77)\n19. PTIN — Pacer Trendpilot International ETF ($843.53)\n20. RTL — Pacer Benchmark Retail Real Estate SCTR ETF ($13,306.76)\n21. SDOW — UltraPro Short Dow30 ($415.17)\n22. SOXS — Direxion Daily Semiconductor Bear 3X Shares ($3,886.62)\n23. SSG — ProShares UltraShort Semiconductors ($263.87)\n24. TECS — Direxion Technology Bear 3X Shares ($253.30)\n25. TZA — Direxion Small Cap Bear 3X Shares ($272.63)\n26. UVXY — ProShares Ultra VIX Short-Term Futures ETF ($81,500.00)\n27. VIXY — ProShares VIX Short-Term Futures ETF ($491.00)\n28. VPC — Virtus Private Credit Strategy ETF ($2,250.14)\n29. XES — SPDR S&P Oil & Gas Equipment & Services ETF ($278.55)\n30. XOP — SPDR S&P Oil & Gas Exploration & Production ETF ($208.74)\n31. YANG — Direxion Daily FTSE China Bear 3x Shares ($347.35)\n\nTOTAL NUMBER OF SUCH ETFs: 31\n\n(Notes: most are leveraged/inverse funds whose split-adjusted histories push them far above $200; mainstream funds such as SPY (max $193.31), IVV ($193.53), DIA ($163.62) and SVXY ($194.80) stayed just under the $200 threshold in 2015.)"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "2",
+    "run": "1",
+    "answer": "ETFs listed on NYSE Arca (Listing Exchange = 'P', ETF = 'Y' in stockinfo) whose 2015 daily Adjusted Close exceeded $200 in the stocktrade_database (1,435 NYSE Arca ETFs checked; peak 2015 Adj Close shown):\n\n1. UVXY – $81,500.00\n2. GUSH – $78,699.22\n3. COM – $40,487.99\n4. RTL – $13,306.76\n5. JDST – $12,988.41\n6. HYUP – $4,329.75\n7. SOXS – $3,886.62\n8. VPC – $2,250.14\n9. DUST – $1,923.28\n10. LBJ – $998.11\n11. PTIN – $843.53\n12. GFIN – $686.76\n13. ERX – $645.16\n14. LABD – $624.08\n15. VIXY – $491.00\n16. BZQ – $462.78\n17. JNUG – $451.07\n18. SDOW – $415.17\n19. BOIL – $382.20\n20. YANG – $347.35\n21. EDZ – $302.01\n22. FAZ – $288.54\n23. XES – $278.55\n24. TZA – $272.63\n25. SSG – $263.87\n26. MDY – $263.77\n27. TECS – $253.30\n28. LABU – $230.28\n29. XOP – $208.74\n30. FXP – $206.00\n31. JPN – $201.52\n\nTotal number of such ETFs: 31"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "2",
+    "run": "2",
+    "answer": "ETF securities listed on NYSE Arca (stockinfo: ETF = 'Y', Listing Exchange = 'P') whose \"Adj Close\" exceeded $200 on at least one trading day in 2015 (stocktrade_database): 31 ETFs.\n\n1. BOIL – ProShares Ultra Bloomberg Natural Gas (2015 max adj close ≈ 382.20; 158/252 days above $200)\n2. BZQ – ProShares UltraShort MSCI Brazil Capped (≈ 462.78; 218 days)\n3. COM – Direxion Auspice Broad Commodity Strategy ETF (≈ 40,487.99; 23 days)\n4. DUST – Direxion Daily Gold Miners Index Bear 2X Shares (≈ 1,923.28; 252 days)\n5. EDZ – Direxion Emerging Markets Bear 3X Shares (≈ 302.01; 74 days)\n6. ERX – Direxion Energy Bull 2X Shares (≈ 645.16; 252 days)\n7. FAZ – Direxion Financial Bear 3X Shares (≈ 288.54; 221 days)\n8. FXP – ProShares UltraShort FTSE China 50 (≈ 206.00; 2 days)\n9. GFIN – Goldman Sachs Motif Finance Reimagined ETF (≈ 686.76; 107 days)\n10. GUSH – Direxion Daily S&P Oil & Gas Exp. & Prod. Bull 2X Shares (≈ 78,699.22; 151 days)\n11. HYUP – Xtrackers High Beta High Yield Bond ETF (≈ 4,329.75; 99 days)\n12. JDST – Direxion Daily Junior Gold Miners Index Bear 2X Shares (≈ 12,988.41; 252 days)\n13. JNUG – Direxion Daily Junior Gold Miners Index Bull 2X Shares (≈ 451.07; 100 days)\n14. JPN – Xtrackers Japan JPX-Nikkei 400 Equity ETF (≈ 201.52; 8 days)\n15. LABD – Direxion Daily S&P Biotech Bear 3X Shares (≈ 624.08; 152 days)\n16. LABU – Direxion Daily S&P Biotech Bull 3X Shares (≈ 230.28; 11 days)\n17. LBJ – Direxion Daily Latin America 3x Bull Shares (≈ 998.11; 252 days)\n18. MDY – SPDR S&P MidCap 400 (SPDR MidCap Trust Series I) (≈ 263.77; 252 days)\n19. PTIN – Pacer Trendpilot International ETF (≈ 843.53; 108 days)\n20. RTL – Pacer Benchmark Retail Real Estate SCTR ETF (≈ 13,306.76; 98 days)\n21. SDOW – UltraPro Short Dow30 (≈ 415.17; 252 days)\n22. SOXS – Direxion Daily Semiconductor Bear 3X Shares (≈ 3,886.62; 252 days)\n23. SSG – ProShares UltraShort Semiconductors (≈ 263.87; 73 days)\n24. TECS – Direxion Technology Bear 3X Shares (≈ 253.30; 68 days)\n25. TZA – Direxion Small Cap Bear 3X Shares (≈ 272.63; 160 days)\n26. UVXY – ProShares Ultra VIX Short-Term Futures ETF (≈ 81,500.00; 252 days)\n27. VIXY – ProShares VIX Short-Term Futures ETF (≈ 491.00; 252 days)\n28. VPC – Virtus Private Credit Strategy ETF (≈ 2,250.14; 114 days)\n29. XES – SPDR S&P Oil & Gas Equipment & Services ETF (≈ 278.55; 155 days)\n30. XOP – SPDR S&P Oil & Gas Exploration & Production ETF (≈ 208.74; 12 days)\n31. YANG – Direxion Daily FTSE China Bear 3x Shares (≈ 347.35; 168 days)\n\nTOTAL NUMBER OF SUCH ETFs: 31 (out of 1,435 NYSE Arca–listed ETFs checked; all 1,435 ticker tables were screened for the maximum 2015 adjusted closing price).\n\nNotes: the screening used MAX(\"Adj Close\") over rows with Date LIKE '2015%' (verified against a superset pre-filter on the all-time max Close, which is valid because \"Adj Close\" ≤ \"Close\" in this dataset). Very large values (e.g., COM, GUSH, UVXY, JDST) reflect this dataset's split-adjusted \"Adj Close\" series for funds that later underwent large reverse splits. High-profile broad-market ETFs such as SPY (193.31), IVV (193.53) and VOO (177.18) did NOT qualify, because their 2015 adjusted closes stayed below $200."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "2",
+    "run": "3",
+    "answer": "ETFs listed on NYSE Arca (Listing Exchange = \"P\", ETF = \"Y\") whose adjusted closing price exceeded $200 on at least one trading day in 2015:\n\n1. BOIL – ProShares Ultra Bloomberg Natural Gas (2015 max Adj Close ≈ 382.20)\n2. BZQ – ProShares UltraShort MSCI Brazil Capped (≈ 462.78)\n3. COM – Direxion Auspice Broad Commodity Strategy ETF (≈ 40,487.99)\n4. DUST – Direxion Daily Gold Miners Index Bear 2X Shares (≈ 1,923.28)\n5. EDZ – Direxion Emerging Markets Bear 3X Shares (≈ 302.01)\n6. ERX – Direxion Energy Bull 2X Shares (≈ 645.16)\n7. FAZ – Direxion Financial Bear 3X Shares (≈ 288.54)\n8. FXP – ProShares UltraShort FTSE China 50 (≈ 206.00)\n9. GFIN – Goldman Sachs Motif Finance Reimagined ETF (≈ 686.76)\n10. GUSH – Direxion Daily S&P Oil & Gas Exp. & Prod. Bull 2X Shares (≈ 78,699.22)\n11. HYUP – Xtrackers High Beta High Yield Bond ETF (≈ 4,329.75)\n12. JDST – Direxion Daily Junior Gold Miners Index Bear 2X Shares (≈ 12,988.41)\n13. JNUG – Direxion Daily Junior Gold Miners Index Bull 2X Shares (≈ 451.07)\n14. JPN – Xtrackers Japan JPX-Nikkei 400 Equity ETF (≈ 201.52)\n15. LABD – Direxion Daily S&P Biotech Bear 3X Shares (≈ 624.08)\n16. LABU – Direxion Daily S&P Biotech Bull 3X Shares (≈ 230.28)\n17. LBJ – Direxion Daily Latin America 3x Bull Shares (≈ 998.11)\n18. MDY – SPDR S&P MidCap 400 (SPDR MidCap Trust Series I) (≈ 263.77)\n19. PTIN – Pacer Trendpilot International ETF (≈ 843.53)\n20. RTL – Pacer Benchmark Retail Real Estate SCTR ETF (≈ 13,306.76)\n21. SDOW – UltraPro Short Dow30 (≈ 415.17)\n22. SOXS – Direxion Daily Semiconductor Bear 3x Shares (≈ 3,886.62)\n23. SSG – ProShares UltraShort Semiconductors (≈ 263.87)\n24. TECS – Direxion Technology Bear 3X Shares (≈ 253.30)\n25. TZA – Direxion Small Cap Bear 3X Shares (≈ 272.63)\n26. UVXY – ProShares Ultra VIX Short-Term Futures ETF (≈ 81,500.00)\n27. VIXY – ProShares VIX Short-Term Futures ETF (≈ 491.00)\n28. VPC – Virtus Private Credit Strategy ETF (≈ 2,250.14)\n29. XES – SPDR S&P Oil & Gas Equipment & Services ETF (≈ 278.55)\n30. XOP – SPDR S&P Oil & Gas Exploration & Production ETF (≈ 208.74)\n31. YANG – Direxion Daily FTSE China Bear 3x Shares (≈ 347.35)\n\nTotal number of such ETFs: 31"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "2",
+    "run": "4",
+    "answer": "31 ETF securities listed on NYSE Arca (Listing Exchange = 'P', ETF = 'Y') recorded an adjusted closing price above $200 at some point during 2015.\n\nSymbols, with their 2015 peak adjusted close (date of peak):\n1. BOIL – $382.20 (2015-01-14)\n2. BZQ – $462.78 (2015-09-28)\n3. COM – $40,487.99 (2015-03-04)\n4. DUST – $1,923.28 (2015-08-05)\n5. EDZ – $302.01 (2015-08-24)\n6. ERX – $645.16 (2015-04-29)\n7. FAZ – $288.54 (2015-01-30)\n8. FXP – $206.00 (2015-09-04)\n9. GFIN – $686.76 (2015-06-02)\n10. GUSH – $78,699.22 (2015-06-10)\n11. HYUP – $4,329.75 (2015-03-25)\n12. JDST – $12,988.41 (2015-07-23)\n13. JNUG – $451.07 (2015-01-20)\n14. JPN – $201.52 (2015-06-01)\n15. LABD – $624.08 (2015-09-29)\n16. LABU – $230.28 (2015-07-17)\n17. LBJ – $998.11 (2015-01-22)\n18. MDY – $263.77 (2015-06-23)\n19. PTIN – $843.53 (2015-04-13)\n20. RTL – $13,306.76 (2015-08-11)\n21. SDOW – $415.17 (2015-08-25)\n22. SOXS – $3,886.62 (2015-08-25)\n23. SSG – $263.87 (2015-08-25)\n24. TECS – $253.30 (2015-08-25)\n25. TZA – $272.63 (2015-09-29)\n26. UVXY – $81,500.00 (2015-01-15)\n27. VIXY – $491.00 (2015-01-30)\n28. VPC – $2,250.14 (2015-01-07)\n29. XES – $278.55 (2015-04-30)\n30. XOP – $208.74 (2015-04-15)\n31. YANG – $347.35 (2015-09-04)\n\nTotal number of such ETFs: 31\n\n(Method: all 1,435 ETFs with Listing Exchange = 'P' in stockinfo were screened in stocktrade for all-time max \"Adj Close\" > 200, then the 112 survivors were re-checked restricted to dates in 2015; the 31 above had a 2015 maximum adjusted close strictly above $200. Very large values reflect split/adjustment factors in the \"Adj Close\" series.)"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "3",
+    "run": "0",
+    "answer": "Financially troubled (status D = Deficient / H = Deficient & Delinquent) companies in the NASDAQ-listed Market Categories (Q = Global Select, G = Global, S = Capital) that have trading volume data in 2008, with their average daily trading volume in 2008 (15 companies):\n\n1. Frontier Communications Corporation (FTR) — 254,397.63 shares/day\n2. Correvio Pharma Corp. (CORV) — 145,247.83\n3. CBAK Energy Technology, Inc. (CBAT) — 86,223.32\n4. Sypris Solutions, Inc. (SYPR) — 36,836.36\n5. Apex Global Brands Inc. (APEX) — 23,781.42\n6. DASAN Zhone Solutions, Inc. (DZSI) — 15,578.66\n7. BIO-key International, Inc. (BKYI) — 10,988.14\n8. Pacific Ethanol, Inc. (PEIX) — 10,706.72\n9. China Ceramics Co., Ltd. (CCCL) — 4,366.80\n10. Synthesis Energy Systems, Inc. (SES, status H = deficient & delinquent) — 2,390.51\n11. Sunesis Pharmaceuticals, Inc. (SNSS) — 781.82\n12. CounterPath Corporation (CPAH) — 375.49\n13. Ocean Power Technologies, Inc. (OPTT) — 254.15\n14. Ideanomics, Inc. (IDEX) — 10.28\n15. Future FinTech Group Inc. (FTFT) — 9.85 (168 of 169 2008 rows had non-null volume)\n\nOther troubled NASDAQ-listed companies were excluded because they have no 2008 trading volume (no non-null average): Aemetis Inc. (AMTX), Invesco RAFI Strategic Developed ex-US Small Company ETF (ISDS), Reebonz Holding Limited (RBZ), SPI Energy Co. Ltd. (SPI), AGM Group Holdings Inc. (AGMH), Biocept Inc. (BIOC), Farmmi Inc. (FAMI), Mid-Con Energy Partners LP (MCEP), NXT-ID Inc. (NXTD), VectoIQ Acquisition Corp. (VTIQW)."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "3",
+    "run": "1",
+    "answer": "Financially troubled companies (Financial Status = D \"Deficient\" or H \"Deficient & Delinquent\") on a NASDAQ-listed market (Market Category Q/G/S) that have trading-volume data in 2008, with their average daily trading volume in 2008 (15 companies, alphabetical):\n\n1. Apex Global Brands Inc. (APEX) – 23,781.42\n2. BIO-key International, Inc. (BKYI) – 10,988.14\n3. CBAK Energy Technology, Inc. (CBAT) – 86,223.32\n4. China Ceramics Co., Ltd. (CCCL) – 4,366.80\n5. Correvio Pharma Corp. (CORV) – 145,247.83\n6. CounterPath Corporation (CPAH) – 375.49\n7. DASAN Zhone Solutions, Inc. (DZSI) – 15,578.66\n8. Future FinTech Group Inc. (FTFT) – 9.85 (168 non-null volume days)\n9. Frontier Communications Corporation (FTR) – 254,397.63\n10. Ideanomics, Inc. (IDEX) – 10.28\n11. Ocean Power Technologies, Inc. (OPTT) – 254.15\n12. Pacific Ethanol, Inc. (PEIX) – 10,706.72\n13. Sunesis Pharmaceuticals, Inc. (SNSS) – 781.82\n14. Synthesis Energy Systems, Inc. (SES) – 2,390.51 (status H: deficient and delinquent)\n15. Sypris Solutions, Inc. (SYPR) – 36,836.36\n\nNote: 10 other troubled NASDAQ-listed companies in the stockinfo table (AGMH – AGM Group Holdings, AMTX – Aemetis, BIOC – Biocept, FAMI – Farmmi, ISDS – Invesco RAFI Strategic Developed ex-US Small Company ETF, MCEP – Mid-Con Energy Partners, NXTD – NXT-ID, RBZ – Reebonz Holding, SPI – SPI Energy, VTIQW – VectoIQ Acquisition Corp.) have no 2008 rows in the trading database, so their 2008 average daily volume is null and they are excluded."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "3",
+    "run": "2",
+    "answer": "15 financially troubled (Deficient \"D\" / Deficient+Delinquent \"H\") NASDAQ-listed-market companies have 2008 trading volume data. Average daily trading volume in 2008 (computed over non-null daily Volume values):\n\n1. Frontier Communications Corporation (FTR) — 254,397.63\n2. Correvio Pharma Corp. (CORV) — 145,247.83\n3. CBAK Energy Technology, Inc. (CBAT) — 86,223.32\n4. Sypris Solutions, Inc. (SYPR) — 36,836.36\n5. Apex Global Brands Inc. (APEX) — 23,781.42\n6. DASAN Zhone Solutions, Inc. (DZSI) — 15,578.66\n7. BIO-key International, Inc. (BKYI) — 10,988.14\n8. Pacific Ethanol, Inc. (PEIX) — 10,706.72\n9. China Ceramics Co., Ltd. (CCCL) — 4,366.80\n10. Synthesis Energy Systems, Inc. (SES) — 2,390.51\n11. Sunesis Pharmaceuticals, Inc. (SNSS) — 781.82\n12. CounterPath Corporation (CPAH) — 375.49\n13. Ocean Power Technologies, Inc. (OPTT) — 254.15\n14. Ideanomics, Inc. (IDEX) — 10.28\n15. Future FinTech Group Inc. (FTFT) — 9.85 (168 non-null volume days out of 169 trading rows in 2008)\n\nNote: Other troubled NASDAQ-listed tickers (AGMH, AMTX, BIOC, FAMI, ISDS, MCEP, NXTD, RBZ, SPI, VTIQW) were excluded because they have no 2008 trading data."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "3",
+    "run": "3",
+    "answer": "15 financially troubled (Deficient \"D\" / Deficient+Delinquent \"H\") NASDAQ-listed companies have trading volume data for 2008. Their average daily trading volume in 2008 (non-null values only) is:\n\n| Company (Symbol) | Avg daily volume 2008 | Non-null trading days |\n|---|---|---|\n| Apex Global Brands Inc. (APEX) | 23,781.42 | 253 |\n| BIO-key International, Inc. (BKYI) | 10,988.14 | 253 |\n| CBAK Energy Technology, Inc. (CBAT) | 86,223.32 | 253 |\n| China Ceramics Co., Ltd. (CCCL) | 4,366.80 | 253 |\n| Correvio Pharma Corp. (CORV) | 145,247.83 | 253 |\n| CounterPath Corporation (CPAH) | 375.49 | 253 |\n| DASAN Zhone Solutions, Inc. (DZSI) | 15,578.66 | 253 |\n| Future FinTech Group Inc. (FTFT) | 9.85 | 168 |\n| Frontier Communications Corporation (FTR) | 254,397.63 | 253 |\n| Ideanomics, Inc. (IDEX) | 10.28 | 253 |\n| Ocean Power Technologies, Inc. (OPTT) | 254.15 | 253 |\n| Pacific Ethanol, Inc. (PEIX) | 10,706.72 | 253 |\n| Synthesis Energy Systems, Inc. (SES, status H = deficient + delinquent) | 2,390.51 | 253 |\n| Sunesis Pharmaceuticals, Inc. (SNSS) | 781.82 | 253 |\n| Sypris Solutions, Inc. (SYPR) | 36,836.36 | 253 |\n\nNote: 10 other financially troubled NASDAQ-listed companies (AGMH, AMTX, BIOC, FAMI, ISDS, MCEP, NXTD, RBZ, SPI, VTIQW) were excluded because their price/volume tables contain no 2008 data (they began trading after 2008)."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "3",
+    "run": "4",
+    "answer": "Financially troubled NASDAQ-listed companies (Financial Status = D \"Deficient\" or H \"Deficient & Delinquent\") that have trading volume data for 2008, with their average daily trading volume in 2008 (average of non-null daily Volume values):\n\n1. Frontier Communications Corporation (FTR) – 254,397.63 shares/day\n2. Correvio Pharma Corp. (CORV) – 145,247.83\n3. CBAK Energy Technology, Inc. (CBAT) – 86,223.32\n4. Sypris Solutions, Inc. (SYPR) – 36,836.36\n5. Apex Global Brands Inc. (APEX) – 23,781.42\n6. DASAN Zhone Solutions, Inc. (DZSI) – 15,578.66\n7. BIO-key International, Inc. (BKYI) – 10,988.14\n8. Pacific Ethanol, Inc. (PEIX) – 10,706.72\n9. China Ceramics Co., Ltd. (CCCL) – 4,366.80\n10. Synthesis Energy Systems, Inc. (SES; status H = deficient + delinquent) – 2,390.51\n11. Sunesis Pharmaceuticals, Inc. (SNSS) – 781.82\n12. CounterPath Corporation (CPAH) – 375.49\n13. Ocean Power Technologies, Inc. (OPTT) – 254.15\n14. Ideanomics, Inc. (IDEX) – 10.28\n15. Future FinTech Group Inc. (FTFT) – 9.85 (based on 168 of 169 2008 trading days with non-null volume)\n\nNotes: 25 companies were financially troubled (24 \"D\" and 1 \"H\"); all 10 remaining troubled companies (AGMH, AMTX, BIOC, FAMI, ISDS, MCEP, NXTD, RBZ, SPI, VTIQW) were excluded because they have no 2008 trading-volume records."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "4",
+    "run": "0",
+    "answer": "Top 5 NYSE-listed, non-ETF stocks by number of 2017 up days (Close > Open) among those with more up days than down days:\n\n1. HDFC Bank Limited (HDB) – 146 up / 102 down\n2. Albany International Corporation (AIN) – 143 up / 101 down\n3. Getty Realty Corporation (GTY) – 143 up / 104 down\n4. Mettler-Toledo International, Inc. (MTD) – 143 up / 108 down\n5. Pfizer, Inc. (PFE) – 141 up / 105 down  (tied at 141 up days with Ameriprise Financial, Inc. (AMP) – 141 up / 110 down, which would be 6th)\n\nNames: HDFC Bank Limited; Albany International Corporation; Getty Realty Corporation; Mettler-Toledo International, Inc.; Pfizer, Inc. (Ameriprise Financial, Inc. ties for 5th place)."
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "4",
+    "run": "1",
+    "answer": "Top 5 NYSE-listed, non-ETF stocks with more up days than down days in 2017 (ranked by the size of the up-day advantage; NYSE = Listing Exchange \"N\", ETF flag = \"N\"):\n\n1. MFA Financial, Inc. (MFO) — 139 up days vs 67 down days\n2. Argo Group International Holdings, Ltd. (ARGD) — 133 up days vs 82 down days\n3. HDFC Bank Limited (HDB) — 146 up days vs 102 down days\n4. Albany International Corporation (AIN) — 143 up days vs 101 down days\n5. DTE Energy Company (DTQ) — 139 up days vs 98 down days\n\nNames only: MFA Financial, Inc.; Argo Group International Holdings, Ltd.; HDFC Bank Limited; Albany International Corporation; DTE Energy Company. (130 of the 234 NYSE non-ETF stocks had more up days than down days in 2017.)"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "4",
+    "run": "2",
+    "answer": "Top 5 NYSE-listed (Listing Exchange = \"N\"), non-ETF stocks with more up days than down days in 2017, ranked by number of up days:\n\n1. HDFC Bank Limited (HDB) – 146 up / 102 down\n2. Albany International Corporation (AIN) – 143 up / 101 down\n3. Getty Realty Corporation (GTY) – 143 up / 104 down\n4. Mettler-Toledo International, Inc. (MTD) – 143 up / 108 down\n5. Ameriprise Financial, Inc. (AMP) – 141 up / 110 down (tied on up days with Pfizer, Inc. at 141 up / 105 down)"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "4",
+    "run": "3",
+    "answer": "Top 5 NYSE‑listed, non‑ETF stocks with the most up days (Close > Open) in 2017 — all of which had more up days than down days:\n\n1. HDFC Bank Limited (HDB) – 146 up / 102 down\n2. Albany International Corporation (AIN) – 143 up / 101 down\n3. Getty Realty Corporation (GTY) – 143 up / 104 down\n4. Mettler‑Toledo International, Inc. (MTD) – 143 up / 108 down\n5. Ameriprise Financial, Inc. (AMP) – 141 up / 110 down (tied on up days with Pfizer, Inc. – PFE – at 141 up / 105 down)"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "4",
+    "run": "4",
+    "answer": "Top 5 NYSE‑listed, non‑ETF stocks with the most up days (Close > Open) in 2017, all with more up days than down days:\n\n1. HDFC Bank Limited (HDB) – 146 up days, 102 down days\n2. Albany International Corporation (AIN) – 143 up days, 101 down days\n3. Getty Realty Corporation (GTY) – 143 up days, 104 down days\n4. Mettler‑Toledo International, Inc. (MTD) – 143 up days, 108 down days\n5. Pfizer, Inc. (PFE) – 141 up days, 105 down days (tied at 141 up days with Ameriprise Financial, Inc. (AMP), 141 up / 110 down, which is 6th by net up‑minus‑down days)\n\n(All had a full 251 trading days of 2017 data; 131 of the 213 NYSE non‑ETF stocks in the price database had more up days than down days.)"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "5",
+    "run": "0",
+    "answer": "Top 5 NASDAQ Capital Market stocks (Market Category = 'S') by number of 2019 trading days where the intraday range (High − Low) exceeded 20% of the day's Low:\n\n1. Synthesis Energy Systems, Inc. (SES) — 51 days\n2. TD Holdings, Inc. (GLG) — 42 days\n3. TMSR Holding Company Limited (TMSR) — 40 days\n4. Verb Technology Company, Inc. (VERB) — 38 days\n5. Sunesis Pharmaceuticals, Inc. (SNSS) — 32 days"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "5",
+    "run": "1",
+    "answer": "Top 5 NASDAQ Capital Market (Market Category \"S\") stocks by number of 2019 trading days where (High − Low) > 20% of Low:\n\n1. Synthesis Energy Systems, Inc. (SES) — 51 days\n2. TD Holdings, Inc. (GLG) — 42 days\n3. TMSR Holding Company Limited (TMSR) — 40 days\n4. Verb Technology Company, Inc. (VERB) — 38 days\n5. Sunesis Pharmaceuticals, Inc. (SNSS) — 32 days"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "5",
+    "run": "2",
+    "answer": "Top 5 NASDAQ Capital Market companies by number of 2019 trading days where (High − Low) > 20% of the Low price:\n\n1. Synthesis Energy Systems, Inc. (SES) – 51 days\n2. TD Holdings, Inc. (GLG) – 42 days\n3. TMSR Holding Company Limited (TMSR) – 40 days\n4. Verb Technology Company, Inc. (VERB) – 38 days\n5. Sunesis Pharmaceuticals, Inc. (SNSS) – 32 days"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "5",
+    "run": "3",
+    "answer": "Top 5 NASDAQ Capital Market (Market Category \"S\") companies by number of 2019 trading days where (High − Low) > 20% of Low:\n\n1. Synthesis Energy Systems, Inc. (SES) — 51 days\n2. TD Holdings, Inc. (GLG) — 42 days\n3. TMSR Holding Company Limited (TMSR) — 40 days\n4. Verb Technology Company, Inc. (VERB) — 38 days\n5. Sunesis Pharmaceuticals, Inc. (SNSS) — 32 days"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "5",
+    "run": "4",
+    "answer": "Top 5 NASDAQ Capital Market stocks by number of 2019 trading days with intraday range (High−Low) > 20% of Low:\n\n1. Synthesis Energy Systems, Inc. (SES) — 51 days\n2. TD Holdings, Inc. (GLG) — 42 days\n3. TMSR Holding Company Limited (TMSR) — 40 days\n4. Verb Technology Company, Inc. (VERB) — 38 days\n5. Sunesis Pharmaceuticals, Inc. (SNSS) — 32 days"
+  },
+  {
+    "dataset": "yelp",
+    "query": "1",
+    "run": "0",
+    "answer": "≈ 3.55 (3.547) — the average of all 117 reviews for the 8 businesses located in Indianapolis, IN (businessref_16, 52, 65, 76, 84, 87, 90, 94). If instead you average each business's own mean rating, the result is 3.50."
+  },
+  {
+    "dataset": "yelp",
+    "query": "1",
+    "run": "1",
+    "answer": "≈ 3.55 out of 5\n\nDetails: 8 businesses are located in Indianapolis, IN (business ids 16, 52, 65, 76, 84, 87, 90, 94), with 117 reviews in total. Averaging all of their review ratings gives 3.547 (3.55). Averaging each business's own mean rating first, then averaging those 8 values, gives 3.497 (3.50)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "1",
+    "run": "2",
+    "answer": "The average rating of all businesses located in Indianapolis, IN is approximately 3.55 (3.5470) — based on all 117 Yelp reviews for the 8 Indianapolis businesses (business_id 16, 52, 65, 76, 84, 87, 90, 94).\n\nDetail (per-business averages):\n- businessref_16 (Fox and Hound English Pub and Grille): 3.02 (41 reviews)\n- businessref_52 (Architectural Antiques of Indianapolis): 4.17 (6)\n- businessref_65 (Pat Flynn's Public House): 3.83 (18)\n- businessref_76 (Big Lots): 3.56 (9)\n- businessref_84 (Gamestop): 5.00 (4)\n- businessref_87 (Jordans Fish and Chicken): 3.33 (6)\n- businessref_90 (Long John Silver's): 1.00 (3)\n- businessref_94 (Taste of Europe): 4.07 (30)\n\nIf instead you average the 8 per-business averages (unweighted), the result is 3.50."
+  },
+  {
+    "dataset": "yelp",
+    "query": "1",
+    "run": "3",
+    "answer": "~3.55 (3.5470) — the average rating across all 117 reviews for the 8 businesses located in Indianapolis, IN (businessids 16, 52, 65, 76, 84, 87, 90, 94). Note: averaging the per-business average ratings instead gives ≈ 3.50 (3.4975)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "1",
+    "run": "4",
+    "answer": "≈ 3.86 (3.8605)\n\nDetails: 5 businesses in the business collection are located in Indianapolis, IN (Architectural Antiques of Indianapolis #52, Gamestop #84, Big Lots #76, Jordans Fish and Chicken #87, Pat Flynn's Public House #65). Their 43 reviews total 166 rating points, giving an average rating of 166/43 ≈ 3.86. (If instead each business's average is averaged equally, the result is ≈ 3.98.)"
+  },
+  {
+    "dataset": "yelp",
+    "query": "2",
+    "run": "0",
+    "answer": "Pennsylvania (PA) has the highest number of reviews — 662 reviews across its 27 businesses (vs. 406 for FL, the next highest). The average rating of businesses in Pennsylvania is approximately 3.70 (3.6994 across all PA reviews; 3.65 if averaging per-business mean ratings)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "2",
+    "run": "1",
+    "answer": "Pennsylvania (PA) has the most reviews of any U.S. state: 662 reviews across its 27 businesses (next highest: FL with 406, MO with 213). The average rating of businesses in Pennsylvania is approximately 3.70 (3.6994 across all 662 PA reviews; the unweighted mean of the 27 business-level average ratings is 3.65)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "2",
+    "run": "2",
+    "answer": "Pennsylvania (PA) has the highest number of reviews — 662 of the 2,000 reviews in the review table (27 PA businesses, by far the most of any state; runner-up Florida has 406 reviews). The average rating of reviews for businesses in Pennsylvania is ≈ 3.70 (3.6994; averaging each business's own mean rating gives 3.65)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "2",
+    "run": "3",
+    "answer": "Pennsylvania (PA) has the highest number of reviews — 662 reviews across 27 businesses. The average rating of businesses in PA is approximately 3.70 (3.6994 when averaging all 662 individual review ratings; ~3.65 if averaging the per-business average ratings). Runner-up: Florida (FL) with 406 reviews (avg 3.03)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "2",
+    "run": "4",
+    "answer": "Pennsylvania (PA) has the most reviews — 662 reviews across its 27 businesses (far ahead of FL with 406 and MO with 213). The average rating of PA businesses is about 3.7 (3.70 across all PA reviews; 3.65 if you average each business's own average rating)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "3",
+    "run": "0",
+    "answer": "35\n\nDetails: 211 reviews were posted in 2018, across 67 distinct businesses. Of these, 35 businesses offer parking — 30 have at least one true BusinessParking option (garage/street/validated/lot/valet) and 27 have BikeParking = True, with overlap between the two groups (union = 35)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "3",
+    "run": "1",
+    "answer": "35\n\nOut of 67 businesses that received at least one review in 2018, 35 offer either business parking (at least one BusinessParking option — garage/street/validated/lot/valet — set to True) or bike parking (BikeParking = True). Breakdown: 30 with business parking, 27 with bike parking, 22 with both."
+  },
+  {
+    "dataset": "yelp",
+    "query": "3",
+    "run": "2",
+    "answer": "35 businesses\n\nDuring 2018, 67 distinct businesses received reviews; of these, 35 offered either business parking (at least one of garage/street/validated/lot/valet = True) or bike parking (BikeParking = True) — 8 business-parking only, 5 bike-parking only, and 22 offering both."
+  },
+  {
+    "dataset": "yelp",
+    "query": "3",
+    "run": "3",
+    "answer": "35\n\n(Out of 67 businesses that received at least one review dated in 2018, 30 offer business parking — i.e., at least one of garage/street/validated/lot/valet is True — and 27 offer bike parking; 35 offer one or both.)"
+  },
+  {
+    "dataset": "yelp",
+    "query": "3",
+    "run": "4",
+    "answer": "35"
+  },
+  {
+    "dataset": "yelp",
+    "query": "4",
+    "run": "0",
+    "answer": "Restaurants — 26 credit‑card‑accepting businesses list \"Restaurants\" among their categories (the highest of any category, ahead of Shopping with 17 and Food with 15). Their average review rating is ≈3.64 (3.6407 across 771 reviews; ≈3.46 if computed as the unweighted mean of the 26 per‑business averages)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "4",
+    "run": "1",
+    "answer": "Restaurants — it is the top business category among businesses that accept credit card payments (26 of the 75 credit‑card‑accepting businesses list \"Restaurants\" as a category, ahead of Shopping (17) and Food (15)). The average rating of these businesses, computed from their Yelp reviews (771 reviews), is ≈ 3.64 stars (3.46 if instead averaging each business's own mean rating)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "4",
+    "run": "2",
+    "answer": "Restaurants is the category with the most businesses that accept credit card payments: 26 of the 75 credit-card-accepting businesses (attributes.BusinessAcceptsCreditCards = \"True\") list \"Restaurants\" among their categories, far ahead of Shopping (17) and Food (15).\n\nAverage rating for these 26 Restaurants businesses (across all 771 of their reviews in the review table): ≈ 3.64 (3.6407). If instead each business's average is weighted equally, the average of the 26 business-level ratings is ≈ 3.46."
+  },
+  {
+    "dataset": "yelp",
+    "query": "4",
+    "run": "3",
+    "answer": "Restaurants — it is the category with the most credit-card-accepting businesses (27 of the 75 businesses whose attributes.BusinessAcceptsCreditCards = \"True\"), and those businesses have an average review rating of about 3.63 (778 reviews; mean of per-business averages ≈ 3.43)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "4",
+    "run": "4",
+    "answer": "Restaurants — it has the most credit-card-accepting businesses (24 of the 75 businesses flagged BusinessAcceptsCreditCards=True, vs. 17 for Shopping and 15 for Food). Its average rating is ≈3.60 (3.6006 across all 711 reviews of those 24 businesses; the mean of the per-business average ratings is ≈3.40)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "5",
+    "run": "0",
+    "answer": "Pennsylvania (PA) has the most businesses that offer WiFi (attributes.WiFi = 'free' or 'paid', i.e. not 'no'): 8 businesses (all offering free WiFi), ahead of FL (5), MO (2) and IN (2).\n\nAverage rating of those 8 Pennsylvania WiFi businesses = ~3.48 (3.484, computed over all 281 reviews in the review table; if instead you average each business's own average rating first, it is ~3.58).\n\n(Note: if any business with a non-null WiFi attribute is counted — including those marked 'no' — PA still leads, with 12 businesses and an average rating of ~3.70.)"
+  },
+  {
+    "dataset": "yelp",
+    "query": "5",
+    "run": "1",
+    "answer": "Pennsylvania (PA) has the highest number of WiFi-offering businesses: 8 of the 100 businesses (attributes.WiFi = \"free\"/\"paid\"), ahead of FL (5), MO (2) and IN (2).\n\nAverage rating of those 8 Pennsylvania WiFi businesses ≈ 3.58 / 5 (mean of the per‑business average ratings: 3.04, 4.29, 3.33, 2.55, 3.74, 4.48, 2.93, 4.31). Weighting all their reviews together gives an overall average of ≈ 3.48."
+  },
+  {
+    "dataset": "yelp",
+    "query": "5",
+    "run": "2",
+    "answer": "Pennsylvania (PA) has the most businesses offering WiFi: 8 out of the 22 businesses with WiFi (free or paid). Their average rating is ≈ 3.48 (3.4840) across all 281 reviews; the average of the 8 per-business mean ratings is ≈ 3.58.\n\nBreakdown of WiFi-offering businesses by state: PA 8, FL 5, MO 2, IN 2, LA 1, IL 1, NV 1, ID 1, AB 1 (Alberta, Canada — not a U.S. state)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "5",
+    "run": "3",
+    "answer": "Pennsylvania (PA) has the highest number of businesses offering WiFi: 8 businesses (all listing WiFi as \"free\") — Philadelphia (4: business IDs 40, 44, 77, 82, 86 subset), King of Prussia, Cheltenham, and Havertown. Their average rating is about 3.48 (3.4840 across their 281 reviews; ~3.58 if averaging each business's own average rating)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "5",
+    "run": "4",
+    "answer": "Pennsylvania (PA) has the most businesses offering WiFi — 8 of them (all with \"free\" WiFi), ahead of Florida with 5. The average rating for those 8 Pennsylvania WiFi businesses is ≈ 3.48 (mean of all 281 reviews; ≈ 3.58 if you instead average each business's own mean rating)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "6",
+    "run": "0",
+    "answer": "Coffee House Too Cafe (businessid_9) received the highest average rating between 2016-01-01 and 2016-06-30: 4.38 (4.375) across 16 reviews in that period. It belongs to the Cafes / Restaurants category — specifically listed as Restaurants, Breakfast & Brunch, American (New), and Cafes (a café/coffee shop in Philadelphia, PA).\n\n(Runners-up with ≥5 reviews in the window: Orangetheory Fitness Carrollwood – 4.00 avg, 7 reviews, Fitness & Instruction/Gyms; Uber – 3.60 avg, 5 reviews, Transportation/Taxis.)"
+  },
+  {
+    "dataset": "yelp",
+    "query": "6",
+    "run": "1",
+    "answer": "Coffee House Too Cafe (businessid_9) received the highest average rating between Jan 1, 2016 and Jun 30, 2016: 4.375 from 16 reviews. It belongs to the Restaurants / Cafes category — its listed categories are Restaurants, Breakfast & Brunch, American (New), and Cafes (located at 501 Fairmount Ave, Philadelphia, PA). Runner-ups: businessref_37 (4.00 avg, 7 reviews) and businessref_8 (3.60 avg, 5 reviews)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "6",
+    "run": "2",
+    "answer": "Coffee House Too Cafe (business_id: businessid_9) had the highest average rating between 2016-01-01 and 2016-06-30: 4.375 from 16 reviews. It belongs to the Restaurants category (description lists: Restaurants, Breakfast & Brunch, American (New), Cafes)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "6",
+    "run": "3",
+    "answer": "Coffee House Too Cafe (businessid_9, 501 Fairmount Ave, Philadelphia, PA) had the highest average rating between Jan 1 and Jun 30, 2016: 4.375 out of 5 from 16 reviews (runners-up: Orangetheory Fitness Carrollwood 4.00 w/ 7 reviews; Uber 3.60 w/ 5 reviews). It belongs to the Cafes/Restaurants category — its listed categories are Restaurants, Breakfast & Brunch, American (New), and Cafes (i.e., a cafe/restaurant)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "6",
+    "run": "4",
+    "answer": "Coffee House Too Cafe (businessid_9) received the highest average rating between Jan 1, 2016 and Jun 30, 2016: 4.375 stars from 16 qualifying reviews. It belongs to the Restaurants / Cafes category — specifically Restaurants, Breakfast & Brunch, American (New), and Cafes (located at 501 Fairmount Ave, Philadelphia, PA)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "7",
+    "run": "0",
+    "answer": "Top 5 business categories by total reviews written since 2016 by users who registered on Yelp in 2016 (168 users; 150 qualifying reviews across 62 businesses; categories parsed from each business's description):\n\n1. Restaurants – 58 reviews\n2. Food – 38 reviews\n3. American (New) – 24 reviews\n4. Shopping – 20 reviews\n5. Breakfast & Brunch – 19 reviews\n\n(Note: since a business can have multiple categories, each review is counted once per category of the reviewed business. The same top 5 ordering holds if \"since 2016\" is read as 2017 onward.)"
+  },
+  {
+    "dataset": "yelp",
+    "query": "7",
+    "run": "1",
+    "answer": "Top 5 business categories by total reviews written since 2016 by users who registered on Yelp in 2016 (168 users, 150 qualifying reviews; categories parsed from the business \"description\" field):\n\n1. Restaurants – 58 reviews\n2. Food – 38 reviews\n3. American (New) – 24 reviews\n4. Shopping – 20 reviews\n5. Breakfast & Brunch – 19 reviews"
+  },
+  {
+    "dataset": "yelp",
+    "query": "7",
+    "run": "2",
+    "answer": "Top 5 business categories by total reviews written since 2016 by users who registered on Yelp in 2016 (168 such users, 150 reviews from 2016 onward):\n\n1. Restaurants – 58 reviews\n2. Food – 38 reviews\n3. American (New) – 24 reviews\n4. Shopping – 20 reviews\n5. Breakfast & Brunch – 19 reviews\n\n(Method: 2016 registrants taken from user.yelping_since; their reviews dated 2016 or later were joined to businesses via business_ref ↔ business_id; categories were parsed from each business's description text, with each review counted once for every category of the reviewed business. The same top 5 holds if \"since 2016\" is read strictly as 2017 onward.)"
+  },
+  {
+    "dataset": "yelp",
+    "query": "7",
+    "run": "3",
+    "answer": "Top 5 business categories by total reviews from users who registered on Yelp in 2016 (reviews posted 2016 onward; 168 such users wrote 150 qualifying reviews across 62 businesses):\n\n1. Restaurants – 58 reviews\n2. Food – 38 reviews\n3. Shopping – 20 reviews\n4. Breakfast & Brunch – 19 reviews\n5. Automotive – 17 reviews (tied exactly with Local Services – 17 reviews; Automotive is listed 5th since it comes from 9 reviewed businesses vs 5 for Local Services)\n\nMethod: users with yelping_since in 2016 were joined to the review table (dates parsed from the three mixed date formats, filtered to >= 2016-01-01; no pre-2016 reviews existed for these users), business_ref was mapped to business_id (businessref_N -> businessid_N), and each business's categories were extracted from its description text; a review counted once per category of its business. Next runners-up: Home Services (14), Nightlife (14), Fast Food (14)."
+  },
+  {
+    "dataset": "yelp",
+    "query": "7",
+    "run": "4",
+    "answer": "Top 5 business categories by total reviews written since 2016 by users who registered in 2016 (168 users; 150 qualifying reviews):\n\n1. Restaurants – 58 reviews\n2. Food – 38 reviews\n3. American (New) – 24 reviews\n4. Shopping – 20 reviews\n5. Breakfast & Brunch – 19 reviews\n\n(Runners-up: Automotive 17, Local Services 17, American (Traditional) 16.)"
+  }
+]

--- a/leaderboard_submissions/qwen38flash_parallel_v1/run_config.json
+++ b/leaderboard_submissions/qwen38flash_parallel_v1/run_config.json
@@ -1,0 +1,1677 @@
+{
+  "created_at": "2026-09-11T17:41:21+08:00",
+  "config": {
+    "schema_version": 2,
+    "dab_revision": "aae973009f65e20585c81d6f860ba92c86d39368",
+    "git_commit": "200fcd9ae313521b3077bf8a330b1708e8f1c697",
+    "sources": {
+      "Dockerfile": "c5d0fc9f476ee9fc8ba4d9d4ae48e931bd52387c976ab1ebc068a4bba6eb3569",
+      "common_scaffold/DataAgent.py": "1828c12f2e11476f270d8feb5243d96358160ca6cee38ab5236863cb2953e1e2",
+      "common_scaffold/benchmark_config.py": "b249fda2e0f8abaf782ac5a7ed63b2422cf2bc1d40b1570ec089fa8d470ba7d7",
+      "common_scaffold/benchmark_processes.py": "2a38d5eb4d8adee860a12077ddeea2dddf8e87d7bba3b92001165c7d012ea53d",
+      "common_scaffold/benchmark_scheduler.py": "aa349bc1b6035cc7d10ee4a53cbac6dbd48a083c6d1308927507f664507419b4",
+      "common_scaffold/config.py": "cc8142c0ee730f767b1bbb565fbcc7954f7672628389b45c90e987ab9e823ea0",
+      "common_scaffold/prompts/prompt_builder.py": "9e94c64f49182cc7fc10a93da04cefdea8a79441c584e370d15ba5bcd6ddd760",
+      "common_scaffold/tools/BaseTool.py": "1a0c759aaedf3f52900d7161b71dcfa9f576dd7d4a68e6f27c0d5ce1c32ea6f8",
+      "common_scaffold/tools/ExecTool.py": "c24fe29804dee7ca51b61d1c2a7fd10ffecd44959e7d0ea5322d9c2245a4dd20",
+      "common_scaffold/tools/ListDBTool.py": "bdcfabc42f7ab04f5030b918707866b87c796a6a4708cb226d42223275089287",
+      "common_scaffold/tools/QueryDBTool.py": "b664e86be71baf735a71b1097c64227f5d49c7483dc5bb6719b061cbe955f8ab",
+      "common_scaffold/tools/ReturnAnswerTool.py": "17c6c1716fb7f0a30c7c0e1740e93df13e621e855a6e3f4e76c5235668f2f014",
+      "common_scaffold/tools/db_utils/db_config.py": "408234cf4189b257b261ac8ce16f483c636a562be77340291805a6b9b424fde5",
+      "common_scaffold/tools/db_utils/duckdb_utils.py": "63a7d486e8095a99cb2ac5c8c74a11ace007b0d0ff51d71712db448c3c6b6870",
+      "common_scaffold/tools/db_utils/mongo_utils.py": "251e9514fc7effbdc3460ede0733342b098e19b1feaccd7f9f23f398a6813f31",
+      "common_scaffold/tools/db_utils/postgres_utils.py": "dcdf5d0fe183c087cb40c06ccfffbfa4d6d1fb817dbf542fb591ec362df0f1b1",
+      "common_scaffold/tools/db_utils/sqlite_utils.py": "59eba86019b61dbd2b28e224ad58826c552e1dbc60c4f4b077d20a417daebdff",
+      "common_scaffold/tools/exec_utils/parse_result.py": "2d63b4352f0ace8109fef849f15af48f8802ed218051ab549c17b1fbe4f7bffd",
+      "common_scaffold/validate/levenshtein.py": "77c2cc868169345908261ad9c14bec48f29f6e25f4b690607c2936fefefa67c1",
+      "common_scaffold/validate/pass_k.py": "44fb0dff55f93a9659e9778911da9076b096ad4c8e19e6d8df793c67a777c2e6",
+      "common_scaffold/validate/validate.py": "676810b87b9372489db3a8fae7e394803126f28881b7e548f7bf885a79809154",
+      "logging_config.py": "38dbefae0f332c075110c0482de529ee60620b507aa29dc3db3bbe42dbb1edbc",
+      "requirements.lock.txt": "f2f52db010d2bfff5cfe74ed42b64feeed43cde06c973455360bad770d4732a1",
+      "run_agent.py": "78379d29168ca2ca93eaf5e2e4b367041f8c0deadcb43f14e9c193cb0e4bf45f",
+      "run_benchmark.py": "d3f5dbd9b46a282f9e66642e4b61d433e0d41f55b5f5b16c8aec3a399a67b663"
+    },
+    "inputs": {
+      "dataset_manifest.tsv": "b9fc770629644862ac5354fca82253b601f1fc85fbbc9e708918cfe09418eb39",
+      "query_DEPS_DEV_V1/db_config.yaml": "fb41b42f81a17377459e5d80415360e91641d4b3dbbf06e039eb17a01fec0c3e",
+      "query_DEPS_DEV_V1/db_description.txt": "cc42969175de961c82d1660b44f4c49eeeac5476cb2442234a5aa9ad5a45278a",
+      "query_DEPS_DEV_V1/db_description_withhint.txt": "b19a9ab19dc779942a8b4838cc89d1a30992e5a99c54485162594f81db25a6e5",
+      "query_DEPS_DEV_V1/query1/query.json": "0cedd62ce3f61e3fa7d45f1db9809b912273bded66b13310823fed671607c0a5",
+      "query_DEPS_DEV_V1/query1/validate.py": "691a1910f0eb76e20b7d0652141584320b5bcfcaa399f07d8601f0dbc00c2d35",
+      "query_DEPS_DEV_V1/query2/query.json": "5fe660eaae9c882a79e1afcb8e91baccdfaf88a0aa59197e3ac1a790fb2f4aed",
+      "query_DEPS_DEV_V1/query2/validate.py": "e7c49325c40ebc7a028f27dd5d677e22485e7acfed456ba6e029f6bdb03d480d",
+      "query_DEPS_DEV_V1/query_dataset/package_query.db": "6676259f784aa89aec838a3e4a74bc68793085e49520c819b2356205a6eaf68a",
+      "query_DEPS_DEV_V1/query_dataset/project_query.db": "e6b171594cbb8dbb5298b54206b235a396b0eee9dd8c2c68deefab8d76c72e6a",
+      "query_GITHUB_REPOS/db_config.yaml": "528a10e2a1827882af97d47514733cddb8264e81cb4e4d6dd2bcff6d8cab6cd5",
+      "query_GITHUB_REPOS/db_description.txt": "9a14a7a391f729498b51334a52612fa3c7f917d0c18d8f691a807834de63379c",
+      "query_GITHUB_REPOS/db_description_withhint.txt": "6105987c80e9aa6d1690dca00d8bdc770ade5daf9c48f84aa75de8ea6c1353dd",
+      "query_GITHUB_REPOS/query1/query.json": "c1ec5a8a222f1df528c246e18cc7791cfc5ffd5bdba3cd3da1f6362a526bd40f",
+      "query_GITHUB_REPOS/query1/validate.py": "c8e979be70776b67ee32372ac1e77b75f7474946809dc81d4941821bf5683bd5",
+      "query_GITHUB_REPOS/query2/query.json": "d643fbf44aef32f8b5f4c24cc5ab9ffc642ac2b5a6a52b6f7bae65b8087b632b",
+      "query_GITHUB_REPOS/query2/validate.py": "782a94fd3f78285d3035fcaa2b9de187c4a8a599b8203c9433f6aaa9ba1c83ef",
+      "query_GITHUB_REPOS/query3/query.json": "be348f0f9207fd049040a6cb3785a2e7d18a24aeb5d75a877e34e28d7916e0f0",
+      "query_GITHUB_REPOS/query3/validate.py": "e415c60c301c0376ee0c9b922390efa20500d5e23dd24fc574d2c000603c4f7c",
+      "query_GITHUB_REPOS/query4/query.json": "e19192b4f504d1c0dd8f61c13b36022f95a0f125fa82a5383d893a6bc0f63f88",
+      "query_GITHUB_REPOS/query4/validate.py": "b6d8110867225717a23f9e217f5586f8b32639b80a57d7d4bbd3f05cbc8d8287",
+      "query_GITHUB_REPOS/query_dataset/repo_artifacts.db": "d514c66eb07403f79b8da2ff6a79a6c82f2d862cadaf71d536ea58644cd07bbc",
+      "query_GITHUB_REPOS/query_dataset/repo_metadata.db": "e9b71beb5d7e2b344f996baf19fb34231c24ab354019d65bd14a1cbfc62c67a1",
+      "query_PANCANCER_ATLAS/db_config.yaml": "5711035bea1820d94eb5041faa687d5974553004dc993023970d3ed9493f5d13",
+      "query_PANCANCER_ATLAS/db_description.txt": "ff2b6e2989c785eaf5d62d7665d2539d5405f65b53451cfb9921b49724b7dc92",
+      "query_PANCANCER_ATLAS/db_description_withhint.txt": "6824e704afbd5b3653908e71ba3d8f0a6e901457689021745a340f668c958795",
+      "query_PANCANCER_ATLAS/query1/query.json": "7a127ebaa5aadfdd3eabf6a01891eda9211b15fa462f3e03f15e67f3a98ec328",
+      "query_PANCANCER_ATLAS/query1/validate.py": "3f1b15e3c24c1ce258ba064fcc3f2523ee4b7c8079ab58c5ac215cd90d1d6d7a",
+      "query_PANCANCER_ATLAS/query2/query.json": "352c6f13e64220ec8cb518ac3411382a66577f98f3c536d9610ea7f5a3e8b628",
+      "query_PANCANCER_ATLAS/query2/validate.py": "e48251d37463258951299880b5784724274aa87fee40583cd3c513fc3ff02312",
+      "query_PANCANCER_ATLAS/query3/query.json": "c21bb23a1d4c9e40717b73a55edf04b237a953a5c79a894e44672a5eab36d1b5",
+      "query_PANCANCER_ATLAS/query3/validate.py": "14b8be8849e25f4ba71b0347589ade0e51dec3e8a51f1273b485244981427520",
+      "query_PANCANCER_ATLAS/query_dataset/pancancer_clinical.sql": "ce57356f7a0f72e1c43a1fc2083d46293991645cbce2f6f237c731bf4035fdd6",
+      "query_PANCANCER_ATLAS/query_dataset/pancancer_molecular.db": "7e1131c386014ea8bdd528d2fd040a85f6891dd9e46e8dc18947f7a712cf8610",
+      "query_PATENTS/db_config.yaml": "1989d2c52cc76beae80a62d68ea46d62a5926118cbce8faf02b64de80711074c",
+      "query_PATENTS/db_description.txt": "3f85a6d3b5bcf450668938c4828f5c6ca03172623efe2311c3d919bc1be3ca26",
+      "query_PATENTS/db_description_withhint.txt": "26a2bd2123730dde9e63d506ad9311c203d7957672fc533d870185be2e6e78f0",
+      "query_PATENTS/query1/query.json": "b181e9bd7ee711fe45783c7bcdd04cc9c44da38ad96592d5895d90b5a33a5912",
+      "query_PATENTS/query1/validate.py": "764c9af0492c15fc12d2ce796fd312717c066af04937aa25c95a6351fe2efee8",
+      "query_PATENTS/query2/query.json": "85222e70a218b55a186a5be14e3ec047739558afbaf98b21b7f824dc9f6ce7ba",
+      "query_PATENTS/query2/validate.py": "28741289c1bb9065924f97981af0b64f19b0415fb110ee8e9d8c536a9f550c28",
+      "query_PATENTS/query3/query.json": "65a4054537b7662556db4ab5e0d04b290b5103080b8759da3d65573fe6034968",
+      "query_PATENTS/query3/validate.py": "c34efa6c273789795d3bf52a02e11503924644a665fa81ca752914a0c5577d50",
+      "query_PATENTS/query_dataset/patent_CPCDefinition.sql": "f888382228bf87538744194ca2ea1be126c316423d6d10e35e7d4ec226da0144",
+      "query_PATENTS/query_dataset/patent_publication.db": "1e22b92b9849b3f7a07dcf89075f37787c84feacb0cdbc7b4bd96ae4fa88071c",
+      "query_agnews/db_config.yaml": "97240184ab0646b66dc5015e10a5884bc673abe70c5a4d0610f5028fe7559d7d",
+      "query_agnews/db_description.txt": "296c7dabfd0fdc1343d2e3d4b17491f2946b44a8e807619bcda350d1397cba47",
+      "query_agnews/db_description_withhint.txt": "db6e3f29714e7898b8c8e91efa1077b2e120fbe0fb0bede47fb9a75481d7f988",
+      "query_agnews/query1/query.json": "bbc94a9e190cc3efe66b92537cb856622c111e52964c9c8bb7c530f3d9e182ce",
+      "query_agnews/query1/validate.py": "f2fd963afb74ae60921613f4662aacc7be39e6fae6d1acc2c121aeec7f61d322",
+      "query_agnews/query2/query.json": "79f736db6659b00b8ce85f03ce0eb9af962ec283404a72ee9e10fb8a477c2ae8",
+      "query_agnews/query2/validate.py": "4f38f4768db4b5bc392efdc495fe5d98a20d937bed9a773ae876445dd6287145",
+      "query_agnews/query3/query.json": "2444519816264b71fb76ba72cb641e04daebb340d8232651f2ab04e4d1b5a855",
+      "query_agnews/query3/validate.py": "809d8d3f011655336e2579577b93681b2f7170eadccf08551de74190e9a61b7f",
+      "query_agnews/query4/query.json": "b9e4940960a6376ea3ebec7bbb46e82fb470862ea7cd083c122dddaa1bedf6f1",
+      "query_agnews/query4/validate.py": "a90e70fefb2f2b97c408d9f236d1b1f07037e5bf553162157c6df36b627a8776",
+      "query_agnews/query_dataset/agnews_articles/articles_db/articles.bson": "ad74220284cb2737273f5b6a9e6c2c1e34374a232db1072a5842f82f8a539488",
+      "query_agnews/query_dataset/metadata.db": "30cfb96d29b4e49c5f6ae6e5cb2c754d98e118a183ddd57ae44ee3564aeb1955",
+      "query_bookreview/db_config.yaml": "974daea2f4e2bd804ad41691207ce86a2562876518487790d4825a5438b27aab",
+      "query_bookreview/db_description.txt": "d180e884f6481699379fcc3f7bc51b99b64d7866b3d63e9ffd82c8efb6e35153",
+      "query_bookreview/db_description_withhint.txt": "fc6a2b44133281359e39eae650ddd00c88117f9cfde58cec1c63ec13638846e6",
+      "query_bookreview/query1/query.json": "908099cc5c9202b498f2f21233bbe0dc1f1d346eb7c79ad4f836d0bb53567289",
+      "query_bookreview/query1/validate.py": "acb4462bb0fe6e1e7b54faf1ec6b7e75e3e88b38b074a9ebbb3d7c4e8f23759e",
+      "query_bookreview/query2/query.json": "97b6ecbd39ac559caab7f0cf6bec74a32011583db87f153afe6cbffeeb18c8b6",
+      "query_bookreview/query2/validate.py": "b85d464dea068a5f49587d6bc0067a50759ad7aca1c3dbf99679f8b45feb4a56",
+      "query_bookreview/query3/query.json": "118b330352dd14214a20a7bea1c2691ff18aa65e7546fb8e270af2e2ff62b976",
+      "query_bookreview/query3/validate.py": "7d234b73b4c2c256ea5f19b1d840e38589b0449e804a126eb9c18881a09d40aa",
+      "query_bookreview/query_dataset/books_info.sql": "80acb3ece574f26b634107c9c553dc5ab0c95ca11f6b226c9602dff9465393d9",
+      "query_bookreview/query_dataset/review_query.db": "01f07a5894f058613374694a8f46d19341bf1fa316367494d019191e772b3e2c",
+      "query_crmarenapro/db_config.yaml": "8440fe2fba1ca42ea5106bb0113c7f3eb4b248f2ea38d63bc432d9e4553b6390",
+      "query_crmarenapro/db_description.txt": "7a5421cb138f6e4bb0b2d1a7458b9b2a53dfbd1df8d5ebd852b6a2f8d9a9ad18",
+      "query_crmarenapro/db_description_withhint.txt": "8dd1fc389af715a4af0dae53543c6e996bbb63eaf75e9813c07cb2ce7176d256",
+      "query_crmarenapro/query1/query.json": "894e6fb92a2c798b3dd29e486a7ec78c5c9f8aa7ff398bef227b8784529d5f66",
+      "query_crmarenapro/query1/validate.py": "579be6cfae68087cc8efd8e2e9c1ae0a5283e722d2a1d033705d52f28b9f9835",
+      "query_crmarenapro/query10/query.json": "cad473f5f29c0965ea73e0c136a96034e3436df59c016c2a3549d03beeca2010",
+      "query_crmarenapro/query10/validate.py": "33e391562f728b4a5d80b7a1a8b046746a8d40a48817db1f379271ed99329193",
+      "query_crmarenapro/query11/query.json": "f26f335645c4383dde4f4532c4c84f21f4b01a26f9dd2738be6d151e8116b0f1",
+      "query_crmarenapro/query11/validate.py": "0a0b8e676ad86e4e90c8c06e0034a04d2b1fb28ef5bf63d097ecbd440d4bb8a7",
+      "query_crmarenapro/query12/query.json": "c4a10a08df2a82e5bbba81c38820f441acc4e69f0e8784b4cd9df76045244a20",
+      "query_crmarenapro/query12/validate.py": "99476c2b08ba7f07bfbe1fb4fd32938a5a78c7942e88fb57c35da748e6c7d2cc",
+      "query_crmarenapro/query13/query.json": "e45a2ab8feb029efd1fdc6dd175053d253ec6a833bec576015ca0fff5bde1044",
+      "query_crmarenapro/query13/validate.py": "cf707902d5ccb87233fbba008ebc70d6e7001d2f77e10ddebeb082575ded4486",
+      "query_crmarenapro/query2/query.json": "9e4834b6399ed135885379b58092992df72a6abfda6d63289c3c6d632ff7a67b",
+      "query_crmarenapro/query2/validate.py": "a9e852fda1bbda63d3d1940e129e32d5af4a428c75a78424b4495db02a984d1d",
+      "query_crmarenapro/query3/query.json": "3413c9ccae6924385e20ca4e5683a2b2bb53e988df87cbd40b2154885824d294",
+      "query_crmarenapro/query3/validate.py": "0b8dda4ccc5958a7ae292ff782329785ac450ac1ccec890484a6ff5a9f774767",
+      "query_crmarenapro/query4/query.json": "e7b8341035f0e32bb2dfe08a1112b2e973bf45ebffde77ec42de102d427f0da3",
+      "query_crmarenapro/query4/validate.py": "44a9efc64699eb0f99703ef0cb1e37d7c11af5bcfb62974a9f3c5d890af27c14",
+      "query_crmarenapro/query5/query.json": "12f4ad0de8c065b851dd9edb53f9003c58ddd02516c73d7b941c7b08ff432962",
+      "query_crmarenapro/query5/validate.py": "2c9fd2b1cef51e8e00b5cbefb15dfe4cb8261d726519f394ab4b2dc1f2c05797",
+      "query_crmarenapro/query6/query.json": "366e380fb2873420a22a287a85a3eeea802bc10985709a0b1ded7eb90aa8736f",
+      "query_crmarenapro/query6/validate.py": "62d23cae1947acf29b02fdc186e25b10b2d11e223965c6f384fbbab6ccf6a7df",
+      "query_crmarenapro/query7/query.json": "82d93f1e5317b087cb59b785270191915f0d1d542779dc1d7035efe99277689a",
+      "query_crmarenapro/query7/validate.py": "6a3a4ce64de4fe3abbb7c38f50f0bd5c54ef09506445b384fa9f2f537bb0704e",
+      "query_crmarenapro/query8/query.json": "c0d1d62e8696fc91c2469b719753ba8c6e4273c3cdeade0f4c58b5d9df5a8408",
+      "query_crmarenapro/query8/validate.py": "f5286f8dadbe0c2d0895b6f0fe4085691fdd2e6ae916e79f2f9293a960c30334",
+      "query_crmarenapro/query9/query.json": "ad49f3909ed2da0fd72a99db50de26652f1a4c7b7b35aead6656092918357a71",
+      "query_crmarenapro/query9/validate.py": "fd1b20664e106209005d1d3f8321d935616927f4529d9a9388098481e6799b78",
+      "query_crmarenapro/query_dataset/activities.duckdb": "f3299b9214885f00c71c9af77d89b62ad73f3e545e3cf5baa4861d1265151c60",
+      "query_crmarenapro/query_dataset/core_crm.db": "aa595797e41db401136a0a68bf14bac44707f9f86ed235f61d9f051728e50506",
+      "query_crmarenapro/query_dataset/products_orders.db": "92ad52f2a624ee5e0cdf7cd4cc64ac60b1e3f7af2c672be27f651f80af4a6bdb",
+      "query_crmarenapro/query_dataset/sales_pipeline.duckdb": "5b44cc3754820bff20c3f25e50cf09c6be401f86e69df6b9d3ee7a4cf64ac5af",
+      "query_crmarenapro/query_dataset/support.sql": "5248cd64cddf4936027859c5d6f74b2d32fbeb4e1939d784b2ff26d45d83950c",
+      "query_crmarenapro/query_dataset/territory.db": "1a9650d4ba3c0a3690b936d294feb31a3227bf6f2ebe886f74cf12e14936366a",
+      "query_googlelocal/db_config.yaml": "e4c808ba9f5d0fa01c4497d1ad3f79d0607a18374efa41397c8bc22def0e8eb0",
+      "query_googlelocal/db_description.txt": "2d865cf4dbfe9d67eafee802e2dca9d3cbe7937d173458bb8f1cbe839e0278a3",
+      "query_googlelocal/db_description_withhint.txt": "231b81dc1f3ff2c708765f65969c9a81afc7dc31d46828c4352a19bca203458f",
+      "query_googlelocal/query1/query.json": "3f9cae56516b7ae78edb2d96a28634746762b983219b85d995db679c554226be",
+      "query_googlelocal/query1/validate.py": "380e9dd0d57319d8c887ebfb5161c38add6bb8d19283265bf9f84e0e4c6323d3",
+      "query_googlelocal/query2/query.json": "d4b527325a39563c28e17bb29a694082677ba6190ecd7d8b232f923de947e2a6",
+      "query_googlelocal/query2/validate.py": "0a2db3d2e36578165b3135c309b9e6d7b4f67665b2e3cf025524efcb711e2ad4",
+      "query_googlelocal/query3/query.json": "edc69dda56e12bd4b5c1b4ec50d98fef8a1f24a1af951aa3933511dae7cc651d",
+      "query_googlelocal/query3/validate.py": "37b5175ce2fe38edf5cf813d1b293ae4b42d22b8b8afe1348e4d56db898096fa",
+      "query_googlelocal/query4/query.json": "1ffd55d9fca7f959216dc13dda75bfc37c3dddadd939b3fad072b1a1f3e48cae",
+      "query_googlelocal/query4/validate.py": "4b9c7096546d5f581c5212e8617caa41b19820f56025ee309abcf7a97ba5f6d9",
+      "query_googlelocal/query_dataset/business_description.sql": "cac36db1c60ab1fcbc661cc7df46c9980db1c2fcdaedb65b57f7a2618339ddd4",
+      "query_googlelocal/query_dataset/review_query.db": "1e9ef561d4edf62ff49bf874253935caf8d404a79c60d21b9b0fc40ee041692c",
+      "query_music_brainz_20k/db_config.yaml": "31c3180aea769887628cf51e91998f9d5e72df98449608fb887d92203f212c6e",
+      "query_music_brainz_20k/db_description.txt": "6741a5467641016ac78d05f8ec6501b48efb182355cc63db8aa4f3cc715a8dc7",
+      "query_music_brainz_20k/db_description_withhint.txt": "c18a833cc12c1ccb055a7a7a717404c2b55129a4ad48941328eb7fb33488ebda",
+      "query_music_brainz_20k/query1/query.json": "b49b9e624260d2ea09ec1191ef32bf7a85fe00a428288140a2ea4fb9233e267f",
+      "query_music_brainz_20k/query1/validate.py": "95e75de5b663e836372faeab70420527c7b42bcf3767e8431beca1ebde17637b",
+      "query_music_brainz_20k/query2/query.json": "8918f918a333b6c28250bfa169a4acd2e7c36876c98b946c30b64e0aeb0c677c",
+      "query_music_brainz_20k/query2/validate.py": "2ef8b4f76ade27acfeed410e59fd52c608a04b86a6bed8626b71c8b589bfcff3",
+      "query_music_brainz_20k/query3/query.json": "c73ce87fbc8a1a57563705070de6867e9d275656ef48d5be0b1b28dfa3375146",
+      "query_music_brainz_20k/query3/validate.py": "cdc581cea003b72d490ab83e3e005bac94531a990a737aa96a39b8cceee33d2e",
+      "query_music_brainz_20k/query_dataset/sales.duckdb": "52ce48c0027eab1b3f85932139425107dd5cf7422217bd8adedfc3edf21ad0e2",
+      "query_music_brainz_20k/query_dataset/tracks.db": "0c349f70e5bafcba1deb605b49e224abfa95c5a83a44688faa511f9e123a02cc",
+      "query_stockindex/db_config.yaml": "d5a8fb635912bbb6aed71bad8e8ca4b93289d5fefbe4dd009287aa501129aa34",
+      "query_stockindex/db_description.txt": "d3e240825f702b68ff87bc72ab341ad10ea47a8581437ac735e01b09def59153",
+      "query_stockindex/db_description_withhint.txt": "7154b91720f27159ef67c085468cf39dd9eac497785adcbfe96bf2927e5e16b3",
+      "query_stockindex/query1/query.json": "cdf0ad83ee620ca66a1c46cdf8eb3ee24ecffc65c362802ab722c7a19ea4a8d7",
+      "query_stockindex/query1/validate.py": "827c71dc7ab3b6624437a4af3c21bedbe64a7b3614d86241e547e70c7e1a7c15",
+      "query_stockindex/query2/query.json": "1f06ad9ec6f8dbd571ef75b77c411bb72349ca2a64d5ae4e4ae1efa3b56fc296",
+      "query_stockindex/query2/validate.py": "834e41dd6de60ef5c824b229560738c7fca33672e8978bb9eb8ca0f71d052355",
+      "query_stockindex/query3/query.json": "d872cc5cce95bfa4f498fecbb8947b143f0cc75bc195c6647b5cdb92a47c903e",
+      "query_stockindex/query3/validate.py": "eff4734185a8d3c7ebd1ec94b13feb50d7e6bd2ee431c01018cf88d3556444cd",
+      "query_stockindex/query_dataset/indexInfo_query.db": "976511f3eb213269c81b286dd4517e4948b3d3bb776e221559943f0439916b55",
+      "query_stockindex/query_dataset/indextrade_query.db": "12e9cf350be2a6396f6be9f0c2bb057013859956bc8269952dc7a85008973bb1",
+      "query_stockmarket/db_config.yaml": "2a5a60ca2ad14195da7f6d98eab8efe7c665ebfb9f149bbb42befa63fab5efd2",
+      "query_stockmarket/db_description.txt": "e795a9ef086b388149f0d31bd422f688b5930fa11e80131adf506e09689b9c89",
+      "query_stockmarket/db_description_withhint.txt": "b915c5cdafca960929cab6f3fc0ff0f1167b83bfaf7417e2535e70aa6ed047a2",
+      "query_stockmarket/query1/query.json": "ec4541f3706936b4950c984be32b011dee7c47cf0333b75c2f45a59d93a29c4d",
+      "query_stockmarket/query1/validate.py": "58282597518b0432ab5d15c0f7845ae97d93a9d8dd66549c840f0c98fa9c815e",
+      "query_stockmarket/query2/query.json": "1dfdfba655707afbb3e02084a572b173b79e20e47be036f413975ecd57664473",
+      "query_stockmarket/query2/validate.py": "be6ef9996c48d357291d87b8e572d20311d8cb6b05a3a6e9702f8d93dad8d63d",
+      "query_stockmarket/query3/query.json": "0770ab30b8e79b9af5a3e91d0dd180a1d5f4708981a6c48f8ebf2716baf55010",
+      "query_stockmarket/query3/validate.py": "948ed2b64b2ea8de48c11034c8c4e2772b5ca7dbdf898f8ff816bea407b227cb",
+      "query_stockmarket/query4/query.json": "01590225dde474c7496ca27c8c79a15a908da8b1388eef730d8b660146c59bc7",
+      "query_stockmarket/query4/validate.py": "09538392d54f1c68d9aac70e5d7d1c692cebe3a743078067b211bbf0909d7f8d",
+      "query_stockmarket/query5/query.json": "a40bc9e12f4723c5b54e3661c8d58518854e0cef2abf330612215d5de2fedd53",
+      "query_stockmarket/query5/validate.py": "8f0e5b28bad6e209a6509662e7fab27d2a0a8114228dd04b49a2851dbefc95c4",
+      "query_stockmarket/query_dataset/stockinfo_query.db": "b8cf6b5627c92e17c10e27779afa8aa77c659e44bd4ccc14b10f1116053bc6a2",
+      "query_stockmarket/query_dataset/stocktrade_query.db": "e9cbf3c4d05d2eeb919c5b207374aefd19aa02e40dca49f2688618beb180350d",
+      "query_yelp/db_config.yaml": "c782c74ef5df85627e3993ab194cb6d0ee7350789546cfed80eea97566e59f41",
+      "query_yelp/db_description.txt": "345e23f2306d398c0fee113a043504a2599d2ec11d7d98d8f82f132fbcde8f34",
+      "query_yelp/db_description_withhint.txt": "81cf2d9f99f12a778bf6412bc57b1cb334ec14457b282418653f314ee9062806",
+      "query_yelp/query1/query.json": "6d7feb548d68d731ea7c3b4cfeed0cc86bd796d4aaf4f142cd00ba02307d0be8",
+      "query_yelp/query1/validate.py": "30d1f2535c4fea561260aa3e5e59fa3af25a98b0528557b11ba5af09f9a27475",
+      "query_yelp/query2/query.json": "271ac8527fd063db0d58911d55429175cdb815d83fc39ba6b3794bafcda0e027",
+      "query_yelp/query2/validate.py": "aa1e9fe46484d1319fe7da725441e34d6c2008672a990ccc8424b75fa19a582b",
+      "query_yelp/query3/query.json": "1dcf772c1298a4df34e9f486ff9ae56dfd6e379fcef4986dbff6f00967af99a1",
+      "query_yelp/query3/validate.py": "c79185af0b0bc5d163d2c617fc853f724ecf30142e903978363e7ad82a4fb4ee",
+      "query_yelp/query4/query.json": "23ec6db6b39fb023c42c753c3b8a834190220b4bfe994bb69c7580fdedcd0080",
+      "query_yelp/query4/validate.py": "fb27e15bd68c5671fd1e152790d220bdd78c88270e398c0ccc4a91ee28b31ed2",
+      "query_yelp/query5/query.json": "26cb0e7d3cadead760b4201dfadfacf333aa6b143637b72c31d6609cd8db8848",
+      "query_yelp/query5/validate.py": "b9e2d3c797b7e51b13cdfdc62896a4dd074bb3135168e57e7faad5b8de52859b",
+      "query_yelp/query6/query.json": "5b9b951319a32b32a070b29ea598f25332afb5529f92926f8268eedb07a49114",
+      "query_yelp/query6/validate.py": "14b3488f8a0b35c69167d93fee30db11f02d2552c2003fd24e2061eb6f7d38b0",
+      "query_yelp/query7/query.json": "5f226f1a026b89cc7d22903987c215df6837d561ebc193f607c12ccb48e40d3f",
+      "query_yelp/query7/validate.py": "b35b9f67c8c915c9e06d02b1abacfe853655b45cb34aef30e5ee972d84a21caf",
+      "query_yelp/query_dataset/yelp_business/yelp_db/business.bson": "3aed3f77a2b0360b0f431decc63aaa0fd69e539a3fe4cb7e08f5ea081eb65c01",
+      "query_yelp/query_dataset/yelp_business/yelp_db/checkin.bson": "879afe04080efd1bfc405109eb87efe4b127bf52d1c749224ca5e9c2f914fc6c",
+      "query_yelp/query_dataset/yelp_user.db": "155ecf989e62e0d087ed9d4586893e6825ab56504bc5e62ad46d454067f9b730"
+    },
+    "runtime": {
+      "python": "3.12.13 (main, Jun 11 2026, 04:03:26) [Clang 22.1.3 ]",
+      "model": {
+        "id": "Qwen/Qwen3.8-Flash-Next",
+        "object": "model",
+        "created": 1789119712,
+        "owned_by": "vllm",
+        "root": "/model",
+        "parent": null,
+        "max_model_len": 262144,
+        "permission": [
+          {
+            "id": "modelperm-8e71c788d498ad24",
+            "object": "model_permission",
+            "created": 1789119712,
+            "allow_create_engine": false,
+            "allow_sampling": true,
+            "allow_logprobs": true,
+            "allow_search_indices": false,
+            "allow_view": true,
+            "allow_fine_tuning": false,
+            "organization": "*",
+            "group": null,
+            "is_blocking": false
+          }
+        ]
+      },
+      "model_revision": null,
+      "base_url": "http://MODEL_ENDPOINT/v1",
+      "packages": {
+        "PyYAML": "6.0.2",
+        "SQLAlchemy": "2.0.41",
+        "annotated-types": "0.8.0",
+        "anyio": "4.15.1",
+        "asyncio-atexit": "1.0.1",
+        "autogen-core": "0.7.5",
+        "autogen-ext": "0.7.5",
+        "certifi": "2026.7.22",
+        "charset-normalizer": "3.5.1",
+        "click": "8.5.0",
+        "colorlog": "6.10.1",
+        "distro": "1.9.0",
+        "dnspython": "2.8.0",
+        "docker": "7.1.0",
+        "duckdb": "1.3.1",
+        "filelock": "3.32.6",
+        "fsspec": "2026.7.0",
+        "greenlet": "3.5.5",
+        "h11": "0.16.0",
+        "hf-xet": "1.6.0",
+        "httpcore": "1.0.9",
+        "httpx": "0.28.1",
+        "huggingface_hub": "1.31.0",
+        "idna": "3.19",
+        "jiter": "0.16.0",
+        "jsonref": "1.1.0",
+        "numpy": "2.2.6",
+        "openai": "2.9.0",
+        "opentelemetry-api": "1.44.0",
+        "packaging": "26.3",
+        "pandas": "2.3.0",
+        "pillow": "12.3.0",
+        "protobuf": "5.29.6",
+        "psycopg2-binary": "2.9.9",
+        "pyarrow": "22.0.0",
+        "pydantic": "2.13.5",
+        "pydantic_core": "2.46.5",
+        "pymongo": "4.13.2",
+        "python-dateutil": "2.9.0.post0",
+        "python-dotenv": "1.1.1",
+        "pytz": "2026.3.post1",
+        "requests": "2.34.2",
+        "six": "1.17.0",
+        "sniffio": "1.3.1",
+        "tqdm": "4.70.0",
+        "typing-inspection": "0.4.4",
+        "typing_extensions": "4.16.0",
+        "tzdata": "2026.3",
+        "urllib3": "2.7.0"
+      },
+      "executor_image": "sha256:ba2ba9013eb356a5da68ecd6f68f5ae47d833be5acc81e996cb4b839851f8553",
+      "postgres_version": "18.4",
+      "postgres_endpoint": {
+        "PG_HOST": "127.0.0.1",
+        "PG_PORT": "15437",
+        "PG_USER": "postgres"
+      },
+      "mongo_version": "8.0.30",
+      "mongo_connection_sha256": "2ef6045640e799273bb243f8dcd7301ea6f03a767c16722f87a38fdb0a80fcef"
+    },
+    "tasks": [
+      {
+        "dataset": "bookreview",
+        "query": 1,
+        "run": 0
+      },
+      {
+        "dataset": "bookreview",
+        "query": 2,
+        "run": 0
+      },
+      {
+        "dataset": "bookreview",
+        "query": 3,
+        "run": 0
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 1,
+        "run": 0
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 2,
+        "run": 0
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 3,
+        "run": 0
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 4,
+        "run": 0
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 5,
+        "run": 0
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 6,
+        "run": 0
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 7,
+        "run": 0
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 8,
+        "run": 0
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 9,
+        "run": 0
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 10,
+        "run": 0
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 11,
+        "run": 0
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 12,
+        "run": 0
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 13,
+        "run": 0
+      },
+      {
+        "dataset": "DEPS_DEV_V1",
+        "query": 1,
+        "run": 0
+      },
+      {
+        "dataset": "DEPS_DEV_V1",
+        "query": 2,
+        "run": 0
+      },
+      {
+        "dataset": "GITHUB_REPOS",
+        "query": 1,
+        "run": 0
+      },
+      {
+        "dataset": "GITHUB_REPOS",
+        "query": 2,
+        "run": 0
+      },
+      {
+        "dataset": "GITHUB_REPOS",
+        "query": 3,
+        "run": 0
+      },
+      {
+        "dataset": "GITHUB_REPOS",
+        "query": 4,
+        "run": 0
+      },
+      {
+        "dataset": "googlelocal",
+        "query": 1,
+        "run": 0
+      },
+      {
+        "dataset": "googlelocal",
+        "query": 2,
+        "run": 0
+      },
+      {
+        "dataset": "googlelocal",
+        "query": 3,
+        "run": 0
+      },
+      {
+        "dataset": "googlelocal",
+        "query": 4,
+        "run": 0
+      },
+      {
+        "dataset": "PANCANCER_ATLAS",
+        "query": 1,
+        "run": 0
+      },
+      {
+        "dataset": "PANCANCER_ATLAS",
+        "query": 2,
+        "run": 0
+      },
+      {
+        "dataset": "PANCANCER_ATLAS",
+        "query": 3,
+        "run": 0
+      },
+      {
+        "dataset": "PATENTS",
+        "query": 1,
+        "run": 0
+      },
+      {
+        "dataset": "PATENTS",
+        "query": 2,
+        "run": 0
+      },
+      {
+        "dataset": "PATENTS",
+        "query": 3,
+        "run": 0
+      },
+      {
+        "dataset": "stockindex",
+        "query": 1,
+        "run": 0
+      },
+      {
+        "dataset": "stockindex",
+        "query": 2,
+        "run": 0
+      },
+      {
+        "dataset": "stockindex",
+        "query": 3,
+        "run": 0
+      },
+      {
+        "dataset": "stockmarket",
+        "query": 1,
+        "run": 0
+      },
+      {
+        "dataset": "stockmarket",
+        "query": 2,
+        "run": 0
+      },
+      {
+        "dataset": "stockmarket",
+        "query": 3,
+        "run": 0
+      },
+      {
+        "dataset": "stockmarket",
+        "query": 4,
+        "run": 0
+      },
+      {
+        "dataset": "stockmarket",
+        "query": 5,
+        "run": 0
+      },
+      {
+        "dataset": "yelp",
+        "query": 1,
+        "run": 0
+      },
+      {
+        "dataset": "yelp",
+        "query": 2,
+        "run": 0
+      },
+      {
+        "dataset": "yelp",
+        "query": 3,
+        "run": 0
+      },
+      {
+        "dataset": "yelp",
+        "query": 4,
+        "run": 0
+      },
+      {
+        "dataset": "yelp",
+        "query": 5,
+        "run": 0
+      },
+      {
+        "dataset": "yelp",
+        "query": 6,
+        "run": 0
+      },
+      {
+        "dataset": "yelp",
+        "query": 7,
+        "run": 0
+      },
+      {
+        "dataset": "agnews",
+        "query": 1,
+        "run": 0
+      },
+      {
+        "dataset": "agnews",
+        "query": 2,
+        "run": 0
+      },
+      {
+        "dataset": "agnews",
+        "query": 3,
+        "run": 0
+      },
+      {
+        "dataset": "agnews",
+        "query": 4,
+        "run": 0
+      },
+      {
+        "dataset": "music_brainz_20k",
+        "query": 1,
+        "run": 0
+      },
+      {
+        "dataset": "music_brainz_20k",
+        "query": 2,
+        "run": 0
+      },
+      {
+        "dataset": "music_brainz_20k",
+        "query": 3,
+        "run": 0
+      },
+      {
+        "dataset": "bookreview",
+        "query": 1,
+        "run": 1
+      },
+      {
+        "dataset": "bookreview",
+        "query": 2,
+        "run": 1
+      },
+      {
+        "dataset": "bookreview",
+        "query": 3,
+        "run": 1
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 1,
+        "run": 1
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 2,
+        "run": 1
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 3,
+        "run": 1
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 4,
+        "run": 1
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 5,
+        "run": 1
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 6,
+        "run": 1
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 7,
+        "run": 1
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 8,
+        "run": 1
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 9,
+        "run": 1
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 10,
+        "run": 1
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 11,
+        "run": 1
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 12,
+        "run": 1
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 13,
+        "run": 1
+      },
+      {
+        "dataset": "DEPS_DEV_V1",
+        "query": 1,
+        "run": 1
+      },
+      {
+        "dataset": "DEPS_DEV_V1",
+        "query": 2,
+        "run": 1
+      },
+      {
+        "dataset": "GITHUB_REPOS",
+        "query": 1,
+        "run": 1
+      },
+      {
+        "dataset": "GITHUB_REPOS",
+        "query": 2,
+        "run": 1
+      },
+      {
+        "dataset": "GITHUB_REPOS",
+        "query": 3,
+        "run": 1
+      },
+      {
+        "dataset": "GITHUB_REPOS",
+        "query": 4,
+        "run": 1
+      },
+      {
+        "dataset": "googlelocal",
+        "query": 1,
+        "run": 1
+      },
+      {
+        "dataset": "googlelocal",
+        "query": 2,
+        "run": 1
+      },
+      {
+        "dataset": "googlelocal",
+        "query": 3,
+        "run": 1
+      },
+      {
+        "dataset": "googlelocal",
+        "query": 4,
+        "run": 1
+      },
+      {
+        "dataset": "PANCANCER_ATLAS",
+        "query": 1,
+        "run": 1
+      },
+      {
+        "dataset": "PANCANCER_ATLAS",
+        "query": 2,
+        "run": 1
+      },
+      {
+        "dataset": "PANCANCER_ATLAS",
+        "query": 3,
+        "run": 1
+      },
+      {
+        "dataset": "PATENTS",
+        "query": 1,
+        "run": 1
+      },
+      {
+        "dataset": "PATENTS",
+        "query": 2,
+        "run": 1
+      },
+      {
+        "dataset": "PATENTS",
+        "query": 3,
+        "run": 1
+      },
+      {
+        "dataset": "stockindex",
+        "query": 1,
+        "run": 1
+      },
+      {
+        "dataset": "stockindex",
+        "query": 2,
+        "run": 1
+      },
+      {
+        "dataset": "stockindex",
+        "query": 3,
+        "run": 1
+      },
+      {
+        "dataset": "stockmarket",
+        "query": 1,
+        "run": 1
+      },
+      {
+        "dataset": "stockmarket",
+        "query": 2,
+        "run": 1
+      },
+      {
+        "dataset": "stockmarket",
+        "query": 3,
+        "run": 1
+      },
+      {
+        "dataset": "stockmarket",
+        "query": 4,
+        "run": 1
+      },
+      {
+        "dataset": "stockmarket",
+        "query": 5,
+        "run": 1
+      },
+      {
+        "dataset": "yelp",
+        "query": 1,
+        "run": 1
+      },
+      {
+        "dataset": "yelp",
+        "query": 2,
+        "run": 1
+      },
+      {
+        "dataset": "yelp",
+        "query": 3,
+        "run": 1
+      },
+      {
+        "dataset": "yelp",
+        "query": 4,
+        "run": 1
+      },
+      {
+        "dataset": "yelp",
+        "query": 5,
+        "run": 1
+      },
+      {
+        "dataset": "yelp",
+        "query": 6,
+        "run": 1
+      },
+      {
+        "dataset": "yelp",
+        "query": 7,
+        "run": 1
+      },
+      {
+        "dataset": "agnews",
+        "query": 1,
+        "run": 1
+      },
+      {
+        "dataset": "agnews",
+        "query": 2,
+        "run": 1
+      },
+      {
+        "dataset": "agnews",
+        "query": 3,
+        "run": 1
+      },
+      {
+        "dataset": "agnews",
+        "query": 4,
+        "run": 1
+      },
+      {
+        "dataset": "music_brainz_20k",
+        "query": 1,
+        "run": 1
+      },
+      {
+        "dataset": "music_brainz_20k",
+        "query": 2,
+        "run": 1
+      },
+      {
+        "dataset": "music_brainz_20k",
+        "query": 3,
+        "run": 1
+      },
+      {
+        "dataset": "bookreview",
+        "query": 1,
+        "run": 2
+      },
+      {
+        "dataset": "bookreview",
+        "query": 2,
+        "run": 2
+      },
+      {
+        "dataset": "bookreview",
+        "query": 3,
+        "run": 2
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 1,
+        "run": 2
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 2,
+        "run": 2
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 3,
+        "run": 2
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 4,
+        "run": 2
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 5,
+        "run": 2
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 6,
+        "run": 2
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 7,
+        "run": 2
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 8,
+        "run": 2
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 9,
+        "run": 2
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 10,
+        "run": 2
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 11,
+        "run": 2
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 12,
+        "run": 2
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 13,
+        "run": 2
+      },
+      {
+        "dataset": "DEPS_DEV_V1",
+        "query": 1,
+        "run": 2
+      },
+      {
+        "dataset": "DEPS_DEV_V1",
+        "query": 2,
+        "run": 2
+      },
+      {
+        "dataset": "GITHUB_REPOS",
+        "query": 1,
+        "run": 2
+      },
+      {
+        "dataset": "GITHUB_REPOS",
+        "query": 2,
+        "run": 2
+      },
+      {
+        "dataset": "GITHUB_REPOS",
+        "query": 3,
+        "run": 2
+      },
+      {
+        "dataset": "GITHUB_REPOS",
+        "query": 4,
+        "run": 2
+      },
+      {
+        "dataset": "googlelocal",
+        "query": 1,
+        "run": 2
+      },
+      {
+        "dataset": "googlelocal",
+        "query": 2,
+        "run": 2
+      },
+      {
+        "dataset": "googlelocal",
+        "query": 3,
+        "run": 2
+      },
+      {
+        "dataset": "googlelocal",
+        "query": 4,
+        "run": 2
+      },
+      {
+        "dataset": "PANCANCER_ATLAS",
+        "query": 1,
+        "run": 2
+      },
+      {
+        "dataset": "PANCANCER_ATLAS",
+        "query": 2,
+        "run": 2
+      },
+      {
+        "dataset": "PANCANCER_ATLAS",
+        "query": 3,
+        "run": 2
+      },
+      {
+        "dataset": "PATENTS",
+        "query": 1,
+        "run": 2
+      },
+      {
+        "dataset": "PATENTS",
+        "query": 2,
+        "run": 2
+      },
+      {
+        "dataset": "PATENTS",
+        "query": 3,
+        "run": 2
+      },
+      {
+        "dataset": "stockindex",
+        "query": 1,
+        "run": 2
+      },
+      {
+        "dataset": "stockindex",
+        "query": 2,
+        "run": 2
+      },
+      {
+        "dataset": "stockindex",
+        "query": 3,
+        "run": 2
+      },
+      {
+        "dataset": "stockmarket",
+        "query": 1,
+        "run": 2
+      },
+      {
+        "dataset": "stockmarket",
+        "query": 2,
+        "run": 2
+      },
+      {
+        "dataset": "stockmarket",
+        "query": 3,
+        "run": 2
+      },
+      {
+        "dataset": "stockmarket",
+        "query": 4,
+        "run": 2
+      },
+      {
+        "dataset": "stockmarket",
+        "query": 5,
+        "run": 2
+      },
+      {
+        "dataset": "yelp",
+        "query": 1,
+        "run": 2
+      },
+      {
+        "dataset": "yelp",
+        "query": 2,
+        "run": 2
+      },
+      {
+        "dataset": "yelp",
+        "query": 3,
+        "run": 2
+      },
+      {
+        "dataset": "yelp",
+        "query": 4,
+        "run": 2
+      },
+      {
+        "dataset": "yelp",
+        "query": 5,
+        "run": 2
+      },
+      {
+        "dataset": "yelp",
+        "query": 6,
+        "run": 2
+      },
+      {
+        "dataset": "yelp",
+        "query": 7,
+        "run": 2
+      },
+      {
+        "dataset": "agnews",
+        "query": 1,
+        "run": 2
+      },
+      {
+        "dataset": "agnews",
+        "query": 2,
+        "run": 2
+      },
+      {
+        "dataset": "agnews",
+        "query": 3,
+        "run": 2
+      },
+      {
+        "dataset": "agnews",
+        "query": 4,
+        "run": 2
+      },
+      {
+        "dataset": "music_brainz_20k",
+        "query": 1,
+        "run": 2
+      },
+      {
+        "dataset": "music_brainz_20k",
+        "query": 2,
+        "run": 2
+      },
+      {
+        "dataset": "music_brainz_20k",
+        "query": 3,
+        "run": 2
+      },
+      {
+        "dataset": "bookreview",
+        "query": 1,
+        "run": 3
+      },
+      {
+        "dataset": "bookreview",
+        "query": 2,
+        "run": 3
+      },
+      {
+        "dataset": "bookreview",
+        "query": 3,
+        "run": 3
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 1,
+        "run": 3
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 2,
+        "run": 3
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 3,
+        "run": 3
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 4,
+        "run": 3
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 5,
+        "run": 3
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 6,
+        "run": 3
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 7,
+        "run": 3
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 8,
+        "run": 3
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 9,
+        "run": 3
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 10,
+        "run": 3
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 11,
+        "run": 3
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 12,
+        "run": 3
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 13,
+        "run": 3
+      },
+      {
+        "dataset": "DEPS_DEV_V1",
+        "query": 1,
+        "run": 3
+      },
+      {
+        "dataset": "DEPS_DEV_V1",
+        "query": 2,
+        "run": 3
+      },
+      {
+        "dataset": "GITHUB_REPOS",
+        "query": 1,
+        "run": 3
+      },
+      {
+        "dataset": "GITHUB_REPOS",
+        "query": 2,
+        "run": 3
+      },
+      {
+        "dataset": "GITHUB_REPOS",
+        "query": 3,
+        "run": 3
+      },
+      {
+        "dataset": "GITHUB_REPOS",
+        "query": 4,
+        "run": 3
+      },
+      {
+        "dataset": "googlelocal",
+        "query": 1,
+        "run": 3
+      },
+      {
+        "dataset": "googlelocal",
+        "query": 2,
+        "run": 3
+      },
+      {
+        "dataset": "googlelocal",
+        "query": 3,
+        "run": 3
+      },
+      {
+        "dataset": "googlelocal",
+        "query": 4,
+        "run": 3
+      },
+      {
+        "dataset": "PANCANCER_ATLAS",
+        "query": 1,
+        "run": 3
+      },
+      {
+        "dataset": "PANCANCER_ATLAS",
+        "query": 2,
+        "run": 3
+      },
+      {
+        "dataset": "PANCANCER_ATLAS",
+        "query": 3,
+        "run": 3
+      },
+      {
+        "dataset": "PATENTS",
+        "query": 1,
+        "run": 3
+      },
+      {
+        "dataset": "PATENTS",
+        "query": 2,
+        "run": 3
+      },
+      {
+        "dataset": "PATENTS",
+        "query": 3,
+        "run": 3
+      },
+      {
+        "dataset": "stockindex",
+        "query": 1,
+        "run": 3
+      },
+      {
+        "dataset": "stockindex",
+        "query": 2,
+        "run": 3
+      },
+      {
+        "dataset": "stockindex",
+        "query": 3,
+        "run": 3
+      },
+      {
+        "dataset": "stockmarket",
+        "query": 1,
+        "run": 3
+      },
+      {
+        "dataset": "stockmarket",
+        "query": 2,
+        "run": 3
+      },
+      {
+        "dataset": "stockmarket",
+        "query": 3,
+        "run": 3
+      },
+      {
+        "dataset": "stockmarket",
+        "query": 4,
+        "run": 3
+      },
+      {
+        "dataset": "stockmarket",
+        "query": 5,
+        "run": 3
+      },
+      {
+        "dataset": "yelp",
+        "query": 1,
+        "run": 3
+      },
+      {
+        "dataset": "yelp",
+        "query": 2,
+        "run": 3
+      },
+      {
+        "dataset": "yelp",
+        "query": 3,
+        "run": 3
+      },
+      {
+        "dataset": "yelp",
+        "query": 4,
+        "run": 3
+      },
+      {
+        "dataset": "yelp",
+        "query": 5,
+        "run": 3
+      },
+      {
+        "dataset": "yelp",
+        "query": 6,
+        "run": 3
+      },
+      {
+        "dataset": "yelp",
+        "query": 7,
+        "run": 3
+      },
+      {
+        "dataset": "agnews",
+        "query": 1,
+        "run": 3
+      },
+      {
+        "dataset": "agnews",
+        "query": 2,
+        "run": 3
+      },
+      {
+        "dataset": "agnews",
+        "query": 3,
+        "run": 3
+      },
+      {
+        "dataset": "agnews",
+        "query": 4,
+        "run": 3
+      },
+      {
+        "dataset": "music_brainz_20k",
+        "query": 1,
+        "run": 3
+      },
+      {
+        "dataset": "music_brainz_20k",
+        "query": 2,
+        "run": 3
+      },
+      {
+        "dataset": "music_brainz_20k",
+        "query": 3,
+        "run": 3
+      },
+      {
+        "dataset": "bookreview",
+        "query": 1,
+        "run": 4
+      },
+      {
+        "dataset": "bookreview",
+        "query": 2,
+        "run": 4
+      },
+      {
+        "dataset": "bookreview",
+        "query": 3,
+        "run": 4
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 1,
+        "run": 4
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 2,
+        "run": 4
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 3,
+        "run": 4
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 4,
+        "run": 4
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 5,
+        "run": 4
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 6,
+        "run": 4
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 7,
+        "run": 4
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 8,
+        "run": 4
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 9,
+        "run": 4
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 10,
+        "run": 4
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 11,
+        "run": 4
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 12,
+        "run": 4
+      },
+      {
+        "dataset": "crmarenapro",
+        "query": 13,
+        "run": 4
+      },
+      {
+        "dataset": "DEPS_DEV_V1",
+        "query": 1,
+        "run": 4
+      },
+      {
+        "dataset": "DEPS_DEV_V1",
+        "query": 2,
+        "run": 4
+      },
+      {
+        "dataset": "GITHUB_REPOS",
+        "query": 1,
+        "run": 4
+      },
+      {
+        "dataset": "GITHUB_REPOS",
+        "query": 2,
+        "run": 4
+      },
+      {
+        "dataset": "GITHUB_REPOS",
+        "query": 3,
+        "run": 4
+      },
+      {
+        "dataset": "GITHUB_REPOS",
+        "query": 4,
+        "run": 4
+      },
+      {
+        "dataset": "googlelocal",
+        "query": 1,
+        "run": 4
+      },
+      {
+        "dataset": "googlelocal",
+        "query": 2,
+        "run": 4
+      },
+      {
+        "dataset": "googlelocal",
+        "query": 3,
+        "run": 4
+      },
+      {
+        "dataset": "googlelocal",
+        "query": 4,
+        "run": 4
+      },
+      {
+        "dataset": "PANCANCER_ATLAS",
+        "query": 1,
+        "run": 4
+      },
+      {
+        "dataset": "PANCANCER_ATLAS",
+        "query": 2,
+        "run": 4
+      },
+      {
+        "dataset": "PANCANCER_ATLAS",
+        "query": 3,
+        "run": 4
+      },
+      {
+        "dataset": "PATENTS",
+        "query": 1,
+        "run": 4
+      },
+      {
+        "dataset": "PATENTS",
+        "query": 2,
+        "run": 4
+      },
+      {
+        "dataset": "PATENTS",
+        "query": 3,
+        "run": 4
+      },
+      {
+        "dataset": "stockindex",
+        "query": 1,
+        "run": 4
+      },
+      {
+        "dataset": "stockindex",
+        "query": 2,
+        "run": 4
+      },
+      {
+        "dataset": "stockindex",
+        "query": 3,
+        "run": 4
+      },
+      {
+        "dataset": "stockmarket",
+        "query": 1,
+        "run": 4
+      },
+      {
+        "dataset": "stockmarket",
+        "query": 2,
+        "run": 4
+      },
+      {
+        "dataset": "stockmarket",
+        "query": 3,
+        "run": 4
+      },
+      {
+        "dataset": "stockmarket",
+        "query": 4,
+        "run": 4
+      },
+      {
+        "dataset": "stockmarket",
+        "query": 5,
+        "run": 4
+      },
+      {
+        "dataset": "yelp",
+        "query": 1,
+        "run": 4
+      },
+      {
+        "dataset": "yelp",
+        "query": 2,
+        "run": 4
+      },
+      {
+        "dataset": "yelp",
+        "query": 3,
+        "run": 4
+      },
+      {
+        "dataset": "yelp",
+        "query": 4,
+        "run": 4
+      },
+      {
+        "dataset": "yelp",
+        "query": 5,
+        "run": 4
+      },
+      {
+        "dataset": "yelp",
+        "query": 6,
+        "run": 4
+      },
+      {
+        "dataset": "yelp",
+        "query": 7,
+        "run": 4
+      },
+      {
+        "dataset": "agnews",
+        "query": 1,
+        "run": 4
+      },
+      {
+        "dataset": "agnews",
+        "query": 2,
+        "run": 4
+      },
+      {
+        "dataset": "agnews",
+        "query": 3,
+        "run": 4
+      },
+      {
+        "dataset": "agnews",
+        "query": 4,
+        "run": 4
+      },
+      {
+        "dataset": "music_brainz_20k",
+        "query": 1,
+        "run": 4
+      },
+      {
+        "dataset": "music_brainz_20k",
+        "query": 2,
+        "run": 4
+      },
+      {
+        "dataset": "music_brainz_20k",
+        "query": 3,
+        "run": 4
+      }
+    ],
+    "prefix": "qwen38flash_parallel_v1",
+    "use_hints": true,
+    "iterations": 300,
+    "llm_timeout": 7200,
+    "generation_config": {
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": 20,
+      "min_p": 0.0,
+      "presence_penalty": 0.0,
+      "repetition_penalty": 1.0,
+      "max_tokens": 131072,
+      "enable_thinking": true,
+      "preserve_thinking": true,
+      "reasoning_effort": "xhigh"
+    },
+    "serial_execution": false,
+    "scheduler": {
+      "version": 2,
+      "strategy": "per_dataset",
+      "max_parallel": 12,
+      "lock_dir": "/DAB_LOCKS",
+      "lock_wait_warn_seconds": 300
+    }
+  }
+}

--- a/leaderboard_submissions/qwen38flash_parallel_v1/trial_scores.json
+++ b/leaderboard_submissions/qwen38flash_parallel_v1/trial_scores.json
@@ -1,0 +1,2162 @@
+[
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "1",
+    "run": "0",
+    "passed": false,
+    "answer_sha256": "9c8f38d76de23f54b55d663a8837906424d9ce4681ef27912bb1c3534511dd12",
+    "final_trace": "query_DEPS_DEV_V1/query1/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "1",
+    "run": "1",
+    "passed": false,
+    "answer_sha256": "37ffb1af2680d520c8b69e07841ce34492d55fbfacb0b89c2cc379df9c031c06",
+    "final_trace": "query_DEPS_DEV_V1/query1/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "1",
+    "run": "2",
+    "passed": false,
+    "answer_sha256": "2cbe811711c19eb227f89f5601857c022a16b46a0cc1da3c3e3b60191ed0462c",
+    "final_trace": "query_DEPS_DEV_V1/query1/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "1",
+    "run": "3",
+    "passed": false,
+    "answer_sha256": "53d3d52ee56f3e6a40b4744c94c4f19fff7d6255a5ee37134128afdbda5a8c7c",
+    "final_trace": "query_DEPS_DEV_V1/query1/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "1",
+    "run": "4",
+    "passed": false,
+    "answer_sha256": "90391c8392fe551a8a5d29abcabab6dad5057cd64763901b64e587978cc21ee1",
+    "final_trace": "query_DEPS_DEV_V1/query1/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "2",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "5170b6a860fc69e66a05a9f38a76b9f2de2910fe1caa1e3d2e398a476747d9b5",
+    "final_trace": "query_DEPS_DEV_V1/query2/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "2",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "1992226c287bcab437307e65fecdb3718643b5a83afee99ea511b58a2af2440b",
+    "final_trace": "query_DEPS_DEV_V1/query2/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "2",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "9f28b461753939818e4e5324814f0e3c9c38a96fb6a72c1405ee94566c50537a",
+    "final_trace": "query_DEPS_DEV_V1/query2/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "2",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "256e038feaf68262f8d78624393628bae2c6c3ba36298c000d834b8cc84008af",
+    "final_trace": "query_DEPS_DEV_V1/query2/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "DEPS_DEV_V1",
+    "query": "2",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "42915a3412d767b53d4608e55a9cf53ed812418c6b393c931d4e286c1f382c1d",
+    "final_trace": "query_DEPS_DEV_V1/query2/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "1",
+    "run": "0",
+    "passed": false,
+    "answer_sha256": "3071846a5692acddb5936bda87777f49e288b1f78326ba9d05e6237156a5c708",
+    "final_trace": "query_GITHUB_REPOS/query1/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "1",
+    "run": "1",
+    "passed": false,
+    "answer_sha256": "3151b01041498b10fbd90e46b94021fd2958d681d17dc6e44d26f60cf090b155",
+    "final_trace": "query_GITHUB_REPOS/query1/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "1",
+    "run": "2",
+    "passed": false,
+    "answer_sha256": "4cdc35732f7a1f5528f907d0b9e92c629aecde063852843746a740d3b29456ad",
+    "final_trace": "query_GITHUB_REPOS/query1/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "1",
+    "run": "3",
+    "passed": false,
+    "answer_sha256": "b3a8fcd0d1bff14ecb75be135f3484d1f278d98ae4b9d74e42cb2982f061a62c",
+    "final_trace": "query_GITHUB_REPOS/query1/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "1",
+    "run": "4",
+    "passed": false,
+    "answer_sha256": "1f0ca8c47d49148c4a8dab91a7f1a427a1c4970edbaede3bd1950108f93e1a0c",
+    "final_trace": "query_GITHUB_REPOS/query1/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "2",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "afd86e6f6add746ada514035aee76519891d0aebd904f66cd79717764839ed06",
+    "final_trace": "query_GITHUB_REPOS/query2/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "2",
+    "run": "1",
+    "passed": false,
+    "answer_sha256": "fa0d2b3159eb73fc39943b29afede0e9486b803998882dd9e89545f66075b020",
+    "final_trace": "query_GITHUB_REPOS/query2/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "2",
+    "run": "2",
+    "passed": false,
+    "answer_sha256": "59b1da70ea51a63093c0c92ca99c237cfe726f969c3d012757947b731e2b265e",
+    "final_trace": "query_GITHUB_REPOS/query2/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "2",
+    "run": "3",
+    "passed": false,
+    "answer_sha256": "242edac42410b3937c53b0ce7d08f42d6fabfac6d5162ee758f50e5b85145bf7",
+    "final_trace": "query_GITHUB_REPOS/query2/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "2",
+    "run": "4",
+    "passed": false,
+    "answer_sha256": "91d400b4d2874570d3b76c75428dd47c7190d85a97401129119faf3fd6d66192",
+    "final_trace": "query_GITHUB_REPOS/query2/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "3",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "bcce03f625c22998dcb812feb157db59cbb8f22a424a70710a8d9ef20c7e5580",
+    "final_trace": "query_GITHUB_REPOS/query3/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "3",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "bcce03f625c22998dcb812feb157db59cbb8f22a424a70710a8d9ef20c7e5580",
+    "final_trace": "query_GITHUB_REPOS/query3/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "3",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "bcce03f625c22998dcb812feb157db59cbb8f22a424a70710a8d9ef20c7e5580",
+    "final_trace": "query_GITHUB_REPOS/query3/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "3",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "bcce03f625c22998dcb812feb157db59cbb8f22a424a70710a8d9ef20c7e5580",
+    "final_trace": "query_GITHUB_REPOS/query3/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "3",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "bcce03f625c22998dcb812feb157db59cbb8f22a424a70710a8d9ef20c7e5580",
+    "final_trace": "query_GITHUB_REPOS/query3/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "4",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "7cd13d84508b9efabdce5c73c1fc43dce2f94d60c814aa9ce71834ab2e34b8ba",
+    "final_trace": "query_GITHUB_REPOS/query4/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "4",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "91db8c57d23ded69c7f2e04024b048ba5a73c607ab0d3c89f9f7651b86d6485c",
+    "final_trace": "query_GITHUB_REPOS/query4/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "4",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "d02eb4e2898a0c4961734579881874a493b07ee4a90f5366b592c93ab25574a4",
+    "final_trace": "query_GITHUB_REPOS/query4/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "4",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "23239ed1b4c67e5ba2e35aecd0abe91aefd55d51eda807d2c464c0502445af65",
+    "final_trace": "query_GITHUB_REPOS/query4/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "GITHUB_REPOS",
+    "query": "4",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "f0211cc7b40aa5888ffb377089d5bb58f7b82b2d359d6a3f51fb86a016586f3f",
+    "final_trace": "query_GITHUB_REPOS/query4/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "1",
+    "run": "0",
+    "passed": false,
+    "answer_sha256": "cf447a67d1bb0d74d379059d4bcff5b879f0ebe6f50c1fdb5d14009c7a483852",
+    "final_trace": "query_PANCANCER_ATLAS/query1/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "1",
+    "run": "1",
+    "passed": false,
+    "answer_sha256": "54c5508d3c13b7b106c95ac23e8850e6e80564444977fb794f8a69b506b56d69",
+    "final_trace": "query_PANCANCER_ATLAS/query1/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "1",
+    "run": "2",
+    "passed": false,
+    "answer_sha256": "d86276ac0bcd02880eb77c6f430f23843c235ca81ba7e492985f3d09973588a7",
+    "final_trace": "query_PANCANCER_ATLAS/query1/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "1",
+    "run": "3",
+    "passed": false,
+    "answer_sha256": "4c0922b0d088c6808ba0ed8d9b2aca1279dee420b0c1008b8bf6f2bad2b42973",
+    "final_trace": "query_PANCANCER_ATLAS/query1/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "1",
+    "run": "4",
+    "passed": false,
+    "answer_sha256": "649a35f437f444e394b4e7934cbecee202c0b1e3a66156cd0f94d7619cb4ff14",
+    "final_trace": "query_PANCANCER_ATLAS/query1/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "2",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "cbebb057544f286a12ae6542baea5f761161d8eadfc7c86a5aebc899fd3c2b1f",
+    "final_trace": "query_PANCANCER_ATLAS/query2/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "2",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "50f36b114d0da5b17724df9738c0ed814f66d72041dc7a5ffc0c506707f7f80b",
+    "final_trace": "query_PANCANCER_ATLAS/query2/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "2",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "1ac7a187957c4db6f9ad4cd4b1b9b63af4d0a59a69377d1a141a54ce0e0a0722",
+    "final_trace": "query_PANCANCER_ATLAS/query2/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "2",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "2cc115e51eade3d777dd229cf13b5ded8ea6bde0c642bf091ab95abcc894e882",
+    "final_trace": "query_PANCANCER_ATLAS/query2/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "2",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "4a68c2983ab5d4eb93e312cc8effd0a49ee808cd2e427f44e79eda54fccf698f",
+    "final_trace": "query_PANCANCER_ATLAS/query2/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "3",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "7914a6ad348bee8f164c8a734b5d6920d6e4e52ff48997f9c1c0045cc5f2732b",
+    "final_trace": "query_PANCANCER_ATLAS/query3/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "3",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "764549cea5075789b350a07514b3896e32af55921cccf9f9fbb903e65fa809d9",
+    "final_trace": "query_PANCANCER_ATLAS/query3/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "3",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "dc83e76e597e9546f01073d194294c510fd1c1645c97a45748ff0f732f6f2598",
+    "final_trace": "query_PANCANCER_ATLAS/query3/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "3",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "f6f7c35076d44590f1aa179578ae699ce1fc5b760dc6a75cbaadbbd630207b9c",
+    "final_trace": "query_PANCANCER_ATLAS/query3/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "PANCANCER_ATLAS",
+    "query": "3",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "42d724766171f1f13e686617d13e136be54b6938bd6b3dff4827e11260398021",
+    "final_trace": "query_PANCANCER_ATLAS/query3/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "1",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "80a4dd9c47722430c84afdf32de8cf39a1480ea74850732c90dea59b60b9518e",
+    "final_trace": "query_PATENTS/query1/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "1",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "ba1a65b74d7b457680905922034d5a6ac7276cc085f09d82d862b568170f61f0",
+    "final_trace": "query_PATENTS/query1/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "1",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "74134bfac3a71ca9c3bf9788f1afe9d4abdad0e170003fb9a13d439b16144894",
+    "final_trace": "query_PATENTS/query1/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "1",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "4070af46ce607a173a11e730613143dc1c578d94cb5fa75ff0e4d02e7c4bcbc1",
+    "final_trace": "query_PATENTS/query1/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "1",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "29086334f8223b2d1e5fce11c411b2b0c91faf93cbed01b1613f38a31b43f585",
+    "final_trace": "query_PATENTS/query1/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "2",
+    "run": "0",
+    "passed": false,
+    "answer_sha256": "2b2a99e62129b2de39ba90e2b189c60f0d151bc19b7fd0a49c076530c2915784",
+    "final_trace": "query_PATENTS/query2/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "2",
+    "run": "1",
+    "passed": false,
+    "answer_sha256": "1bd1b7a83f740f57f282e4fb00a6f9acd537a8d988be5a85c1c50408a1357823",
+    "final_trace": "query_PATENTS/query2/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "2",
+    "run": "2",
+    "passed": false,
+    "answer_sha256": "bcd6ab1eca928a0e27bb0e3238d42a075e0c44100a8e6a933fd6e1909bfafb8c",
+    "final_trace": "query_PATENTS/query2/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "2",
+    "run": "3",
+    "passed": false,
+    "answer_sha256": "6bcc4f0fc18812197ed7216f7186016825aa081d74dbfc332f7266a590ecf637",
+    "final_trace": "query_PATENTS/query2/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "2",
+    "run": "4",
+    "passed": false,
+    "answer_sha256": "a1b9bdfee14aa9ef84229b9df5e4d6891fa8fc3aa703163ad1b95ad54d8713cd",
+    "final_trace": "query_PATENTS/query2/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "3",
+    "run": "0",
+    "passed": false,
+    "answer_sha256": "cd0953f10437911ca64ab42cb00184b9582225c1b54862b5ec5a0e694a95aecc",
+    "final_trace": "query_PATENTS/query3/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "3",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "27290be0f15d4fd9141d93f732e02233f6db2661c91da257e23b31fe0cc8d20d",
+    "final_trace": "query_PATENTS/query3/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "3",
+    "run": "2",
+    "passed": false,
+    "answer_sha256": "7dda68bf19c8e2b6e1f498ff6e341c42fa24a733dc3943924ac7533c0ed2f65e",
+    "final_trace": "query_PATENTS/query3/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "3",
+    "run": "3",
+    "passed": false,
+    "answer_sha256": "52b84a82524d6df816652d8c6bde14b6cb29dee5f2dd5cf551b94298718ee10c",
+    "final_trace": "query_PATENTS/query3/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "PATENTS",
+    "query": "3",
+    "run": "4",
+    "passed": false,
+    "answer_sha256": "97f578f218c6f52815bd6d7ced2b148ccafdaee9967665c875a207aa4a432289",
+    "final_trace": "query_PATENTS/query3/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "agnews",
+    "query": "1",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "3e183c3ae5c85ec93a91c92eee92e7f0830d05cc1eb9d32bc2ac52b27f4e32b6",
+    "final_trace": "query_agnews/query1/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "agnews",
+    "query": "1",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "3e183c3ae5c85ec93a91c92eee92e7f0830d05cc1eb9d32bc2ac52b27f4e32b6",
+    "final_trace": "query_agnews/query1/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "agnews",
+    "query": "1",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "3e183c3ae5c85ec93a91c92eee92e7f0830d05cc1eb9d32bc2ac52b27f4e32b6",
+    "final_trace": "query_agnews/query1/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "agnews",
+    "query": "1",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "3e183c3ae5c85ec93a91c92eee92e7f0830d05cc1eb9d32bc2ac52b27f4e32b6",
+    "final_trace": "query_agnews/query1/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "agnews",
+    "query": "1",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "fe636cf62ee20ebc29c5bb302ff59bc97c089402f431286d72bc2b332e1c0d5a",
+    "final_trace": "query_agnews/query1/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "agnews",
+    "query": "2",
+    "run": "0",
+    "passed": false,
+    "answer_sha256": "0e2c3b598ec27618a94e7b8169984c6b2b1ca9047e1a37a3d9a456d267437c11",
+    "final_trace": "query_agnews/query2/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "agnews",
+    "query": "2",
+    "run": "1",
+    "passed": false,
+    "answer_sha256": "31d98d4e7a6bff30e2a7347e25adef265b06e00be2791ba968865ce6c3698101",
+    "final_trace": "query_agnews/query2/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "agnews",
+    "query": "2",
+    "run": "2",
+    "passed": false,
+    "answer_sha256": "59a5d2d5297b7efd05cad2602ff3c810afc6812b8cef104c3541e22f240bec83",
+    "final_trace": "query_agnews/query2/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "agnews",
+    "query": "2",
+    "run": "3",
+    "passed": false,
+    "answer_sha256": "52a77e88f331a8e124cc154dda699b69a98847852c4197dddb52f6c2128f7407",
+    "final_trace": "query_agnews/query2/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "agnews",
+    "query": "2",
+    "run": "4",
+    "passed": false,
+    "answer_sha256": "1c70108f2127f20bce79312cd0a99683b3e3c002070dbbdb5af46ef616fb37e4",
+    "final_trace": "query_agnews/query2/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "agnews",
+    "query": "3",
+    "run": "0",
+    "passed": false,
+    "answer_sha256": "5247cf3faebd4ee1b4c7bf7ef6a6e57f9cb92ffb2a7cdef309dd47fcbe8223dd",
+    "final_trace": "query_agnews/query3/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "agnews",
+    "query": "3",
+    "run": "1",
+    "passed": false,
+    "answer_sha256": "f429df5a80b7180cc3e678610ac1570e0be4c8fb2ae2fd8f8d113989ebc01b62",
+    "final_trace": "query_agnews/query3/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "agnews",
+    "query": "3",
+    "run": "2",
+    "passed": false,
+    "answer_sha256": "6df165636eae4e565ae2f657e7777b8bba3e60acc6a8af95fd51b1ea006f6849",
+    "final_trace": "query_agnews/query3/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "agnews",
+    "query": "3",
+    "run": "3",
+    "passed": false,
+    "answer_sha256": "e6ca19d2a83676966ab171bcfc84a787a667ee223b8ca6e60c2f07e7676bd55f",
+    "final_trace": "query_agnews/query3/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "agnews",
+    "query": "3",
+    "run": "4",
+    "passed": false,
+    "answer_sha256": "b2d69923f1c64f9c15924a93d47f3e555e21ac0e8353df51e85a6785c2fd1150",
+    "final_trace": "query_agnews/query3/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "agnews",
+    "query": "4",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "0d0c9a4aa64ebdda88d01947933c0c090e32c9e5ddfcaf26a4cb40f0d1865532",
+    "final_trace": "query_agnews/query4/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "agnews",
+    "query": "4",
+    "run": "1",
+    "passed": false,
+    "answer_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "final_trace": "query_agnews/query4/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "agnews",
+    "query": "4",
+    "run": "2",
+    "passed": false,
+    "answer_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "final_trace": "query_agnews/query4/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "agnews",
+    "query": "4",
+    "run": "3",
+    "passed": false,
+    "answer_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "final_trace": "query_agnews/query4/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "agnews",
+    "query": "4",
+    "run": "4",
+    "passed": false,
+    "answer_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "final_trace": "query_agnews/query4/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "1",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "4124e240d1dcc7a076c42ba1455aca2966ff8c5020cc8d01a2e529d485a330c9",
+    "final_trace": "query_bookreview/query1/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "1",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "8ffe6e0f57be6a909c6b49517a4b47f7ccc995176f1d11476d1a1ac651c785bd",
+    "final_trace": "query_bookreview/query1/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "1",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "6d7348226b6064aa406865a0095a629f0f8e1cb882275780b0b0a139cb2c37c4",
+    "final_trace": "query_bookreview/query1/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "1",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "85bd5c279325798a62a1b970fe1506ba080e5f1f37c6de6a69caeaa580248df3",
+    "final_trace": "query_bookreview/query1/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "1",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "3617ea1f2aad3788dafbcdbc440997966cf1e09e2cd7e2df96f12767dc6bff7b",
+    "final_trace": "query_bookreview/query1/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "2",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "d2529236c7f5a4fa6154f43c9fe2b48654c4d760d660f8e0334cc895a0d3de17",
+    "final_trace": "query_bookreview/query2/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "2",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "5908f309b2d06932690af5755cde0e9396ae19e7419fcf96921190c5718f0514",
+    "final_trace": "query_bookreview/query2/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "2",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "86740c8d836119f2f60af65ac63270700a3249ccaf35118d9d3f9f47c36c2ff3",
+    "final_trace": "query_bookreview/query2/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "2",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "14c0ba2251e9f6175ee91daea751531f8b4fde365d3b1d3fce6b0fb1a4868128",
+    "final_trace": "query_bookreview/query2/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "2",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "b616dc1281fbb0ea7e2bc0dd28e3a3a61b8534e8618ad8fc376873c93e807504",
+    "final_trace": "query_bookreview/query2/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "3",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "15123435f3516da86c3fca25b24a73db46c967e9a524a94a3b4966956ccd5999",
+    "final_trace": "query_bookreview/query3/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "3",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "23820abe89448055d3de0bbe036653cda3fb570aae6af57250158af5431b4c6e",
+    "final_trace": "query_bookreview/query3/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "3",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "676abfb95e831868fc1515d377983f338a9d075e0fa13cfa9b7014bc9836385b",
+    "final_trace": "query_bookreview/query3/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "3",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "c96cb092006bfe60f0537bb03e2debbdff4f95b08a7c9a39613dbbccd92b896f",
+    "final_trace": "query_bookreview/query3/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "bookreview",
+    "query": "3",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "9136a970da9aafa6fc92c7a18e42486a152ac738b7d0e9a8fb67d95e8d7bed0e",
+    "final_trace": "query_bookreview/query3/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "1",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "b4481ac084885d8d78c7146bc593d2c780d027dc73b06c58c4196905690e4c5b",
+    "final_trace": "query_crmarenapro/query1/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "1",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "4d015c612b1c7589d5c6b97822980bc1e5c108843669522474dd1beeaf82c156",
+    "final_trace": "query_crmarenapro/query1/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "1",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "c55ff7640819369a5e9c7d18cdc12b35c42cdf6478cd5a9ea8dd6ade6ed67661",
+    "final_trace": "query_crmarenapro/query1/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "1",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "c55ff7640819369a5e9c7d18cdc12b35c42cdf6478cd5a9ea8dd6ade6ed67661",
+    "final_trace": "query_crmarenapro/query1/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "1",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "b80e403d2645d45e3503a6575390f40760515800fc9199c522bb2466c9132f1d",
+    "final_trace": "query_crmarenapro/query1/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "2",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "6b6a6337891ae7619f92991923a68920a4c4b1eca81e1733463af2bf7ed2d458",
+    "final_trace": "query_crmarenapro/query2/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "2",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "6b6a6337891ae7619f92991923a68920a4c4b1eca81e1733463af2bf7ed2d458",
+    "final_trace": "query_crmarenapro/query2/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "2",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "6b6a6337891ae7619f92991923a68920a4c4b1eca81e1733463af2bf7ed2d458",
+    "final_trace": "query_crmarenapro/query2/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "2",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "6b6a6337891ae7619f92991923a68920a4c4b1eca81e1733463af2bf7ed2d458",
+    "final_trace": "query_crmarenapro/query2/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "2",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "6b6a6337891ae7619f92991923a68920a4c4b1eca81e1733463af2bf7ed2d458",
+    "final_trace": "query_crmarenapro/query2/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "3",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "3e18e2dab6f2bdb77a8888916f368ab87ad7a23534560f8159744aff0e245aff",
+    "final_trace": "query_crmarenapro/query3/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "3",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "3e18e2dab6f2bdb77a8888916f368ab87ad7a23534560f8159744aff0e245aff",
+    "final_trace": "query_crmarenapro/query3/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "3",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "3e18e2dab6f2bdb77a8888916f368ab87ad7a23534560f8159744aff0e245aff",
+    "final_trace": "query_crmarenapro/query3/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "3",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "3e18e2dab6f2bdb77a8888916f368ab87ad7a23534560f8159744aff0e245aff",
+    "final_trace": "query_crmarenapro/query3/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "3",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "987adbff3959b59461c17684409e552f1ef93790566152ea9a7565a53b0c92aa",
+    "final_trace": "query_crmarenapro/query3/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "4",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "0248061796ab2fa79218e83e558366f06ebb7f7a5f9e82933d79bd35bb07aad5",
+    "final_trace": "query_crmarenapro/query4/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "4",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "9de6fe1d72659daec67e919b0c473a24da5f03d3d096dc44ead1687240975f7c",
+    "final_trace": "query_crmarenapro/query4/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "4",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "9de6fe1d72659daec67e919b0c473a24da5f03d3d096dc44ead1687240975f7c",
+    "final_trace": "query_crmarenapro/query4/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "4",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "9de6fe1d72659daec67e919b0c473a24da5f03d3d096dc44ead1687240975f7c",
+    "final_trace": "query_crmarenapro/query4/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "4",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "9de6fe1d72659daec67e919b0c473a24da5f03d3d096dc44ead1687240975f7c",
+    "final_trace": "query_crmarenapro/query4/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "5",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "1527ff4fc7764fd9d086de285177637357747e3d583dcc594151607ea0b3409d",
+    "final_trace": "query_crmarenapro/query5/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "5",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "1527ff4fc7764fd9d086de285177637357747e3d583dcc594151607ea0b3409d",
+    "final_trace": "query_crmarenapro/query5/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "5",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "1527ff4fc7764fd9d086de285177637357747e3d583dcc594151607ea0b3409d",
+    "final_trace": "query_crmarenapro/query5/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "5",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "1527ff4fc7764fd9d086de285177637357747e3d583dcc594151607ea0b3409d",
+    "final_trace": "query_crmarenapro/query5/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "5",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "1527ff4fc7764fd9d086de285177637357747e3d583dcc594151607ea0b3409d",
+    "final_trace": "query_crmarenapro/query5/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "6",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "8cdf00212cda9d032e0fbc6640cb5084b544d45ef5f14a8480908b46d13879a4",
+    "final_trace": "query_crmarenapro/query6/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "6",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "6dcb146b0c2b9eafa8588e83f10e655a9db823987fb8638a9fc23d5106cd3d84",
+    "final_trace": "query_crmarenapro/query6/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "6",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "6dcb146b0c2b9eafa8588e83f10e655a9db823987fb8638a9fc23d5106cd3d84",
+    "final_trace": "query_crmarenapro/query6/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "6",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "6dcb146b0c2b9eafa8588e83f10e655a9db823987fb8638a9fc23d5106cd3d84",
+    "final_trace": "query_crmarenapro/query6/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "6",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "6dcb146b0c2b9eafa8588e83f10e655a9db823987fb8638a9fc23d5106cd3d84",
+    "final_trace": "query_crmarenapro/query6/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "7",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "b673d6904b108ea9c43d1ce5f49bf549de8b09d5773b27cccfd8af6aaafceea7",
+    "final_trace": "query_crmarenapro/query7/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "7",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "b673d6904b108ea9c43d1ce5f49bf549de8b09d5773b27cccfd8af6aaafceea7",
+    "final_trace": "query_crmarenapro/query7/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "7",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "b673d6904b108ea9c43d1ce5f49bf549de8b09d5773b27cccfd8af6aaafceea7",
+    "final_trace": "query_crmarenapro/query7/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "7",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "b673d6904b108ea9c43d1ce5f49bf549de8b09d5773b27cccfd8af6aaafceea7",
+    "final_trace": "query_crmarenapro/query7/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "7",
+    "run": "4",
+    "passed": false,
+    "answer_sha256": "7840e5b330e27886f150b445286739dea1b283c8c9247b84d07011bcba0745e4",
+    "final_trace": "query_crmarenapro/query7/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "8",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "be36265800ecbe24c88dee30c0ca85caae5a0affdd22455feada802d3ff8587c",
+    "final_trace": "query_crmarenapro/query8/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "8",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "be36265800ecbe24c88dee30c0ca85caae5a0affdd22455feada802d3ff8587c",
+    "final_trace": "query_crmarenapro/query8/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "8",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "be36265800ecbe24c88dee30c0ca85caae5a0affdd22455feada802d3ff8587c",
+    "final_trace": "query_crmarenapro/query8/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "8",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "be36265800ecbe24c88dee30c0ca85caae5a0affdd22455feada802d3ff8587c",
+    "final_trace": "query_crmarenapro/query8/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "8",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "be36265800ecbe24c88dee30c0ca85caae5a0affdd22455feada802d3ff8587c",
+    "final_trace": "query_crmarenapro/query8/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "9",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "176f7254b803f38a0359c42d8fe8459d0a6ecac8ca9e7539a64df346290c966d",
+    "final_trace": "query_crmarenapro/query9/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "9",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "176f7254b803f38a0359c42d8fe8459d0a6ecac8ca9e7539a64df346290c966d",
+    "final_trace": "query_crmarenapro/query9/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "9",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "176f7254b803f38a0359c42d8fe8459d0a6ecac8ca9e7539a64df346290c966d",
+    "final_trace": "query_crmarenapro/query9/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "9",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "176f7254b803f38a0359c42d8fe8459d0a6ecac8ca9e7539a64df346290c966d",
+    "final_trace": "query_crmarenapro/query9/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "9",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "176f7254b803f38a0359c42d8fe8459d0a6ecac8ca9e7539a64df346290c966d",
+    "final_trace": "query_crmarenapro/query9/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "10",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "6d935e6f705c93174be6576cdd4467bca849d126a6be8e0b9023f944284ace1c",
+    "final_trace": "query_crmarenapro/query10/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "10",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "6d935e6f705c93174be6576cdd4467bca849d126a6be8e0b9023f944284ace1c",
+    "final_trace": "query_crmarenapro/query10/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "10",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "6d935e6f705c93174be6576cdd4467bca849d126a6be8e0b9023f944284ace1c",
+    "final_trace": "query_crmarenapro/query10/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "10",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "6d935e6f705c93174be6576cdd4467bca849d126a6be8e0b9023f944284ace1c",
+    "final_trace": "query_crmarenapro/query10/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "10",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "6d935e6f705c93174be6576cdd4467bca849d126a6be8e0b9023f944284ace1c",
+    "final_trace": "query_crmarenapro/query10/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "11",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "8eae503568db8e087f4553b80f1acadcba3972fbc09cf4b697a76cbedb5e3f7e",
+    "final_trace": "query_crmarenapro/query11/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "11",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "8eae503568db8e087f4553b80f1acadcba3972fbc09cf4b697a76cbedb5e3f7e",
+    "final_trace": "query_crmarenapro/query11/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "11",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "8eae503568db8e087f4553b80f1acadcba3972fbc09cf4b697a76cbedb5e3f7e",
+    "final_trace": "query_crmarenapro/query11/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "11",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "8eae503568db8e087f4553b80f1acadcba3972fbc09cf4b697a76cbedb5e3f7e",
+    "final_trace": "query_crmarenapro/query11/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "11",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "8eae503568db8e087f4553b80f1acadcba3972fbc09cf4b697a76cbedb5e3f7e",
+    "final_trace": "query_crmarenapro/query11/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "12",
+    "run": "0",
+    "passed": false,
+    "answer_sha256": "6441453567b7c9250a1da4d322512220f0731efebaa162ea0ca7613a90bb9a32",
+    "final_trace": "query_crmarenapro/query12/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "12",
+    "run": "1",
+    "passed": false,
+    "answer_sha256": "6441453567b7c9250a1da4d322512220f0731efebaa162ea0ca7613a90bb9a32",
+    "final_trace": "query_crmarenapro/query12/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "12",
+    "run": "2",
+    "passed": false,
+    "answer_sha256": "6441453567b7c9250a1da4d322512220f0731efebaa162ea0ca7613a90bb9a32",
+    "final_trace": "query_crmarenapro/query12/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "12",
+    "run": "3",
+    "passed": false,
+    "answer_sha256": "6441453567b7c9250a1da4d322512220f0731efebaa162ea0ca7613a90bb9a32",
+    "final_trace": "query_crmarenapro/query12/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "12",
+    "run": "4",
+    "passed": false,
+    "answer_sha256": "6441453567b7c9250a1da4d322512220f0731efebaa162ea0ca7613a90bb9a32",
+    "final_trace": "query_crmarenapro/query12/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "13",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "392ca1513b6b80d358b95124c4f212920d4424d75b5ccfaa70349d4574047ab0",
+    "final_trace": "query_crmarenapro/query13/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "13",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "392ca1513b6b80d358b95124c4f212920d4424d75b5ccfaa70349d4574047ab0",
+    "final_trace": "query_crmarenapro/query13/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "13",
+    "run": "2",
+    "passed": false,
+    "answer_sha256": "145b2c3381cec1cc1f4f4a6271ea38f73fbbf6867b25c16ccf3863b3ca73c98b",
+    "final_trace": "query_crmarenapro/query13/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "13",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "392ca1513b6b80d358b95124c4f212920d4424d75b5ccfaa70349d4574047ab0",
+    "final_trace": "query_crmarenapro/query13/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "crmarenapro",
+    "query": "13",
+    "run": "4",
+    "passed": false,
+    "answer_sha256": "69a98287d314a75a01de4961bf71b6d5860c15546d9e6ecd3186750774b11385",
+    "final_trace": "query_crmarenapro/query13/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "1",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "f654dc310bcc2046df1b9ce0eb2666ad4c5992e427adabf487b5b2a0ec25426f",
+    "final_trace": "query_googlelocal/query1/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "1",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "513ac0eabcb28f198ef90f6ff3680a5375572a68363c26dbfe03b82589653fff",
+    "final_trace": "query_googlelocal/query1/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "1",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "67a0b5ec3d7fc10631064c278d561d24d9f5c4608c2a0e44e0b5f49de27111d4",
+    "final_trace": "query_googlelocal/query1/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "1",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "c491588812d0fe24c12539fa1b8ddbb9ad87c942f679ecb3edcd6c920bb4da66",
+    "final_trace": "query_googlelocal/query1/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "1",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "67fd0ccf65043aa6b21610db2a26795e0f08f8f8da46d43e547eb58f4d4cf106",
+    "final_trace": "query_googlelocal/query1/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "2",
+    "run": "0",
+    "passed": false,
+    "answer_sha256": "e66d79597272d3847bbac50fd5bd009c7d75037da80faf9af0b975c9f58b4bf0",
+    "final_trace": "query_googlelocal/query2/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "2",
+    "run": "1",
+    "passed": false,
+    "answer_sha256": "c839cfabaa4054ea8a664bd50a64a6a6378a899902b80178f919985d60a4165e",
+    "final_trace": "query_googlelocal/query2/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "2",
+    "run": "2",
+    "passed": false,
+    "answer_sha256": "1fd5b626aa0b4998939917f420bd045f5910de8c55b77854565eee648c822ec1",
+    "final_trace": "query_googlelocal/query2/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "2",
+    "run": "3",
+    "passed": false,
+    "answer_sha256": "0e9a3fbc8166268bce9df32f870ef5411c491c2d516bdfc2700061bf324ba89a",
+    "final_trace": "query_googlelocal/query2/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "2",
+    "run": "4",
+    "passed": false,
+    "answer_sha256": "254a8d841fa9ca3c615e50d3642b569f89a8cd604ff43076c3e8a37976ef5fb4",
+    "final_trace": "query_googlelocal/query2/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "3",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "3c6e8b46141eb1f2f631abfe6a9042389195a5c264c6d4f1aa231b31bb22e0cc",
+    "final_trace": "query_googlelocal/query3/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "3",
+    "run": "1",
+    "passed": false,
+    "answer_sha256": "d6796c07333fe11f30efdb474f507ed724629d75c7796b8bd8b1cc5a2e595d7f",
+    "final_trace": "query_googlelocal/query3/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "3",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "23db1f771066bd6a1285f19c192e7c2a20ad0e16725129e095be02b4a10253dd",
+    "final_trace": "query_googlelocal/query3/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "3",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "d139d9753ca041d8b300e1bef83e45cdc84dc351340c16595508c6e557d89910",
+    "final_trace": "query_googlelocal/query3/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "3",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "32b867baf9b8d45fd271ed73f486dd5b49eb9f0a79c9ef61d5b58a7279b3dc44",
+    "final_trace": "query_googlelocal/query3/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "4",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "9609b83a854c899e12da0a9ec000512b69248cc2c2ffd948b4e3b1d75dcd7b5a",
+    "final_trace": "query_googlelocal/query4/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "4",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "34762f4edbd8caec783b21f0375a64c1ff51bea50a610e47cd4d76111c95ff7c",
+    "final_trace": "query_googlelocal/query4/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "4",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "3aeafb3289b310303800c0a74a438d408c854c834badf3463e330848e49ebdeb",
+    "final_trace": "query_googlelocal/query4/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "4",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "f0230bf99c5844752b9ac46d154ab934b75f8eb7958d5b1fbe612051a7059f64",
+    "final_trace": "query_googlelocal/query4/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "googlelocal",
+    "query": "4",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "e10419a99689804fdac8ddbcc0f5f7693b5a38406f726245e9989e9f5cd8bc47",
+    "final_trace": "query_googlelocal/query4/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "1",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "3c73d8695424afce419fea1fc6e70bb354e2e5e7ddb50b2b9da8dc5385be2885",
+    "final_trace": "query_music_brainz_20k/query1/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "1",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "dbb54c5f5104f632e837d7218b673165891729ac138c3c91bfe7636d8d353675",
+    "final_trace": "query_music_brainz_20k/query1/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "1",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "cf572772398008afd707d43012108b892eb1868bb8b20e2ff6fa1d99e5faee0b",
+    "final_trace": "query_music_brainz_20k/query1/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "1",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "e23e23745871145c3cf2a4406acd51ca30743700c48567671e0db68ba29d676d",
+    "final_trace": "query_music_brainz_20k/query1/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "1",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "41bafd26c1d081baa950bcd8005409f6d01efc668a67f9ca5e32ce31b8b1a7f3",
+    "final_trace": "query_music_brainz_20k/query1/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "2",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "439a249b4a83643637ccef37f7a4a91d87a2d41e34e82bce188f3856154e6ebd",
+    "final_trace": "query_music_brainz_20k/query2/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "2",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "40a63f034bafb7903dc5abc4234013dc6200cfacbba73d418e4c0665584c0684",
+    "final_trace": "query_music_brainz_20k/query2/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "2",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "a8aae464807cb0edddc568a6712350cef21674f6163b9cfd40888f698d502f0c",
+    "final_trace": "query_music_brainz_20k/query2/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "2",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "080dc9fa4f16f0fffde65270b65576f0e3ecb401dfb1fc552981674d4265432c",
+    "final_trace": "query_music_brainz_20k/query2/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "2",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "4b72a34c035081fc2ed7b7878c13e875ecbf312e137e050595c3b13f43a3c006",
+    "final_trace": "query_music_brainz_20k/query2/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "3",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "5ee5c7852a0501a41769b97bb05ca7a9d1321b5d17cf0db85b55fa7261b6bcdd",
+    "final_trace": "query_music_brainz_20k/query3/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "3",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "6e37dc1cfa923da2395c5e30fe6c01f448f03524002df242d6f7b4e279b7825e",
+    "final_trace": "query_music_brainz_20k/query3/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "3",
+    "run": "2",
+    "passed": false,
+    "answer_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "final_trace": "query_music_brainz_20k/query3/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "3",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "912801d05c27d1c31a427cb924d31256d4952c5de368958c78d828df7872b210",
+    "final_trace": "query_music_brainz_20k/query3/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "music_brainz_20k",
+    "query": "3",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "25a763ba7b5219cab1a6b7a9de67b4a392aa4e7daad813b63fedda55adf52298",
+    "final_trace": "query_music_brainz_20k/query3/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "1",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "75a36e7314d06b800135fe1a8bd196366c103ef1fc4d1fb5f0543bf3d9d1bddf",
+    "final_trace": "query_stockindex/query1/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "1",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "c106058409e6f6b3b2b496a3f6ccbdb667f7552d7979341f93f3ef0f2a3bde86",
+    "final_trace": "query_stockindex/query1/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "1",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "bb0af4dc7b4aa4cb8c24d92a75db8ab218c44ec391f20aa75f6f7ad4d82e6427",
+    "final_trace": "query_stockindex/query1/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "1",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "cbbf7f91043f73bea4d308efa87d6096695e2df81c693cac84de20a0e61413f0",
+    "final_trace": "query_stockindex/query1/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "1",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "e956b0c37d542b21020f3a02c355c6c2f6654bb53e7afba464e91312816ee65a",
+    "final_trace": "query_stockindex/query1/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "2",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "64d0c73da633cf2df5e2be70b24365599422816e54b9a826dc352c6bb8a0fca1",
+    "final_trace": "query_stockindex/query2/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "2",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "d751ccb644862f7aee8a2328c2f98d9de5babace46daa456c0177494f620d94c",
+    "final_trace": "query_stockindex/query2/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "2",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "08260c9def8d27259d7252cb1ca17b093eaec40af5c8d038e79a9a3c1b84ed28",
+    "final_trace": "query_stockindex/query2/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "2",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "e198f809256b4a58fb85510b6b9ec81eb2b05b05a1cc2cf5aa9b50a078b2027a",
+    "final_trace": "query_stockindex/query2/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "2",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "921efccb097e97c428b798a5581558d91a82f34b85223ae441d2e2c449fc3e20",
+    "final_trace": "query_stockindex/query2/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "3",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "ddd53394544c63a147c67eecc48664b29b0e7a3cfaa5d7f1f8b2627a2a67122c",
+    "final_trace": "query_stockindex/query3/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "3",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "8c395a6f736d48e72f94669d5694f72f89882ba45cbcb8b7a9b442060998145c",
+    "final_trace": "query_stockindex/query3/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "3",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "2b9f810f06c8ef46f8d80ddf56d2f317a62c77e77d0e6b1e7db3ed64903fd202",
+    "final_trace": "query_stockindex/query3/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "3",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "a16a009bec7d84d47d5d79960752676fe1f539835a30c0f8ba2a9a9a886ccbb5",
+    "final_trace": "query_stockindex/query3/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "stockindex",
+    "query": "3",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "3ec7c7a9d94b63fa9ea47d86d562d8c5fa12402cb5322fb83f8c2e3966883950",
+    "final_trace": "query_stockindex/query3/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "1",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "c02781c52930ee053c7516a828079dea6fc9c63f2ad012fb269ca3443b143d27",
+    "final_trace": "query_stockmarket/query1/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "1",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "2d4e2f9245cdeaaec96959270cf00cfd5e543d2f1f7ade62b12effccab30dd76",
+    "final_trace": "query_stockmarket/query1/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "1",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "781824304a91f8beee0536c64a27b9859da5392a973e19c1ce941bd4920db4c2",
+    "final_trace": "query_stockmarket/query1/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "1",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "c32da32d40b3721f2a24b16356c5226d87a64e54d00150b0a9ce09230c1e7d9f",
+    "final_trace": "query_stockmarket/query1/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "1",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "a9d5240f658a0efab6381f04f2e8a7051d39957b218210fb54e12edc763b0815",
+    "final_trace": "query_stockmarket/query1/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "2",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "62485477b4488c30f9fce9c1cf4d5cd55e4b373f14c4d43e798c7df14c43971a",
+    "final_trace": "query_stockmarket/query2/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "2",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "f077e435f2bf4d8b13f05cd5077691c3b30b9426de6aca33b5f51fbdca0bb866",
+    "final_trace": "query_stockmarket/query2/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "2",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "fe98d63d17bbc89cf81adf7b60f51a1b004414636b1a992e9f67caef4ccbb3d3",
+    "final_trace": "query_stockmarket/query2/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "2",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "8f4c46faa6f9a4ba0bf2fb43b6aa093f185ed1f1db51ad041478f2b0356c98af",
+    "final_trace": "query_stockmarket/query2/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "2",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "96e96c67c88ec0374bc44fdf2c9cdc80ad46cf43d8848a62e515d5e77d0d1bc9",
+    "final_trace": "query_stockmarket/query2/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "3",
+    "run": "0",
+    "passed": false,
+    "answer_sha256": "811c27b2a53da1b8c4fb1f5034b7f0feb15c30180db5a636ed89fb78da626732",
+    "final_trace": "query_stockmarket/query3/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "3",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "252b5d3b39b448a609886ad1a9bc09b75400f8c209cc7f86c3480161f180755e",
+    "final_trace": "query_stockmarket/query3/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "3",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "867901c372708fb25e61fca103d10d325aad5ae64b8023160f13d68032063f0f",
+    "final_trace": "query_stockmarket/query3/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "3",
+    "run": "3",
+    "passed": false,
+    "answer_sha256": "e453a7e71f9460dfa705992bc553c63519e5dba7b54adf38deae9d7e587bc95a",
+    "final_trace": "query_stockmarket/query3/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "3",
+    "run": "4",
+    "passed": false,
+    "answer_sha256": "654d36ba4d1ae4e6d16ed736edf6ea0373fc47211a035f474d66004faac1832f",
+    "final_trace": "query_stockmarket/query3/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "4",
+    "run": "0",
+    "passed": false,
+    "answer_sha256": "022a73765fb1ee1b7457b7a37ca9ed1185a550f4354eca035a908b937087825d",
+    "final_trace": "query_stockmarket/query4/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "4",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "67865c2b6aca0318ac847ee84b75d96c4a977c189ed35a563c7bd61904087b92",
+    "final_trace": "query_stockmarket/query4/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "4",
+    "run": "2",
+    "passed": false,
+    "answer_sha256": "d54240f1be20b37e65f24a8bd01c087216f9f1f8f60611664454134a941d173d",
+    "final_trace": "query_stockmarket/query4/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "4",
+    "run": "3",
+    "passed": false,
+    "answer_sha256": "ac65deba4171a5d93fe001748f9b631742634734de2966de75f8daf12c1d64b8",
+    "final_trace": "query_stockmarket/query4/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "4",
+    "run": "4",
+    "passed": false,
+    "answer_sha256": "a0c32043ce9a22ff8025056c84f9a174e0a064ee9abb0566592d5cf620016b88",
+    "final_trace": "query_stockmarket/query4/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "5",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "7f98172eff59cb149ffeb89715e4a1333c9c70db5732f582931aeb6a92c67b32",
+    "final_trace": "query_stockmarket/query5/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "5",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "65e76dedb00d0307609dd33b37cd0849b696712fa0133167068762048f80a873",
+    "final_trace": "query_stockmarket/query5/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "5",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "4ab8f9b3eb97ca0d4d2dfb37f42b5ad983a921df64b96f5775710815cf0fb7be",
+    "final_trace": "query_stockmarket/query5/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "5",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "d3ccad410927590266cbc2f549b1e341a796b88acf20a2044f8a119b86c3350e",
+    "final_trace": "query_stockmarket/query5/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "stockmarket",
+    "query": "5",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "ea786fe34dd411dfcb5a9949270010fe46f9b174040f16f3d5bbf3856482a565",
+    "final_trace": "query_stockmarket/query5/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "1",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "79d36ffb406e4bb7611477a589b3a53e9c3b338df1d756d5d0c969f23f675324",
+    "final_trace": "query_yelp/query1/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "1",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "4de045b930e001f7c093a7515c64fc05bcb53506457a31a257954418527d925c",
+    "final_trace": "query_yelp/query1/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "1",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "d04895343821d78d44fb158f49523742cb1a12772025318893ba4b18a7d3c9a3",
+    "final_trace": "query_yelp/query1/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "1",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "697ea374c59963d6e8520e04fb65e939b919bd2951ef001b741ef387573c18dd",
+    "final_trace": "query_yelp/query1/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "1",
+    "run": "4",
+    "passed": false,
+    "answer_sha256": "027e46ac41c9c9526954fc2910085584fdcde7eb5f91191e48d072115c2eb80a",
+    "final_trace": "query_yelp/query1/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "2",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "d80a512f2660c95ae9ae5827dedad4bf7f2181ac12fa239882436a0694ae21f1",
+    "final_trace": "query_yelp/query2/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "2",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "dfb520518f9e4fb270fc0f5666f9905a53abb5ea43d52bd01003001d3f7048f0",
+    "final_trace": "query_yelp/query2/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "2",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "b00bc53ddcf9aa573415db175d6da6777f99a7f5105e9251edc31ae2f3a63ad4",
+    "final_trace": "query_yelp/query2/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "2",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "2d506210ac18453ec7a8857b962c12f6efdd602a4ad6902ca9ec712bec83c2d0",
+    "final_trace": "query_yelp/query2/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "2",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "9d740e93a26952e23ecfd4f6e96dbd11268e8432174b9b159ccb143d10a3f227",
+    "final_trace": "query_yelp/query2/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "3",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "4cad110ba674769b8833ed8c39111fc148380d49aa16110ce74d776e5f03820b",
+    "final_trace": "query_yelp/query3/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "3",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "0b29ad6e561ce044662983ae6098a610123be8b56867c7df08ef3bc032e82535",
+    "final_trace": "query_yelp/query3/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "3",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "9bc138a6f7d4803220be5ae3fa99ef1c36d68ca088132e21fd075d91cc0fa47e",
+    "final_trace": "query_yelp/query3/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "3",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "01bea53fbed28ea0d6c1c3023eb71eb4b1be321e0719acd9f404448050309bed",
+    "final_trace": "query_yelp/query3/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "3",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "9f14025af0065b30e47e23ebb3b491d39ae8ed17d33739e5ff3827ffb3634953",
+    "final_trace": "query_yelp/query3/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "4",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "21a818ddb8527f4e322db4d40554a671fdf3796df725fa3b2e566050ff4d76e7",
+    "final_trace": "query_yelp/query4/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "4",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "162b9cc1443e23132d79e499184ce5e62a91bcb7995a6ffcb67a5a2ccb649a75",
+    "final_trace": "query_yelp/query4/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "4",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "1adf47af7ebd1ade7ac655eb639c963075a5c8e6818c83bccad5ed08eb7903bc",
+    "final_trace": "query_yelp/query4/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "4",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "2258b1f26f726cbb8e0641c3e15a618a5fa2fb11c5f4034f3330840947b621a3",
+    "final_trace": "query_yelp/query4/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "4",
+    "run": "4",
+    "passed": false,
+    "answer_sha256": "108e285ac9284bd6c14f5318fabd1391c65011099d7f200b2131ba4e8568610f",
+    "final_trace": "query_yelp/query4/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "5",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "aaffe008c2334a5900ca7ec214543b5d45c815bdd95fa25a27eebfc22aadba21",
+    "final_trace": "query_yelp/query5/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "5",
+    "run": "1",
+    "passed": false,
+    "answer_sha256": "a57afd67781625d91302f6b22f4a797bec3ac0d15072a0b4b2f975d63195ba1b",
+    "final_trace": "query_yelp/query5/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "5",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "0799f1ff687697e1a6e8db87db6553e3257ac6f69bd9ecb8a46027062100cce8",
+    "final_trace": "query_yelp/query5/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "5",
+    "run": "3",
+    "passed": false,
+    "answer_sha256": "6ee7d10457b5670f4bd61f346693c7f8252d2870d26640b6163ad4522d6626b1",
+    "final_trace": "query_yelp/query5/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "5",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "c197cb0c8197161cc96984a3248d1218bea047402f42bff83704326ddc9a99f2",
+    "final_trace": "query_yelp/query5/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "6",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "6c58f57e218f9e445b16223dc7e466aec4ffb60e20ef3c3326f5c80bb03e2b6d",
+    "final_trace": "query_yelp/query6/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "6",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "93945b1d2ece0c687ea37d0f7dd69d384a0c70bed8d3290b59b7869c6ae5f5d1",
+    "final_trace": "query_yelp/query6/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "6",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "a996151f2a6b5d28db54d1e0298278508019f864dfe2156608059d3a9b3cbd42",
+    "final_trace": "query_yelp/query6/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "6",
+    "run": "3",
+    "passed": true,
+    "answer_sha256": "a80636ea6648f77cc7a78e2e6506cf903e1bbb2dd64f99856d8408a75bc6f458",
+    "final_trace": "query_yelp/query6/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "6",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "41d62d5158c85d54feb031d2380a1f7adb1c35eeed5c1d95406c29d18c50f896",
+    "final_trace": "query_yelp/query6/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "7",
+    "run": "0",
+    "passed": true,
+    "answer_sha256": "cd932f6a5937d0f152765bd2a7d8b0afa1575e5a0fb828a730a4b96b163864ef",
+    "final_trace": "query_yelp/query7/logs/data_agent/qwen38flash_parallel_v1_run_0/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "7",
+    "run": "1",
+    "passed": true,
+    "answer_sha256": "2c11aae5ff9bf2a7220b45a9402eb26bb922b33abea6a85f9fd203bc421240cd",
+    "final_trace": "query_yelp/query7/logs/data_agent/qwen38flash_parallel_v1_run_1/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "7",
+    "run": "2",
+    "passed": true,
+    "answer_sha256": "bc2b950865e728ca01ad4cfbf420b3e9c2881912cfd3afb411356af66f925e06",
+    "final_trace": "query_yelp/query7/logs/data_agent/qwen38flash_parallel_v1_run_2/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "7",
+    "run": "3",
+    "passed": false,
+    "answer_sha256": "64fa9b3f75d31798b3fd0762ff530dca927b747fc3239840611d7f2521a34534",
+    "final_trace": "query_yelp/query7/logs/data_agent/qwen38flash_parallel_v1_run_3/final_agent.json"
+  },
+  {
+    "dataset": "yelp",
+    "query": "7",
+    "run": "4",
+    "passed": true,
+    "answer_sha256": "29cd277c98c5546dfedaa463572607e24d86c7bce367fca927440773ca802ce9",
+    "final_trace": "query_yelp/query7/logs/data_agent/qwen38flash_parallel_v1_run_4/final_agent.json"
+  }
+]

--- a/leaderboard_submissions/qwen38flash_parallel_v1/verify_submission.py
+++ b/leaderboard_submissions/qwen38flash_parallel_v1/verify_submission.py
@@ -1,0 +1,122 @@
+"""Verify exported answers, archive integrity, and optionally official scoring."""
+import argparse
+import collections
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import tarfile
+
+sys.dont_write_bytecode = True
+COUNTS = {'bookreview': 3, 'crmarenapro': 13, 'DEPS_DEV_V1': 2,
+          'GITHUB_REPOS': 4, 'googlelocal': 4, 'PANCANCER_ATLAS': 3,
+          'PATENTS': 3, 'stockindex': 3, 'stockmarket': 5, 'yelp': 7,
+          'agnews': 4, 'music_brainz_20k': 3}
+PREFIX = 'qwen38flash_parallel_v1/'
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--archive', type=Path, required=True)
+    parser.add_argument('--validators-root', type=Path)
+    args = parser.parse_args()
+    base = Path(__file__).resolve().parent
+    read = lambda name: json.loads((base / name).read_text())
+    key = lambda row: (row['dataset'], int(row['query']), int(row['run']))
+    expected = {(d, q, r) for d, n in COUNTS.items() for q in range(1, n + 1) for r in range(5)}
+    results, rows, metrics = read('results.json'), read('trial_scores.json'), read('metrics.json')
+    assert len(results) == len(rows) == len(expected) == 270
+    assert {key(r) for r in results} == {key(r) for r in rows} == expected
+    answers = {key(r): r['answer'] for r in results}
+    assert all(set(r) == {'dataset', 'query', 'run', 'answer'} and isinstance(r['answer'], str) for r in results)
+    sha = lambda value: hashlib.sha256(value).hexdigest()
+    for row in rows:
+        assert sha(answers[key(row)].encode()) == row['answer_sha256'], key(row)
+    failed = {key(r) for r in read('failures.json')}
+    assert len(failed) == 5
+    assert failed == {k for k, v in answers.items() if v == ''}
+    assert all(not r['passed'] for r in rows if key(r) in failed)
+    archive_hash = hashlib.sha256()
+    with args.archive.open('rb') as f:
+        for chunk in iter(lambda: f.read(4 * 1024 * 1024), b''):
+            archive_hash.update(chunk)
+    assert archive_hash.hexdigest() == read('export_summary.json')['archive_sha256']
+    with tarfile.open(args.archive, 'r:gz') as archive:
+        members = archive.getmembers()
+        names = [m.name for m in members]
+        assert len(names) == len(set(names)), 'Duplicate archive members'
+        assert all(m.isfile() and m.name.startswith(PREFIX) and '..' not in Path(m.name).parts for m in members)
+        manifest = json.load(archive.extractfile(PREFIX + 'artifact_manifest.json'))
+        indexed = {PREFIX + row['path']: row for row in manifest}
+        assert set(names) == set(indexed) | {PREFIX + 'artifact_manifest.json'}
+        answer_checks = 0
+        tool_checks = 0
+        for member in members:
+            if member.name not in indexed:
+                continue
+            stream = archive.extractfile(member)
+            h = hashlib.sha256()
+            capture = member.name.endswith(('/final_agent.json', '/tool_calls.jsonl'))
+            chunks = []
+            for chunk in iter(lambda: stream.read(4 * 1024 * 1024), b''):
+                h.update(chunk)
+                if capture:
+                    chunks.append(chunk)
+            record = indexed[member.name]
+            assert member.size == record['bytes'] and h.hexdigest() == record['published_sha256'], member.name
+            if capture:
+                data = b''.join(chunks)
+                parts = member.name.split('/')
+                d = parts[1].removeprefix('query_')
+                q = int(parts[2].removeprefix('query'))
+                r = int(parts[5].rsplit('_', 1)[1])
+                k = (d, q, r)
+                if member.name.endswith('/final_agent.json'):
+                    final = json.loads(data)
+                    assert (final.get('final_result') or '') == answers[k], k
+                    assert (final['terminate_reason'] == 'return_answer') == (k not in failed)
+                    answer_checks += 1
+                else:
+                    calls = [json.loads(line) for line in data.splitlines() if line.strip()]
+                    returned = [c['args']['answer'] for c in calls if c['tool_name'] == 'return_answer']
+                    if k not in failed:
+                        assert returned and returned[-1] == answers[k], k
+                    else:
+                        assert not returned, k
+                    tool_checks += 1
+        assert answer_checks == tool_checks == 270
+    counts = collections.Counter()
+    if args.validators_root:
+        repo = args.validators_root.resolve()
+        sys.path.insert(0, str(repo))
+        validators = {}
+        for row in rows:
+            d, q, r = k = key(row)
+            if not answers[k]:
+                passed = False
+            else:
+                if (d, q) not in validators:
+                    path = repo / f'query_{d}/query{q}/validate.py'
+                    spec = importlib.util.spec_from_file_location(f'validator_{d}_{q}', path)
+                    module = importlib.util.module_from_spec(spec)
+                    spec.loader.exec_module(module)
+                    validators[d, q] = module.validate
+                verdict = validators[d, q](answers[k])
+                passed = bool(verdict[0] if isinstance(verdict, tuple) else verdict)
+            assert passed == row['passed'], f'Official validator score differs: {k}'
+            counts[d] += passed
+    else:
+        for row in rows:
+            counts[row['dataset']] += row['passed']
+    micro = sum(counts.values()) / 270
+    macro = sum(counts[d] / (5 * n) for d, n in COUNTS.items()) / len(COUNTS)
+    assert sum(counts.values()) == metrics['passed'] == 201
+    assert abs(micro - metrics['micro_accuracy']) < 1e-12
+    assert abs(macro - metrics['macro_pass_at_1']) < 1e-12
+    print(json.dumps({'trials': 270, 'failed_trials_retained': 5,
+                      'archive_files_verified': len(indexed), 'trace_answer_pairs_verified': 270,
+                      'passed': 201, 'macro_pass_at_1': macro, 'micro_accuracy': micro,
+                      'official_validators_rerun': bool(args.validators_root)}, indent=2))
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This submits **Qwen3.8-Flash-Next running the DAB DataAgent scaffold** for leaderboard review.

- Backbone: `Qwen/Qwen3.8-Flash-Next`, self-hosted with vLLM on 8 NVIDIA L40S GPUs.
- Hints: **Yes**. No added task-specific prompt; the Qwen adapter uses the scaffold's existing tool-result access instruction.
- Coverage: **54 queries × 5 runs = 270 trials across 12 datasets**.
- Dataset-weighted **Pass@1: 0.7086721612 (70.87%)**. Unweighted trial average: 201/270 = 74.44%.
- One fixed configuration, no trial selection or replacement runs. Five context-limit failures are retained as empty answers and non-passes.

The submission directory is `leaderboard_submissions/qwen38flash_parallel_v1/`. It contains the 270 verbatim answers, per-trial scores, failure records, run configuration, deployment metadata, archive checksum, reproduction instructions, and an independent verification script.

The complete execution traces, generated code/intermediates, batch/session records, and actual harness source overlay are available in the [trace release](https://github.com/qiboyu301-crypto/DataAgentBench/releases/tag/qwen38flash-parallel-v1-traces). The archive includes all 270 final-agent, LLM-call and tool-call logs. Its manifest records original and published hashes; credentials and text-file deployment locations are redacted, with answer strings unchanged.

### Validation

- Official questions, description/hint files, validators and 54 ground-truth files match checked revision `881bab89f69ac4f150e2586357ede8c5b95719d5`.
- All 270 keys are present exactly once; exported answers match the original final records and corresponding return-answer tool calls.
- The archive checksum and every published artifact hash are checked by the supplied verifier.
- The final verification run checked all 3982 archived files and all 270 answer/trace pairs, then independently re-scored with the official validators: 201 passes and dataset-weighted Pass@1 0.7086721611721613.
- Full run configuration and environment are recorded. The exact upstream weight revision was not captured; this is explicitly disclosed, with available model metadata hashes and serving-image identification supplied instead.

### Failures and data-access disclosure

`agnews/query4/run1–4` and `music_brainz_20k/query3/run2` exhausted the 262144-token context budget while requesting 131072 output tokens. Their complete traces are retained and all five score zero.

The audit scanned 5603 raw tool calls and inspected filesystem-related matches. `stockmarket/query2/run0` and `run4` enumerated repository filenames, including gold/grader filenames; run0 also counted records from its database configuration. Run2 enumerated directories and read `/proc/self/cmdline`. We did not identify reading gold/validator contents or obtaining an external answer, but DuckDB host filesystem access was **not structurally restricted**. All three of these stockmarket trials passed the validators. The calls are retained in the traces and described in the README for rubric review; the audit is not claimed to be exhaustive semantic verification.

Please review the disclosed traces under the submission rubric and independently validate the reported score.
